### PR TITLE
Warn on bad CSV filenames and remove them

### DIFF
--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -33,11 +33,21 @@
     "state_early_vote_site.txt"
     "street_segment.txt"})
 
-(defn validate-filenames [ctx]
+(defn file-name [file]
+  (.getName file))
+
+(defn good-filename? [file]
+  (->> file
+       file-name
+       (contains? csv-filenames)))
+
+(defn remove-bad-filenames [ctx]
   (let [input (:input ctx)
-        filenames (map #(.getName %) input)
-        bad-filenames (seq (set/difference (set filenames) csv-filenames))]
-    (if bad-filenames
-      (assoc ctx :stop (apply str "Bad filenames: "
-                                  (interpose ", " (sort bad-filenames))))
+        {good-files true bad-files false} (group-by good-filename? input)]
+    (if (seq bad-files)
+      (-> ctx
+          (assoc-in [:warnings :validate-filenames]
+                    (apply str "Bad filenames: "
+                           (interpose ", " (->> bad-files (map file-name) sort))))
+          (assoc :input good-files))
       ctx)))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -22,7 +22,7 @@
   [(fn [ctx] (assoc ctx :stop "This is an XML feed"))])
 
 (def csv-validations
-  [csv/validate-filenames])
+  [csv/remove-bad-filenames])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -1,0 +1,18 @@
+(ns vip.data-processor.validation.csv-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.validation.csv :refer :all])
+  (:import [java.io File]))
+
+(deftest remove-bad-filenames-test
+  (let [bad-filenames [(File. "/data/BAD_FILE_NAME")
+                       (File. "/data/BAD_FILE_NAME_2")]
+        good-filenames (map #(File. (str "/data/" %)) csv-filenames)
+        ctx {:input good-filenames}]
+    (testing "with good filenames passes the context through"
+      (is (= ctx (remove-bad-filenames ctx))))
+    (testing "with bad filenames removes the bad files and warns"
+      (let [ctx (update ctx :input (partial concat bad-filenames))
+            out-ctx (remove-bad-filenames ctx)]
+        (is (get-in out-ctx [:warnings :validate-filenames]))
+        (is (not-every? good-filename? (:input ctx)))
+        (is (every? good-filename? (:input out-ctx)))))))


### PR DESCRIPTION
Bad files in an upload should only produce warnings and be removed from the context, not stop the processing.

[Pivotal story](https://www.pivotaltracker.com/story/show/87562548)