### PR TITLE
Sqlite

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [joplin.jdbc "0.2.7"]
                  [korma "0.4.0"]
                  [org.clojure/java.jdbc "0.3.5"]
-                 [org.postgresql/postgresql "9.4-1200-jdbc4" :exclusions [org.slf4j/slf4j-simple]]]
+                 [org.postgresql/postgresql "9.4-1200-jdbc4" :exclusions [org.slf4j/slf4j-simple]]
+                 [org.xerial/sqlite-jdbc "3.8.7"]]
   :profiles {:test {:resource-paths ["test-resources"]}}
   :main vip.data-processor)

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -12,6 +12,7 @@
 (def pipeline
   [t/read-edn-sqs-message
    t/assert-filename
+   t/attach-sqlite-db
    t/download-from-s3
    zip/unzip
    zip/extracted-contents

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -1,0 +1,24 @@
+(ns vip.data-processor.db.sqlite
+  (:require [joplin.core :as j]
+            [joplin.jdbc.database]
+            [korma.db :as db]
+            [korma.core :as korma])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn create-temp-db-file [prefix]
+  (Files/createTempFile (str prefix "-") ".db" (into-array FileAttribute [])))
+
+(defmacro entity [ent & body]
+  `(-> (korma/create-entity ~(name ent))
+       ~@body))
+
+(defn temp-db [upload-filename]
+  (let [temp-file (create-temp-db-file upload-filename)
+        url (str "jdbc:sqlite:" temp-file)
+        db (db/sqlite3 {:db temp-file})]
+    (j/migrate-db {:db {:type :sql
+                        :url url}
+                   :migrator "resources/processing-migrations"})
+    {:db db
+     :entities {}}))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -2,6 +2,7 @@
   (:require [clojure.edn :as edn]
             [clojure.set :as set]
             [clojure.string :as s]
+            [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.s3 :as s3]
             [vip.data-processor.validation.csv :as csv]))
 
@@ -12,6 +13,9 @@
   (if-let [filename (get-in ctx [:input :filename])]
     (assoc ctx :filename filename)
     (assoc ctx :stop "No filename!")))
+
+(defn attach-sqlite-db [ctx]
+  (assoc ctx :db (sqlite/temp-db (:filename ctx))))
 
 (defn download-from-s3 [ctx]
   (let [filename (get-in ctx [:input :filename])


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/87534884)

The `vip.data-processor.db.sqlite/entity` macro is not used here, but is about to be. It's simply Korma's `defentity` macro minus the `def` part. We don't want to be defining anything, since we'll be making a bunch of temporary databases in parallel. Using the entity value itself off a key on the processing context will work just as well.

For example:
```clojure
(korma/select (get-in ctx [:db :entities :elections]))
```