### PR TITLE
Load elections

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [joplin.jdbc "0.2.7"]
                  [korma "0.4.0"]
                  [org.clojure/java.jdbc "0.3.5"]
-                 [org.postgresql/postgresql "9.4-1200-jdbc4" :exclusions [org.slf4j/slf4j-simple]]]
+                 [org.postgresql/postgresql "9.4-1200-jdbc4" :exclusions [org.slf4j/slf4j-simple]]
+                 [org.xerial/sqlite-jdbc "3.8.7"]]
   :profiles {:test {:resource-paths ["test-resources"]}}
   :main vip.data-processor)

--- a/project.clj
+++ b/project.clj
@@ -2,6 +2,7 @@
   :description "Voting Information Project Data Processor"
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]
                  [org.slf4j/slf4j-log4j12 "1.7.10"]
+                 [org.clojure/data.csv "0.1.2"]
                  [org.clojure/tools.logging "0.3.1"]
                  [com.novemberain/langohr "3.0.1"]
                  [joda-time "2.7"]

--- a/resources/processing-migrations/20150218-01-create-elections-table.down.sql
+++ b/resources/processing-migrations/20150218-01-create-elections-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE elections;

--- a/resources/processing-migrations/20150218-01-create-elections-table.up.sql
+++ b/resources/processing-migrations/20150218-01-create-elections-table.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE elections (id INTEGER PRIMARY KEY,
+                        absentee_ballot_info TEXT,
+                        absentee_request_deadline DATE,
+                        date DATE,
+                        election_day_registration BOOLEAN NOT NULL CHECK (statewide IN (0,1)),
+                        election_type VARCHAR(20), -- should this be a reference to an election_types table?
+                                                   -- Is there a known list of good values?
+                        polling_hours TEXT,
+                        registration_deadline DATE,
+                        registration_info TEXT,
+                        results_url TEXT,
+                        state_id INT,
+                        statewide BOOLEAN NOT NULL CHECK (statewide IN (0,1)));

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -12,6 +12,7 @@
 (def pipeline
   [t/read-edn-sqs-message
    t/assert-filename
+   t/attach-sqlite-db
    t/download-from-s3
    zip/unzip
    zip/extracted-contents

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -1,0 +1,24 @@
+(ns vip.data-processor.db.sqlite
+  (:require [joplin.core :as j]
+            [joplin.jdbc.database]
+            [korma.db :as db]
+            [korma.core :as korma])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn create-temp-db-file [prefix]
+  (Files/createTempFile (str prefix "-") ".db" (into-array FileAttribute [])))
+
+(defmacro entity [ent & body]
+  `(-> (korma/create-entity ~(name ent))
+       ~@body))
+
+(defn temp-db [upload-filename]
+  (let [temp-file (create-temp-db-file upload-filename)
+        url (str "jdbc:sqlite:" temp-file)
+        db (db/sqlite3 {:db temp-file})]
+    (j/migrate-db {:db {:type :sql
+                        :url url}
+                   :migrator "resources/processing-migrations"})
+    {:db db
+     :entities {}}))

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -21,4 +21,4 @@
                         :url url}
                    :migrator "resources/processing-migrations"})
     {:db db
-     :entities {}}))
+     :tables {:elections (entity :elections (korma/database db))}}))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -1,5 +1,8 @@
 (ns vip.data-processor.validation.csv
-  (:require [clojure.set :as set]))
+  (:require [clojure.data.csv :as csv]
+            [clojure.java.io :as io]
+            [clojure.set :as set]
+            [korma.core :as korma]))
 
 (def csv-filenames
   #{"ballot.txt"
@@ -51,3 +54,11 @@
                            (interpose ", " (->> bad-files (map file-name) sort))))
           (assoc :input good-files))
       ctx)))
+
+(defn read-csv-with-headers [file]
+  (let [raw-rows (with-open [in-file (io/reader file)]
+                   (doall
+                    (csv/read-csv in-file)))
+        headers (first raw-rows)
+        rows (rest raw-rows)]
+    (map (partial zipmap headers) rows)))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -62,3 +62,19 @@
         headers (first raw-rows)
         rows (rest raw-rows)]
     (map (partial zipmap headers) rows)))
+
+(defn load-elections [ctx]
+  (let [files (:input ctx)
+        election-file (first (filter #(= "election.txt" (.getName %)) files))]
+    (when election-file
+      (let [elections-table (get-in ctx [:tables :elections])
+            contents (read-csv-with-headers election-file)
+            coerced-contents (->> contents
+                                  (map #(assoc % "election_day_registration"
+                                               (if (= "yes" (% "election_day_registration"))
+                                                 1 0)))
+                                  (map #(assoc % "statewide"
+                                               (if (= "yes" (% "statewide"))
+                                                 1 0))))]
+        (korma/insert elections-table (korma/values coerced-contents))))
+    ctx))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -71,11 +71,12 @@
 (defn load-elections [ctx]
   (let [files (:input ctx)
         election-file (first (filter #(= "election.txt" (.getName %)) files))]
-    (when election-file
+    (if election-file
       (let [elections-table (get-in ctx [:tables :elections])
             contents (read-csv-with-headers election-file)
             coerced-contents (->> contents
                                   (map (booleanize "election_day_registration"))
                                   (map (booleanize "statewide")))]
-        (korma/insert elections-table (korma/values coerced-contents))))
-    ctx))
+        (korma/insert elections-table (korma/values coerced-contents))
+        ctx)
+      (assoc-in ctx [:errors :load-elections] "election.txt missing"))))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -2,6 +2,7 @@
   (:require [clojure.edn :as edn]
             [clojure.set :as set]
             [clojure.string :as s]
+            [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.s3 :as s3]
             [vip.data-processor.validation.csv :as csv]))
 
@@ -12,6 +13,9 @@
   (if-let [filename (get-in ctx [:input :filename])]
     (assoc ctx :filename filename)
     (assoc ctx :stop "No filename!")))
+
+(defn attach-sqlite-db [ctx]
+  (assoc ctx :db (sqlite/temp-db (:filename ctx))))
 
 (defn download-from-s3 [ctx]
   (let [filename (get-in ctx [:input :filename])

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -26,7 +26,8 @@
   [(fn [ctx] (assoc ctx :stop "This is an XML feed"))])
 
 (def csv-validations
-  [csv/remove-bad-filenames])
+  [csv/remove-bad-filenames
+   csv/load-elections])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -15,7 +15,7 @@
     (assoc ctx :stop "No filename!")))
 
 (defn attach-sqlite-db [ctx]
-  (assoc ctx :db (sqlite/temp-db (:filename ctx))))
+  (merge ctx (sqlite/temp-db (:filename ctx))))
 
 (defn download-from-s3 [ctx]
   (let [filename (get-in ctx [:input :filename])

--- a/test-resources/election.txt
+++ b/test-resources/election.txt
@@ -1,0 +1,3 @@
+"date","election_type","state_id","statewide","registration_info","absentee_ballot_info","results_url","polling_hours","election_day_registration","registration_deadline","absentee_request_deadline","id"
+"2014-11-04","General","54","yes","","","","6:30 am - 7:30 pm","no","2014-10-14","2014-10-29","5400"
+"2014-11-05","Generalish","55","no","","","","8:30 am - 1:30 pm","no","2012-10-14","2012-10-29","5401"

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -1,6 +1,9 @@
 (ns vip.data-processor.validation.csv-test
   (:require [clojure.test :refer :all]
-            [vip.data-processor.validation.csv :refer :all])
+            [vip.data-processor.validation.csv :refer :all]
+            [vip.data-processor.db.sqlite :as sqlite]
+            [clojure.java.io :as io]
+            [korma.core :as korma])
   (:import [java.io File]))
 
 (deftest remove-bad-filenames-test
@@ -16,3 +19,24 @@
         (is (get-in out-ctx [:warnings :validate-filenames]))
         (is (not-every? good-filename? (:input ctx)))
         (is (every? good-filename? (:input out-ctx)))))))
+
+(deftest load-elections-test
+  (testing "with a valid election.txt file"
+    (let [db (sqlite/temp-db "load-elections-test")
+          ctx (merge {:input [(io/as-file (io/resource "election.txt"))]}
+                     db)]
+      (is (empty? (korma/select (get-in ctx [:tables :elections]))))
+      (testing "inserts rows from the valid election.txt file"
+        (let [out-ctx (load-elections ctx)]
+          (is (= '({:id 5400} {:id 5401})
+                 (korma/select (get-in out-ctx [:tables :elections])
+                               (korma/fields :id))))
+          (testing "no/yes values are turned into 0/1"
+            (is (= '({:id 5400 :statewide 1} {:id 5401 :statewide 0})
+                   (korma/select (get-in out-ctx [:tables :elections])
+                                 (korma/fields :id :statewide)))))))))
+  (testing "with no election.txt file the ctx remains the same"
+    (let [db (sqlite/temp-db "no-load-elections-test")
+          ctx (merge {:input []} db)
+          out-ctx (load-elections (assoc ctx :input []))]
+      (is (empty? (korma/select (get-in out-ctx [:tables :elections])))))))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -35,8 +35,9 @@
             (is (= '({:id 5400 :statewide 1} {:id 5401 :statewide 0})
                    (korma/select (get-in out-ctx [:tables :elections])
                                  (korma/fields :id :statewide)))))))))
-  (testing "with no election.txt file the ctx remains the same"
+  (testing "with no election.txt file the ctx includes an error"
     (let [db (sqlite/temp-db "no-load-elections-test")
           ctx (merge {:input []} db)
           out-ctx (load-elections (assoc ctx :input []))]
-      (is (empty? (korma/select (get-in out-ctx [:tables :elections])))))))
+      (is (empty? (korma/select (get-in out-ctx [:tables :elections]))))
+      (is (get-in out-ctx [:errors :load-elections])))))


### PR DESCRIPTION
This is built off of the SQLite PR #8.

Creates `load-elections` function which takes in an election.txt and makes a sweet db.

[Pivotal Card](https://www.pivotaltracker.com/story/show/87558780) & [Pivotal Card](https://www.pivotaltracker.com/story/show/87562724)

Assigned to @tank157.