### PR TITLE
Load states

### DIFF
--- a/resources/processing-migrations/20150219-01-create-states-table.down.sql
+++ b/resources/processing-migrations/20150219-01-create-states-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE states;

--- a/resources/processing-migrations/20150219-01-create-states-table.up.sql
+++ b/resources/processing-migrations/20150219-01-create-states-table.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE states(id INTEGER PRIMARY KEY,
+                    name TEXT,
+                    election_administration_id INT);

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -22,4 +22,5 @@
                    :migrator "resources/processing-migrations"})
     {:db db
      :tables {:elections (entity :elections (korma/database db))
-              :sources (entity :sources (korma/database db))}}))
+              :sources (entity :sources (korma/database db))
+              :states (entity :states (korma/database db))}}))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -99,4 +99,4 @@
             contents (read-csv-with-headers state-file)]
         (korma/insert states-table (korma/values contents))
         ctx)
-      (assoc-in ctx [:errors :load-states] "state.txt missing"))))
+      (assoc-in ctx [:warnings :load-states] "state.txt missing"))))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -90,3 +90,13 @@
         (korma/insert sources-table (korma/values contents))
         ctx)
       (assoc-in ctx [:errors :load-sources] "source.txt missing"))))
+
+(defn load-states [ctx]
+  (let [files (:input ctx)
+        state-file (first (filter #(= "state.txt" (.getName %)) files))]
+    (if state-file
+      (let [states-table (get-in ctx [:tables :states])
+            contents (read-csv-with-headers state-file)]
+        (korma/insert states-table (korma/values contents))
+        ctx)
+      (assoc-in ctx [:errors :load-states] "state.txt missing"))))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -28,7 +28,8 @@
 (def csv-validations
   [csv/remove-bad-filenames
    csv/load-elections
-   csv/load-sources])
+   csv/load-sources
+   csv/load-states])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/test-resources/state.txt
+++ b/test-resources/state.txt
@@ -1,0 +1,2 @@
+name,election_administration_id,id
+NORTH CAROLINA,,1

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -71,9 +71,9 @@
           (is (= '({:id 1})
                  (korma/select (get-in out-ctx [:tables :states])
                                (korma/fields :id))))))))
-  (testing "with no state.txt file the ctx includes an error"
+  (testing "with no state.txt file the ctx includes a warning"
     (let [db (sqlite/temp-db "no-load-states-test")
           ctx (merge {:input []} db)
           out-ctx (load-states (assoc ctx :input []))]
       (is (empty? (korma/select (get-in out-ctx [:tables :states]))))
-      (is (get-in out-ctx [:errors :load-states])))))
+      (is (get-in out-ctx [:warnings :load-states])))))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -59,3 +59,21 @@
           out-ctx (load-sources (assoc ctx :input []))]
       (is (empty? (korma/select (get-in out-ctx [:tables :sources]))))
       (is (get-in out-ctx [:errors :load-sources])))))
+
+(deftest load-states-test
+  (testing "with a valid state.txt file"
+    (let [db (sqlite/temp-db "load-states-test")
+          ctx (merge {:input [(io/as-file (io/resource "state.txt"))]}
+                     db)]
+      (is (empty? (korma/select (get-in ctx [:tables :states]))))
+      (testing "inserts rows from the valid state.txt file"
+        (let [out-ctx (load-states ctx)]
+          (is (= '({:id 1})
+                 (korma/select (get-in out-ctx [:tables :states])
+                               (korma/fields :id))))))))
+  (testing "with no state.txt file the ctx includes an error"
+    (let [db (sqlite/temp-db "no-load-states-test")
+          ctx (merge {:input []} db)
+          out-ctx (load-states (assoc ctx :input []))]
+      (is (empty? (korma/select (get-in out-ctx [:tables :states]))))
+      (is (get-in out-ctx [:errors :load-states])))))


### PR DESCRIPTION
Loads the state.txt file. If it doesn't exist, adds a warning.

[Pivotal Card](https://www.pivotaltracker.com/story/show/87563418)

Assigned @tie-rack.