### PR TITLE
csv-loaders and missing-file fns

### DIFF
--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -24,3 +24,16 @@
      :tables {:elections (entity :elections (korma/database db))
               :sources (entity :sources (korma/database db))
               :states (entity :states (korma/database db))}}))
+
+(defn column-names
+  "Find the names of all columns for a table. Uses a JDBC connection
+  directly."
+  [db table]
+  (let [url (str "jdbc:sqlite:" (:db db))]
+    (with-open [conn (java.sql.DriverManager/getConnection url)]
+      (let [statement (.createStatement conn)
+            result-set (.executeQuery statement (str "PRAGMA table_info(" table ")"))]
+        (loop [columns []]
+          (if (.next result-set)
+            (recur (conj columns (.getString result-set "name")))
+            columns))))))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -91,7 +91,8 @@
             contents (read-csv-with-headers file-to-load)
             transforms (apply comp select-columns row-transform-fns)
             transformed-contents (map transforms contents)]
-        (korma/insert sql-table (korma/values transformed-contents))))
+        (doseq [row transformed-contents]
+          (korma/insert sql-table (korma/values row)))))
     ctx))
 
 (defn add-report-on-missing-file-fn

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -86,7 +86,7 @@
   (fn [ctx]
     (when-let [file-to-load (find-input-file ctx filename)]
       (let [sql-table (get-in ctx [:tables table])
-            column-names (sqlite/column-names (:db ctx) (name table))
+            column-names (sqlite/column-names (:db ctx) (:name sql-table))
             select-columns (fn [row] (select-keys row column-names))
             contents (read-csv-with-headers file-to-load)
             transforms (apply comp select-columns row-transform-fns)

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -114,10 +114,6 @@
   error-on-missing-file
   (add-report-on-missing-file-fn :errors))
 
-(def error-on-missing-election (error-on-missing-file "election.txt"))
-(def error-on-missing-source (error-on-missing-file "source.txt"))
-(def warn-on-missing-state (warn-on-missing-file "state.txt"))
-
 (def load-elections (csv-loader "election.txt" :elections
                                 (booleanize "election_day_registration")
                                 (booleanize "statewide")))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -27,9 +27,9 @@
 
 (def csv-validations
   [csv/remove-bad-filenames
-   (error-on-missing-file "election.txt")
-   (error-on-missing-file "source.txt")
-   (warn-on-missing-file "state.txt")
+   (csv/error-on-missing-file "election.txt")
+   (csv/error-on-missing-file "source.txt")
+   (csv/warn-on-missing-file "state.txt")
    csv/load-elections
    csv/load-sources
    csv/load-states])

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -27,9 +27,9 @@
 
 (def csv-validations
   [csv/remove-bad-filenames
-   csv/error-on-missing-election
-   csv/error-on-missing-source
-   csv/warn-on-missing-state
+   (error-on-missing-file "election.txt")
+   (error-on-missing-file "source.txt")
+   (warn-on-missing-file "state.txt")
    csv/load-elections
    csv/load-sources
    csv/load-states])

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -27,6 +27,9 @@
 
 (def csv-validations
   [csv/remove-bad-filenames
+   csv/error-on-missing-election
+   csv/error-on-missing-source
+   csv/warn-on-missing-state
    csv/load-elections
    csv/load-sources
    csv/load-states])

--- a/test-resources/state-with-bad-columns.txt
+++ b/test-resources/state-with-bad-columns.txt
@@ -1,0 +1,2 @@
+name,election_administration_id,id,state_bird,state_flower
+NORTH CAROLINA,8,1,Cardinal,Dogwood

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -85,3 +85,12 @@
       (is (get-in out-ctx [:errors "election.txt"]))
       (is (get-in out-ctx [:warnings "state.txt"]))
       (is (not (contains? (:errors out-ctx) "source.txt"))))))
+
+(deftest csv-loader-test
+  (testing "ignores unknown columns"
+    (let [loader (csv-loader "state-with-bad-columns.txt" :states)
+          ctx (merge {:input [(io/as-file (io/resource "state-with-bad-columns.txt"))]}
+                     (sqlite/temp-db "ignore-columns-test"))
+          out-ctx (loader ctx)]
+      (is (= [{:id 1 :name "NORTH CAROLINA" :election_administration_id 8}]
+             (korma/select (get-in out-ctx [:tables :states])))))))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -78,7 +78,6 @@
 (deftest missing-files-test
   (testing "reports errors or warnings when certain files are missing"
     (let [ctx {:input [(io/as-file (io/resource "source.txt"))]}
-          ()
           out-ctx (-> ctx
                       ((error-on-missing-file "election.txt"))
                       ((error-on-missing-file "source.txt"))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -78,10 +78,11 @@
 (deftest missing-files-test
   (testing "reports errors or warnings when certain files are missing"
     (let [ctx {:input [(io/as-file (io/resource "source.txt"))]}
+          ()
           out-ctx (-> ctx
-                      error-on-missing-election
-                      error-on-missing-source
-                      warn-on-missing-state)]
+                      ((error-on-missing-file "election.txt"))
+                      ((error-on-missing-file "source.txt"))
+                      ((warn-on-missing-file "state.txt")))]
       (is (get-in out-ctx [:errors "election.txt"]))
       (is (get-in out-ctx [:warnings "state.txt"]))
       (is (not (contains? (:errors out-ctx) "source.txt"))))))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -35,12 +35,11 @@
             (is (= '({:id 5400 :statewide 1} {:id 5401 :statewide 0})
                    (korma/select (get-in out-ctx [:tables :elections])
                                  (korma/fields :id :statewide)))))))))
-  (testing "with no election.txt file the ctx includes an error"
+  (testing "with no election.txt file, does nothing"
     (let [db (sqlite/temp-db "no-load-elections-test")
           ctx (merge {:input []} db)
           out-ctx (load-elections (assoc ctx :input []))]
-      (is (empty? (korma/select (get-in out-ctx [:tables :elections]))))
-      (is (get-in out-ctx [:errors :load-elections])))))
+      (is (empty? (korma/select (get-in out-ctx [:tables :elections])))))))
 
 (deftest load-sources-test
   (testing "with a valid source.txt file"
@@ -53,12 +52,11 @@
           (is (= '({:id 4400})
                  (korma/select (get-in out-ctx [:tables :sources])
                                (korma/fields :id))))))))
-  (testing "with no source.txt file the ctx includes an error"
+  (testing "with no source.txt file, does nothing"
     (let [db (sqlite/temp-db "no-load-sources-test")
           ctx (merge {:input []} db)
           out-ctx (load-sources (assoc ctx :input []))]
-      (is (empty? (korma/select (get-in out-ctx [:tables :sources]))))
-      (is (get-in out-ctx [:errors :load-sources])))))
+      (is (empty? (korma/select (get-in out-ctx [:tables :sources])))))))
 
 (deftest load-states-test
   (testing "with a valid state.txt file"
@@ -71,9 +69,19 @@
           (is (= '({:id 1})
                  (korma/select (get-in out-ctx [:tables :states])
                                (korma/fields :id))))))))
-  (testing "with no state.txt file the ctx includes a warning"
+  (testing "with no state.txt file, does nothing"
     (let [db (sqlite/temp-db "no-load-states-test")
           ctx (merge {:input []} db)
           out-ctx (load-states (assoc ctx :input []))]
-      (is (empty? (korma/select (get-in out-ctx [:tables :states]))))
-      (is (get-in out-ctx [:warnings :load-states])))))
+      (is (empty? (korma/select (get-in out-ctx [:tables :states])))))))
+
+(deftest missing-files-test
+  (testing "reports errors or warnings when certain files are missing"
+    (let [ctx {:input [(io/as-file (io/resource "source.txt"))]}
+          out-ctx (-> ctx
+                      error-on-missing-election
+                      error-on-missing-source
+                      warn-on-missing-state)]
+      (is (get-in out-ctx [:errors "election.txt"]))
+      (is (get-in out-ctx [:warnings "state.txt"]))
+      (is (not (contains? (:errors out-ctx) "source.txt"))))))


### PR DESCRIPTION
Now that we've built a few, let's make it a nicer experience:

For example, a processing function that loads a CSV:
```clojure
(def load-elections (csv-loader "election.txt" :elections
                                (booleanize "election_day_registration")
                                (booleanize "statewide")))
```

This will load the data in "elections.txt" into the `:elections` table, applying those two `booleanize` functions to each row in the CSV. It will also ignore any missing columns (instead of, as before, blowing up).

Also, a processing function that adds an error if a file is missing:
```clojure
(error-on-missing-file "election.txt")
```

This functionality was moved from the loading functions because it's a different job. There is also a similar processing function generator called `warn-on-missing-file`.