### PR TITLE
[CS] Insert multiple rows during csv import

### DIFF
--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -47,3 +47,28 @@
           (if (.next result-set)
             (recur (conj columns (.getString result-set "name")))
             columns))))))
+
+(defn chunk-rows
+  "Given a seq of maps, split them into groups, such that no group
+  have more than n total keys across its maps."
+  [rows n]
+  (lazy-seq
+   (loop [this-chunk []
+          this-chunk-size 0
+          to-go rows]
+     (if (empty? to-go)
+       (list this-chunk)
+       (let [next-row (first to-go)
+             size-with-next-row (+ this-chunk-size (count next-row))]
+         (cond
+          (< n (count next-row)) (throw (ex-info "Map too large" {:map next-row}))
+          (< n size-with-next-row) (cons this-chunk (chunk-rows to-go n))
+          :else (recur (conj this-chunk next-row)
+                       size-with-next-row
+                       (rest to-go))))))))
+
+(def statement-parameter-limit 999)
+
+(defn bulk-import [rows table]
+  (doseq [chunk (chunk-rows rows statement-parameter-limit)]
+    (korma/insert table (korma/values chunk))))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -73,6 +73,27 @@
        (filter #(= filename (.getName %)))
        first))
 
+(defn chunk-rows
+  "Given a seq of maps, split them into groups, such that no group
+  have more than n total keys across its maps."
+  [rows n]
+  (lazy-seq
+   (loop [this-chunk []
+          this-chunk-size 0
+          to-go rows]
+     (if (empty? to-go)
+       (list this-chunk)
+       (let [next-row (first to-go)
+             size-with-next-row (+ this-chunk-size (count next-row))]
+         (cond
+          (< n (count next-row)) (throw (ex-info "Map too large" {:map next-row}))
+          (< n size-with-next-row) (cons this-chunk (chunk-rows to-go n))
+          :else (recur (conj this-chunk next-row)
+                       size-with-next-row
+                       (rest to-go))))))))
+
+(def sqlite-statement-parameter-limit 999)
+
 (defn csv-loader
   "Generates a validation function that loads the specified file into
   the specified table, transforming each row by the
@@ -90,8 +111,9 @@
               contents (read-csv-with-headers in-file)
               transforms (apply comp select-columns row-transform-fns)
               transformed-contents (map transforms contents)]
-          (doseq [row transformed-contents]
-            (korma/insert sql-table (korma/values row))))))
+          (doseq [rows (chunk-rows transformed-contents
+                                   sqlite-statement-parameter-limit)]
+            (korma/insert sql-table (korma/values rows))))))
     ctx))
 
 (defn add-report-on-missing-file-fn

--- a/test/vip/data_processor/db/sqlite_test.clj
+++ b/test/vip/data_processor/db/sqlite_test.clj
@@ -1,0 +1,22 @@
+(ns vip.data-processor.db.sqlite-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.db.sqlite :refer :all]))
+
+(deftest chunk-rows-test
+  (let [n 7
+        rows [{:first "George" :last "Washington" :start 1789}
+              {:first "John"   :last "Adams"      :start 1797}
+              {:first "Thomas" :last "Jefferson"  :start 1801}
+              {:first "James"  :last "Madison"    :start 1809}
+              {:first "James"  :last "Monroe"     :start 1817}]
+        chunked (chunk-rows rows n)]
+    (testing "returns a lazy sequence"
+      (is (not (realized? chunked))))
+    (testing "contains every row in the same order"
+      (is (= rows (apply concat chunked))))
+    (testing "no chunk has more than n keys"
+      (doseq [n (range 3 17)]
+        (let [chunked (chunk-rows rows n)
+              key-count (fn [coll] (apply + (map count coll)))
+              no-more-than-n-keys? (fn [coll] (>= n (key-count coll)))]
+          (is (every? no-more-than-n-keys? chunked)))))))


### PR DESCRIPTION
`chunk-rows` breaks up rows for import into as big chunks as possible for a SQLite insert. We can be sure we can import all rows for an import at once, since SQLite can only support 999 statement parameters at a time. This breaks them down into groups such that no group has more than 999 values to insert.

This *dramatically* speeds up imports of large files, especially street_segment.txt.

[Pivotal story](https://www.pivotaltracker.com/story/show/89618646)