### PR TITLE
Load precinct districts and sites

### DIFF
--- a/resources/processing-migrations/20150310-3-load-precinct-electoral-districts.down.sql
+++ b/resources/processing-migrations/20150310-3-load-precinct-electoral-districts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE precinct_electoral_districts;

--- a/resources/processing-migrations/20150310-3-load-precinct-electoral-districts.up.sql
+++ b/resources/processing-migrations/20150310-3-load-precinct-electoral-districts.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE precinct_electoral_districts (id INTEGER PRIMARY KEY,
+                                           precinct_id INTEGER,
+                                           electoral_district_id INTEGER);

--- a/resources/processing-migrations/20150310-3-load-precinct-electoral-districts.up.sql
+++ b/resources/processing-migrations/20150310-3-load-precinct-electoral-districts.up.sql
@@ -1,3 +1,2 @@
-CREATE TABLE precinct_electoral_districts (id INTEGER PRIMARY KEY,
-                                           precinct_id INTEGER,
+CREATE TABLE precinct_electoral_districts (precinct_id INTEGER,
                                            electoral_district_id INTEGER);

--- a/resources/processing-migrations/20150310-4-load-precinct-early-vote-sites.down.sql
+++ b/resources/processing-migrations/20150310-4-load-precinct-early-vote-sites.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE precinct_early_vote_sites;

--- a/resources/processing-migrations/20150310-4-load-precinct-early-vote-sites.up.sql
+++ b/resources/processing-migrations/20150310-4-load-precinct-early-vote-sites.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE precinct_early_vote_sites (id INTEGER PRIMARY KEY,
+                                          precinct_id INTEGER,
+                                          early_vote_site_id INTEGER);

--- a/resources/processing-migrations/20150310-4-load-precinct-early-vote-sites.up.sql
+++ b/resources/processing-migrations/20150310-4-load-precinct-early-vote-sites.up.sql
@@ -1,3 +1,2 @@
-CREATE TABLE precinct_early_vote_sites (id INTEGER PRIMARY KEY,
-                                          precinct_id INTEGER,
-                                          early_vote_site_id INTEGER);
+CREATE TABLE precinct_early_vote_sites (precinct_id INTEGER,
+                                        early_vote_site_id INTEGER);

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -44,7 +44,8 @@
               :ballot-candidates (entity :ballot_candidates (korma/database db))
               :state-early-vote-sites (entity :state_early_vote_sites (korma/database db))
               :precinct-split-polling-locations (entity :precinct_split_polling_locations (korma/database db))
-              :precinct-electoral-districts (entity :precinct_electoral_districts (korma/database db))}}))
+              :precinct-electoral-districts (entity :precinct_electoral_districts (korma/database db))
+              :precinct-early-vote-sites (entity :precinct_early_vote_sites (korma/database db))}}))
 
 (defn column-names
   "Find the names of all columns for a table. Uses a JDBC connection

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -43,7 +43,8 @@
               :candidates (entity :candidates (korma/database db))
               :ballot-candidates (entity :ballot_candidates (korma/database db))
               :state-early-vote-sites (entity :state_early_vote_sites (korma/database db))
-              :precinct-split-polling-locations (entity :precinct_split_polling_locations (korma/database db))}}))
+              :precinct-split-polling-locations (entity :precinct_split_polling_locations (korma/database db))
+              :precinct-electoral-districts (entity :precinct_electoral_districts (korma/database db))}}))
 
 (defn column-names
   "Find the names of all columns for a table. Uses a JDBC connection

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -144,3 +144,4 @@
 (def load-state-early-vote-sites (csv-loader "state_early_vote_site.txt" :state-early-vote-sites))
 (def load-precinct-split-polling-locations (csv-loader "precinct_split_polling_location.txt" :precinct-split-polling-locations))
 (def load-precinct-electoral-districts (csv-loader "precinct_electoral_district.txt" :precinct-electoral-districts))
+(def load-precinct-early-vote-sites (csv-loader "precinct_early_vote_site.txt" :precinct-early-vote-sites))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -143,3 +143,4 @@
 (def load-ballot-candidates (csv-loader "ballot_candidate.txt" :ballot-candidates))
 (def load-state-early-vote-sites (csv-loader "state_early_vote_site.txt" :state-early-vote-sites))
 (def load-precinct-split-polling-locations (csv-loader "precinct_split_polling_location.txt" :precinct-split-polling-locations))
+(def load-precinct-electoral-districts (csv-loader "precinct_electoral_district.txt" :precinct-electoral-districts))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -50,6 +50,7 @@
    (csv/warn-on-missing-file "ballot_candidate.txt")
    (csv/warn-on-missing-file "state_early_vote_site.txt")
    (csv/warn-on-missing-file "precinct_split_polling_location.txt")
+   (csv/warn-on-missing-file "precinct_electoral_district.txt")
    csv/load-elections
    csv/load-sources
    csv/load-states
@@ -72,7 +73,8 @@
    csv/load-candidates
    csv/load-ballot-candidates
    csv/load-state-early-vote-sites
-   csv/load-precinct-split-polling-locations])
+   csv/load-precinct-split-polling-locations
+   csv/load-precinct-electoral-districts])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -51,6 +51,7 @@
    (csv/warn-on-missing-file "state_early_vote_site.txt")
    (csv/warn-on-missing-file "precinct_split_polling_location.txt")
    (csv/warn-on-missing-file "precinct_electoral_district.txt")
+   (csv/warn-on-missing-file "precinct_early_vote_site.txt")
    csv/load-elections
    csv/load-sources
    csv/load-states
@@ -74,7 +75,8 @@
    csv/load-ballot-candidates
    csv/load-state-early-vote-sites
    csv/load-precinct-split-polling-locations
-   csv/load-precinct-electoral-districts])
+   csv/load-precinct-electoral-districts
+   csv/load-precinct-early-vote-sites])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/test-resources/full-good-run/precinct_early_vote_site.txt
+++ b/test-resources/full-good-run/precinct_early_vote_site.txt
@@ -1,0 +1,1 @@
+precinct_id,early_vote_site_id

--- a/test-resources/full-good-run/precinct_electoral_district.txt
+++ b/test-resources/full-good-run/precinct_electoral_district.txt
@@ -1,0 +1,1 @@
+precinct_id,electoral_district_id


### PR DESCRIPTION
Add CSV loading capability for:
* precinct_electoral_district.txt
* precinct_early_vote_site.txt

Pivotal cards: [89140714](https://www.pivotaltracker.com/story/show/89140714) and [89140516](https://www.pivotaltracker.com/story/show/89140516)

The data processor can now upload this data into individual tables and make changes (i.e. boolean values) where appropriate.