### PR TITLE
Load moar csvs

### DIFF
--- a/resources/processing-migrations/20150311-01-load-locality-early-vote-sites.down.sql
+++ b/resources/processing-migrations/20150311-01-load-locality-early-vote-sites.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE locality_early_vote_sites;

--- a/resources/processing-migrations/20150311-01-load-locality-early-vote-sites.up.sql
+++ b/resources/processing-migrations/20150311-01-load-locality-early-vote-sites.up.sql
@@ -1,0 +1,2 @@
+CREATE TABLE locality_early_vote_sites (locality_id INTEGER,
+                                        early_vote_site_id INTEGER);

--- a/resources/processing-migrations/20150311-02-custom-ballot-ballot-responses.down.sql
+++ b/resources/processing-migrations/20150311-02-custom-ballot-ballot-responses.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE custom_ballot_ballot_responses;

--- a/resources/processing-migrations/20150311-02-custom-ballot-ballot-responses.up.sql
+++ b/resources/processing-migrations/20150311-02-custom-ballot-ballot-responses.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE custom_ballot_ballot_responses (custom_ballot_id INTEGER,
+                                             ballot_response_id INTEGER,
+                                             sort_order INTEGER);

--- a/resources/processing-migrations/20150311-03-custom-ballots.down.sql
+++ b/resources/processing-migrations/20150311-03-custom-ballots.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE custom_ballots;

--- a/resources/processing-migrations/20150311-03-custom-ballots.up.sql
+++ b/resources/processing-migrations/20150311-03-custom-ballots.up.sql
@@ -1,0 +1,2 @@
+CREATE TABLE custom_ballots (id INTEGER PRIMARY KEY,
+                             heading TEXT);

--- a/resources/processing-migrations/20150311-04-contest-results.down.sql
+++ b/resources/processing-migrations/20150311-04-contest-results.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE contest_results;

--- a/resources/processing-migrations/20150311-04-contest-results.up.sql
+++ b/resources/processing-migrations/20150311-04-contest-results.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE contest_results (id INTEGER PRIMARY KEY,
+                              contest_id INTEGER,
+                              jurisdiction_id INTEGER,
+                              entire_district BOOLEAN NOT NULL CHECK (entire_district IN (0,1)),
+                              total_votes INTEGER,
+                              total_valid_votes INTEGER,
+                              overvotes INTEGER,
+                              blank_votes INTEGER,
+                              accepted_provisional_votes INTEGER,
+                              rejected_votes INTEGER,
+                              certification TEXT);

--- a/resources/processing-migrations/20150312-01-load-ballot-line-results.down.sql
+++ b/resources/processing-migrations/20150312-01-load-ballot-line-results.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE ballot_line_results;

--- a/resources/processing-migrations/20150312-01-load-ballot-line-results.up.sql
+++ b/resources/processing-migrations/20150312-01-load-ballot-line-results.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE ballot_line_results (id INTEGER PRIMARY KEY,
+                                  contest_id INTEGER,
+                                  jurisdiction_id INTEGER,
+                                  entire_district BOOLEAN NOT NULL CHECK (entire_district IN (0,1)),
+                                  candidate_id INTEGER,
+                                  ballot_response_id INTEGER,
+                                  votes INTEGER,
+                                  victorious BOOLEAN NOT NULL CHECK (victorious IN (0,1)),
+                                  certification TEXT);
+
+
+
+
+

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -48,7 +48,8 @@
               :precinct-early-vote-sites (entity :precinct_early_vote_sites (korma/database db))
               :locality-early-vote-sites (entity :locality_early_vote_sites (korma/database db))
               :custom-ballot-ballot-responses (entity :custom_ballot_ballot_responses (korma/database db))
-              :custom-ballots (entity :custom_ballots (korma/database db ))}}))
+              :custom-ballots (entity :custom_ballots (korma/database db ))
+              :contest-results (entity :contest_results (korma/database db))}}))
 
 (defn column-names
   "Find the names of all columns for a table. Uses a JDBC connection

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -49,7 +49,8 @@
               :locality-early-vote-sites (entity :locality_early_vote_sites (korma/database db))
               :custom-ballot-ballot-responses (entity :custom_ballot_ballot_responses (korma/database db))
               :custom-ballots (entity :custom_ballots (korma/database db ))
-              :contest-results (entity :contest_results (korma/database db))}}))
+              :contest-results (entity :contest_results (korma/database db))
+              :ballot-line-results (entity :ballot_line_results (korma/database db))}}))
 
 (defn column-names
   "Find the names of all columns for a table. Uses a JDBC connection

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -45,7 +45,8 @@
               :state-early-vote-sites (entity :state_early_vote_sites (korma/database db))
               :precinct-split-polling-locations (entity :precinct_split_polling_locations (korma/database db))
               :precinct-electoral-districts (entity :precinct_electoral_districts (korma/database db))
-              :precinct-early-vote-sites (entity :precinct_early_vote_sites (korma/database db))}}))
+              :precinct-early-vote-sites (entity :precinct_early_vote_sites (korma/database db))
+              :locality-early-vote-sites (entity :locality_early_vote_sites (korma/database db))}}))
 
 (defn column-names
   "Find the names of all columns for a table. Uses a JDBC connection

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -46,7 +46,8 @@
               :precinct-split-polling-locations (entity :precinct_split_polling_locations (korma/database db))
               :precinct-electoral-districts (entity :precinct_electoral_districts (korma/database db))
               :precinct-early-vote-sites (entity :precinct_early_vote_sites (korma/database db))
-              :locality-early-vote-sites (entity :locality_early_vote_sites (korma/database db))}}))
+              :locality-early-vote-sites (entity :locality_early_vote_sites (korma/database db))
+              :custom-ballot-ballot-responses (entity :custom_ballot_ballot_responses (korma/database db))}}))
 
 (defn column-names
   "Find the names of all columns for a table. Uses a JDBC connection

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -47,7 +47,8 @@
               :precinct-electoral-districts (entity :precinct_electoral_districts (korma/database db))
               :precinct-early-vote-sites (entity :precinct_early_vote_sites (korma/database db))
               :locality-early-vote-sites (entity :locality_early_vote_sites (korma/database db))
-              :custom-ballot-ballot-responses (entity :custom_ballot_ballot_responses (korma/database db))}}))
+              :custom-ballot-ballot-responses (entity :custom_ballot_ballot_responses (korma/database db))
+              :custom-ballots (entity :custom_ballots (korma/database db ))}}))
 
 (defn column-names
   "Find the names of all columns for a table. Uses a JDBC connection

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -146,3 +146,4 @@
 (def load-precinct-electoral-districts (csv-loader "precinct_electoral_district.txt" :precinct-electoral-districts))
 (def load-precinct-early-vote-sites (csv-loader "precinct_early_vote_site.txt" :precinct-early-vote-sites))
 (def load-locality-early-vote-sites (csv-loader "locality_early_vote_site.txt" :locality-early-vote-sites))
+(def load-custom-ballot-ballot-responses (csv-loader "custom_ballot_ballot_response.txt" :custom-ballot-ballot-responses))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -152,4 +152,4 @@
                                       (booleanize "entire_district")))
 (def load-ballot-line-results (csv-loader "ballot_line_result.txt" :ballot-line-results
                                           (booleanize "entire_district")
-                                          (booleanize "victorious"))
+                                          (booleanize "victorious")))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -148,3 +148,4 @@
 (def load-locality-early-vote-sites (csv-loader "locality_early_vote_site.txt" :locality-early-vote-sites))
 (def load-custom-ballot-ballot-responses (csv-loader "custom_ballot_ballot_response.txt" :custom-ballot-ballot-responses))
 (def load-custom-ballots (csv-loader "custom_ballot.txt" :custom-ballots))
+(def load-contest-results (csv-loader "contest_result.txt" :contest-results))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -147,3 +147,4 @@
 (def load-precinct-early-vote-sites (csv-loader "precinct_early_vote_site.txt" :precinct-early-vote-sites))
 (def load-locality-early-vote-sites (csv-loader "locality_early_vote_site.txt" :locality-early-vote-sites))
 (def load-custom-ballot-ballot-responses (csv-loader "custom_ballot_ballot_response.txt" :custom-ballot-ballot-responses))
+(def load-custom-ballots (csv-loader "custom_ballot.txt" :custom-ballots))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -149,3 +149,4 @@
 (def load-custom-ballot-ballot-responses (csv-loader "custom_ballot_ballot_response.txt" :custom-ballot-ballot-responses))
 (def load-custom-ballots (csv-loader "custom_ballot.txt" :custom-ballots))
 (def load-contest-results (csv-loader "contest_result.txt" :contest-results))
+(def load-ballot-line-results (csv-loader "ballot_line_result.txt" :ballot-line-results))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -145,3 +145,4 @@
 (def load-precinct-split-polling-locations (csv-loader "precinct_split_polling_location.txt" :precinct-split-polling-locations))
 (def load-precinct-electoral-districts (csv-loader "precinct_electoral_district.txt" :precinct-electoral-districts))
 (def load-precinct-early-vote-sites (csv-loader "precinct_early_vote_site.txt" :precinct-early-vote-sites))
+(def load-locality-early-vote-sites (csv-loader "locality_early_vote_site.txt" :locality-early-vote-sites))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -148,5 +148,8 @@
 (def load-locality-early-vote-sites (csv-loader "locality_early_vote_site.txt" :locality-early-vote-sites))
 (def load-custom-ballot-ballot-responses (csv-loader "custom_ballot_ballot_response.txt" :custom-ballot-ballot-responses))
 (def load-custom-ballots (csv-loader "custom_ballot.txt" :custom-ballots))
-(def load-contest-results (csv-loader "contest_result.txt" :contest-results))
-(def load-ballot-line-results (csv-loader "ballot_line_result.txt" :ballot-line-results))
+(def load-contest-results (csv-loader "contest_result.txt" :contest-results
+                                      (booleanize "entire_district")))
+(def load-ballot-line-results (csv-loader "ballot_line_result.txt" :ballot-line-results
+                                          (booleanize "entire_district")
+                                          (booleanize "victorious"))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -77,7 +77,8 @@
    csv/load-precinct-split-polling-locations
    csv/load-precinct-electoral-districts
    csv/load-precinct-early-vote-sites
-   csv/load-locality-early-vote-sites])
+   csv/load-locality-early-vote-sites
+   csv/load-custom-ballot-ballot-responses])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -78,7 +78,8 @@
    csv/load-precinct-electoral-districts
    csv/load-precinct-early-vote-sites
    csv/load-locality-early-vote-sites
-   csv/load-custom-ballot-ballot-responses])
+   csv/load-custom-ballot-ballot-responses
+   csv/load-custom-ballots])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -80,7 +80,8 @@
    csv/load-locality-early-vote-sites
    csv/load-custom-ballot-ballot-responses
    csv/load-custom-ballots
-   csv/load-contest-results])
+   csv/load-contest-results
+   csv/load-ballot-line-results])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -76,7 +76,8 @@
    csv/load-state-early-vote-sites
    csv/load-precinct-split-polling-locations
    csv/load-precinct-electoral-districts
-   csv/load-precinct-early-vote-sites])
+   csv/load-precinct-early-vote-sites
+   csv/load-locality-early-vote-sites])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -79,7 +79,8 @@
    csv/load-precinct-early-vote-sites
    csv/load-locality-early-vote-sites
    csv/load-custom-ballot-ballot-responses
-   csv/load-custom-ballots])
+   csv/load-custom-ballots
+   csv/load-contest-results])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/test-resources/full-good-run/ballot_line_result.txt
+++ b/test-resources/full-good-run/ballot_line_result.txt
@@ -1,0 +1,1 @@
+contest_id,jurisdiction_id,entire_district,candidate_id,ballot_response_id,votes,victorious,id,certification

--- a/test-resources/full-good-run/contest_result.txt
+++ b/test-resources/full-good-run/contest_result.txt
@@ -1,0 +1,1 @@
+contest_id,jurisdiction_id,entire_district,total_votes,total_valid_votes,overvotes,blank_votes,accepted_provisional_votes,rejected_votes,id,certification

--- a/test-resources/full-good-run/custom_ballot.txt
+++ b/test-resources/full-good-run/custom_ballot.txt
@@ -1,0 +1,1 @@
+heading,id

--- a/test-resources/full-good-run/custom_ballot_ballot_response.txt
+++ b/test-resources/full-good-run/custom_ballot_ballot_response.txt
@@ -1,0 +1,1 @@
+custom_ballot_id,ballot_response_id,sort_order

--- a/test-resources/full-good-run/locality_early_vote_site.txt
+++ b/test-resources/full-good-run/locality_early_vote_site.txt
@@ -1,0 +1,1 @@
+locality_id,early_vote_site_id


### PR DESCRIPTION
Pivotal Cards: [89140146](https://www.pivotaltracker.com/story/show/89140146), [89139764](https://www.pivotaltracker.com/story/show/89139764), [89139702](https://www.pivotaltracker.com/story/show/89139702), [89139630](https://www.pivotaltracker.com/story/show/89139630), [89139048](https://www.pivotaltracker.com/story/show/89139048)

All of these cards are geared towards adding CSV loading capabilities for the following files:
* locality_early_vote_site.txt
* custom_ballot_ballot_response.txt
* custom_ballot.txt
* contest_result.txt
* ballot_line_result.txt

The data processor can now upload this data into individual tables and make changes (i.e. boolean values) where appropriate.