### PR TITLE
Validate number of values in each CSV row

### DIFF
--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -312,11 +312,11 @@
      :bad-rows (remove (fn [[_ row]] (= (count headers) (count row)))
                        (map list (iterate inc 2) rows))}))
 
-(defn report-bad-rows [ctx filename bad-rows]
+(defn report-bad-rows [ctx filename expected-number bad-rows]
   (if-not (empty? bad-rows)
     (reduce (fn [ctx [line-number row]]
               (assoc-in ctx [:critical filename line-number "Number of values"]
-                        (str "Wrong number of values: " (str/join "," row))))
+                        (str "Expected " expected-number " values, found " (count row))))
             ctx bad-rows)
     ctx))
 
@@ -382,7 +382,7 @@
                   (assoc-in ctx [:warnings filename :extraneous-headers]
                             (str/join ", " extraneous-headers))
                   ctx)
-            ctx (report-bad-rows ctx filename bad-rows)
+            ctx (report-bad-rows ctx filename (count headers) bad-rows)
             contents (map #(select-keys % column-names) contents)]
         (if (empty? (set/intersection (set headers) (set column-names)))
           (assoc-in ctx [:critical filename :headers] "No header row")

--- a/test-resources/bad-number-of-values/contest.txt
+++ b/test-resources/bad-number-of-values/contest.txt
@@ -1,0 +1,7 @@
+election_id,electoral_district_id,type,partisan,primary_party,electorate_specifications,special,office,filing_closed_date,number_elected,number_voting_for,ballot_id,ballot_placement,id
+2003,330004745,primary,yes,DEM,,,PRESIDENTIAL PREFERENCE,,1,1,410004745,1,320004745
+2003,330004746,primary,yes,,,PRESIDENTIAL PREFERENCE,,1,1,410004746,1,320004746
+2003,330004747,primary,yes,LIB,,,PRESIDENTIAL PREFERENCE,,1,1,410004747,1,320004747
+2003,330004801,primary,yes,DEM,,,NC GOVERNOR,,1,1,410004801,4,320004801,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2003,330004802,primary,yes,REP,,,NC GOVERNOR,,1,1,410004802,4,320004802
+2003,330004745,referendum,no,,,,,,,,41100368,,32100368

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -62,6 +62,16 @@
     (testing "does not import contest.txt"
       (is (empty? (korma/select (get-in ctx [:tables :contests])))))))
 
+(deftest number-of-values-in-a-row-test
+  (let [ctx (merge {:input [(io/as-file (io/resource "bad-number-of-values/contest.txt"))]}
+                   (sqlite/temp-db "bad-number-of-values"))
+        only-contests-spec (filter #(= "contest.txt" (:filename %)) csv-specs)
+        load-contests (load-csvs only-contests-spec)
+        out-ctx (load-contests ctx)]
+    (testing "reports critical errors for rows with wrong number of values"
+      (is (get-in out-ctx [:critical "contest.txt" 3 "Number of values"]))
+      (is (get-in out-ctx [:critical "contest.txt" 5 "Number of values"])))))
+
 (deftest create-format-rule-test
   (let [column "id"
         filename "test.txt"


### PR DESCRIPTION
Pivotal story: [90226200](https://www.pivotaltracker.com/story/show/90226200)

Validate that the number of data columns in each file match the number of column headers for each row. Adds a critical error for each bad row.