### PR TITLE
Validate no duplicate IDs across all CSVs

### DIFF
--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -1,0 +1,30 @@
+(ns vip.data-processor.validation.db
+  (:require [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.db.sqlite :as sqlite]
+            [korma.core :as korma]))
+
+(defn has-id? [csv-spec]
+  (some #(-> % :name (= "id")) (:columns csv-spec)))
+
+(defn tables-with-ids [ctx]
+  (let [csvs-with-id (filter has-id? csv/csv-specs)
+        table-names (map :table csvs-with-id)]
+    (map (:tables ctx) table-names)))
+
+(defn add-to-seen-ids [seen-ids table]
+  (let [ids (korma/select table (korma/fields :id))]
+    (reduce (fn [seen-ids {:keys [id]}]
+              (update seen-ids id conj (:table table)))
+            seen-ids
+            ids)))
+
+(defn duplicated-ids [ctx]
+  (let [tables (tables-with-ids ctx)
+        all-ids (reduce add-to-seen-ids {} tables)]
+    (apply dissoc all-ids (for [[k v] all-ids :when (= 1 (count v))] k))))
+
+(defn validate-no-duplicated-ids [ctx]
+  (let [dupes (duplicated-ids ctx)]
+    (if-not (empty? dupes)
+      (assoc-in ctx [:errors "Duplicate IDs"] dupes)
+      ctx)))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -5,7 +5,8 @@
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.s3 :as s3]
             [vip.data-processor.validation.csv :as csv]
-            [vip.data-processor.validation.csv.file-set :as csv-files]))
+            [vip.data-processor.validation.csv.file-set :as csv-files]
+            [vip.data-processor.validation.db :as db]))
 
 (defn read-edn-sqs-message [ctx]
   (assoc ctx :input (edn/read-string (get-in ctx [:input :body]))))
@@ -31,7 +32,8 @@
    (csv/error-on-missing-file "election.txt")
    (csv/error-on-missing-file "source.txt")
    (csv-files/validate-dependencies csv-files/file-dependencies)
-   (csv/load-csvs csv/csv-specs)])
+   (csv/load-csvs csv/csv-specs)
+   db/validate-no-duplicated-ids])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/test-resources/duplicate-ids/candidate.txt
+++ b/test-resources/duplicate-ids/candidate.txt
@@ -1,0 +1,4 @@
+name,party,candidate_url,biography,phone,photo_url,filed_mailing_address_location_name,filed_mailing_address_line1,filed_mailing_address_line2,filed_mailing_address_line3,filed_mailing_address_city,filed_mailing_address_state,filed_mailing_address_zip,email,sort_order,id
+Barack Obama,DEM,,,,,,,,,,,,,,8
+No Preference,DEM,,,,,,,,,,,,,,5882300
+Newt Gingrich,REP,,,,,,,,,,,,,,8675309

--- a/test-resources/duplicate-ids/contest.txt
+++ b/test-resources/duplicate-ids/contest.txt
@@ -1,0 +1,4 @@
+election_id,electoral_district_id,type,partisan,primary_party,electorate_specifications,special,office,filing_closed_date,number_elected,number_voting_for,ballot_id,ballot_placement,id
+2003,330004745,primary,yes,DEM,,,PRESIDENTIAL PREFERENCE,,1,1,410004745,1,5882300
+2003,330004746,primary,yes,REP,,,PRESIDENTIAL PREFERENCE,,1,1,410004746,1,8675309
+2003,330004747,primary,yes,LIB,,,PRESIDENTIAL PREFERENCE,,1,1,410004747,1,7

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -1,0 +1,19 @@
+(ns vip.data-processor.validation.db-test
+  (:require [vip.data-processor.validation.db :refer :all]
+            [clojure.test :refer :all]
+            [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.db.sqlite :as sqlite]
+            [vip.data-processor.pipeline :as pipeline]
+            [clojure.java.io :as io]))
+
+(deftest validate-no-duplicated-ids-test
+  (testing "finds duplicated ids across CSVs and errors"
+    (let [ctx (merge {:input [(io/as-file (io/resource "duplicate-ids/contest.txt"))
+                              (io/as-file (io/resource "duplicate-ids/candidate.txt"))]
+                      :pipeline [(csv/load-csvs csv/csv-specs)
+                                 validate-no-duplicated-ids]}
+                     (sqlite/temp-db "duplicate-ids"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:errors "Duplicate IDs" 8675309]))
+      (is (get-in out-ctx [:errors "Duplicate IDs" 5882300]))
+      (is (not (get-in out-ctx [:errors "Duplicate IDs" 7]))))))


### PR DESCRIPTION
Pivotal story: [90229472](https://www.pivotaltracker.com/story/show/90229472)

Add a validation that no IDs have been duplicated across any files in an upload. Adds errors for each duplicated ID found with where those IDs were specified.