### PR TITLE
[WR] validates that election, source, and state files include exactly one record

### DIFF
--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.db
   (:require [vip.data-processor.validation.db.duplicate-records :as dupe-records]
             [vip.data-processor.validation.db.duplicate-ids :as dupe-ids]
+            [vip.data-processor.validation.db.record-limit :as record-limit]
             [vip.data-processor.validation.db.references :as refs]))
 
 (defn validate-no-duplicated-ids [ctx]
@@ -12,6 +13,9 @@
 (defn validate-no-duplicated-rows [csv-specs]
   (fn [ctx]
     (reduce dupe-records/validate-no-duplicated-rows-in-table ctx csv-specs)))
+
+(defn validate-one-record-limit [ctx]
+  (record-limit/tables-allow-only-one-record ctx))
 
 (defn validate-references [csv-specs]
   (fn [ctx]

--- a/src/vip/data_processor/validation/db/record_limit.clj
+++ b/src/vip/data_processor/validation/db/record_limit.clj
@@ -1,0 +1,38 @@
+(ns vip.data-processor.validation.db.record-limit
+  (:require [korma.core :as korma]))
+
+(def single-record-files
+  "A list of those files which are allowed only a single record."
+  {:elections "election.txt"
+   :sources "source.txt"
+   :states "state.txt"})
+
+(defn count-rows [table]
+  "Takes a single table and counts the number of rows in it."
+  (:cnt (first (korma/select table (korma/aggregate (count "*") :cnt)))))
+
+(defn file-and-count [tables]
+  "Transforms the selected tables into a map of files and counts."
+  (map 
+   (fn [[_ table]]
+     {:file (-> table :table keyword single-record-files)
+      :count (count-rows table)})
+   tables))
+
+(defn error-if-not-one-row [ctx count]
+  "If the count of the rows is not equal to 1, add an error."
+  (if-not (= 1 (:count count))
+    (assoc-in ctx [:errors (:file count) :row-constraint]
+              "File needs to contain exactly one row.")
+    ctx))
+
+(defn tables-allow-only-one-record [ctx]
+  "Sort through the ctx to select out specific tables as defined
+   in single-record-files. Then, count the rows and return errors
+   for any that do not have exactly one row."
+  (let [table-keys (-> single-record-files keys vec)
+        tables (select-keys (:tables ctx) table-keys)
+        counts (file-and-count tables)]
+    (reduce error-if-not-one-row ctx counts)))
+
+

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -36,7 +36,8 @@
    db/validate-no-duplicated-ids
    (db/validate-no-duplicated-rows csv/csv-specs)
    (db/validate-references csv/csv-specs)
-   (db/validate-jurisdiction-references csv/csv-specs)])
+   (db/validate-jurisdiction-references csv/csv-specs)
+   db/validate-one-record-limit])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/test-resources/bad-number-of-rows/election.txt
+++ b/test-resources/bad-number-of-rows/election.txt
@@ -1,2 +1,3 @@
 "date","election_type","state_id","statewide","registration_info","absentee_ballot_info","results_url","polling_hours","election_day_registration","registration_deadline","absentee_request_deadline","id"
 "2014-11-04","Federal","37","yes","","","","6:30 am - 7:30 pm","no","2014-10-14","2014-10-29","2003"
+"2014-11-05","State","37","no","","","","8:30 am - 1:30 pm","no","2012-10-14","2012-10-29","2004"

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -31,6 +31,17 @@
       (is (= #{{:candidate_id 3100047456987, :ballot_id 410004745} {:candidate_id 3100047466988, :ballot_id 410004746}}
              (set (get-in out-ctx [:warnings "ballot_candidate.txt" :duplicated-rows])))))))
 
+(deftest validate-one-record-limit-test
+  (testing "validates that only one row exists in certain files"
+    (let [ctx (merge {:input [(io/as-file
+                                (io/resource "bad-number-of-rows/election.txt"))]
+                      :pipeline [(csv/load-csvs csv/csv-specs)
+                                 validate-one-record-limit]}
+                     (sqlite/temp-db "too-many-records"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (= (get-in out-ctx [:errors "election.txt" :row-constraint])
+             "File needs to contain exactly one row.")))))
+
 (deftest validate-references-test
   (testing "finds bad references"
     (let [ctx (merge {:input [(io/as-file (io/resource "bad-references/ballot.txt"))


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/90231906)

Ensures that election.txt, source.txt, and state.txt only include one record. Otherwise, adds an error for each file.

Assigned @tie-rack.