### PR TITLE
Check CSV values for non-UTF-8 characters

### DIFF
--- a/test-resources/invalid-utf8/source.txt
+++ b/test-resources/invalid-utf8/source.txt
@@ -1,0 +1,2 @@
+name,vip_id,datetime,description,organization_url,feed_contact_id,tou_url,id
+"Department of Elections ÿ Commonwealth of Virginia",51,2015-01-21T18:13:25,The Department of Elections is the official source for Virginia data,http://www.elections.virginia.gov/,,,1

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -117,3 +117,13 @@
       (let [format-rule (create-format-rule filename {:name column})]
         (is (= ctx (format-rule ctx {column "hi"} line-number)))
         (is (= ctx (format-rule ctx {} line-number)))))))
+
+(deftest invalid-utf-8-test
+  (testing "marks any value with a Unicode replacement character as invalid UTF-8 because that's what we assume we get"
+    (let [ctx (merge {:input [(io/as-file (io/resource "invalid-utf8/source.txt"))]
+                    :csv-specs csv-specs}
+                   (sqlite/temp-db "invalid-utf-8"))
+          out-ctx (load-csvs ctx)]
+    (testing "reports errors for values with the Unicode replacement character"
+      (is (= (get-in out-ctx [:errors "source.txt" 2 "name"])
+             "Is not valid UTF-8."))))))


### PR DESCRIPTION
Pivotal story: [90230268](https://www.pivotaltracker.com/story/show/90230268)

Add errors for any value with the Unicode replacement character (which means that there was an invalid UTF-8 byte sequence in the file there).