### PR TITLE
Load XML elements with addresses

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -42,6 +42,7 @@
               {:name "sort_order" :format format/all-digits}]}
    {:filename "candidate.txt"
     :table :candidates
+    :tag-name :candidate
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "name" :required true}
               {:name "party"}
@@ -101,6 +102,7 @@
               {:name "sort_order" :format format/all-digits}]}
    {:filename "early_vote_site.txt"
     :table :early-vote-sites
+    :tag-name :early_vote_site
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "name"}
               {:name "address_location_name"}
@@ -132,6 +134,7 @@
               {:name "absentee_request_deadline" :format format/date}]}
    {:filename "election_administration.txt"
     :table :election-administrations
+    :tag-name :election_administration
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "name"}
               {:name "eo_id" :format format/all-digits :references :election-officials}
@@ -189,6 +192,7 @@
               {:name "early_vote_site_id" :required true :format format/all-digits :references :early-vote-sites}]}
    {:filename "polling_location.txt"
     :table :polling-locations
+    :tag-name :polling_location
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "address_location_name"}
               {:name "address_line1" :required true}
@@ -260,6 +264,7 @@
               {:name "early_vote_site_id" :required true :format format/all-digits :references :early-vote-sites}]}
    {:filename "street_segment.txt"
     :table :street-segments
+    :tag-name :street_segment
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "start_house_number" :required true}
               {:name "end_house_number" :required true}

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -32,4 +32,65 @@
       (testing "loads data from attributes"
         (assert-column out-ctx :ballot-line-results :certification (repeat 4 "certified")))
       (testing "transforms boolean values"
-        (assert-column out-ctx :elections :statewide [1])))))
+        (assert-column out-ctx :elections :statewide [1]))
+      (testing "loads addresses"
+        (is (= [{:mailing_address_line1 "P.O. Box 1776"
+                 :mailing_address_city "Columbus"
+                 :mailing_address_state "OH"
+                 :mailing_address_zip "33333"}]
+               (korma/select (get-in out-ctx [:tables :election-administrations])
+                             (korma/fields :mailing_address_line1
+                                           :mailing_address_city
+                                           :mailing_address_state
+                                           :mailing_address_zip))))
+        (is (= [{:physical_address_location_name "Government Center"
+                 :physical_address_line1 "12 Chad Ct."
+                 :physical_address_city "Columbus"
+                 :physical_address_state "OH"
+                 :physical_address_zip "33333"}]
+               (korma/select (get-in out-ctx [:tables :election-administrations])
+                             (korma/fields :physical_address_location_name
+                                           :physical_address_line1
+                                           :physical_address_city
+                                           :physical_address_state
+                                           :physical_address_zip))))
+        (is (= [{:filed_mailing_address_line1 "123 Fake St."
+                 :filed_mailing_address_city "Rockville"
+                 :filed_mailing_address_state "OH"
+                 :filed_mailing_address_zip "20852"}]
+               (korma/select (get-in out-ctx [:tables :candidates])
+                             (korma/fields :filed_mailing_address_line1
+                                           :filed_mailing_address_city
+                                           :filed_mailing_address_state
+                                           :filed_mailing_address_zip)
+                             (korma/where {:id 90001}))))
+        (is (= [{:non_house_address_street_direction "E"
+                 :non_house_address_street_name "Guinevere"
+                 :non_house_address_street_suffix "Dr"
+                 :non_house_address_address_direction "SE"
+                 :non_house_address_apartment "616S"
+                 :non_house_address_state "VA"
+                 :non_house_address_city "Annandale"
+                 :non_house_address_zip "22003"}]
+               (korma/select (get-in out-ctx [:tables :street-segments])
+                             (korma/fields :non_house_address_street_direction
+                                           :non_house_address_street_name
+                                           :non_house_address_street_suffix
+                                           :non_house_address_address_direction
+                                           :non_house_address_apartment
+                                           :non_house_address_state
+                                           :non_house_address_city
+                                           :non_house_address_zip)
+                             (korma/where {:id 1210001}))))
+        (is (= [{:address_location_name "Springfield Elementary"
+                 :address_line1 "123 Main St."
+                 :address_city "Fake Twp"
+                 :address_state "OH"
+                 :address_zip "33333"}]
+               (korma/select (get-in out-ctx [:tables :polling-locations])
+                             (korma/fields :address_location_name
+                                           :address_line1
+                                           :address_city
+                                           :address_state
+                                           :address_zip)
+                             (korma/where {:id 20121}))))))))


### PR DESCRIPTION
Pivotal story: [91602732](https://www.pivotaltracker.com/story/show/91602732)

Load data from XML uploads into a SQLite database for the following elements:

* election_administration
* polling_location
* early_vote_site
* candidate
* street_segment