### PR TITLE
Load join data from xml

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -1,5 +1,5 @@
 (ns vip.data-processor.validation.data-spec
-  (:require [vip.data-processor.validation.csv.value-format :as format]))
+  (:require [vip.data-processor.validation.data-spec.value-format :as format]))
 
 (defn boolean-value [x]
   (if (re-find #"\A(?i:yes)\z" x) 1 0))

--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -12,6 +12,9 @@
   [{:filename "ballot.txt"
     :table :ballots
     :tag-name :ballot
+    :xml-references [{:join-table :ballot-candidates
+                      :id "ballot_id"
+                      :joined-id "candidate_id"}]
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "referendum_id" :format format/all-digits :references :referendums}
               {:name "custom_ballot_id" :format format/all-digits :references :custom-ballots}
@@ -93,6 +96,9 @@
    {:filename "custom_ballot.txt"
     :table :custom-ballots
     :tag-name :custom_ballot
+    :xml-references [{:join-table :custom-ballot-ballot-responses
+                      :id "custom_ballot_id"
+                      :joined-id "ballot_response_id"}]
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "heading" :required true}]}
    {:filename "custom_ballot_ballot_response.txt"
@@ -181,6 +187,9 @@
    {:filename "locality.txt"
     :table :localities
     :tag-name :locality
+    :xml-references [{:join-table :locality-early-vote-sites
+                      :id "locality_id"
+                      :joined-id "early_vote_site_id"}]
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "name" :required true}
               {:name "state_id" :required true :format format/all-digits :references :states}
@@ -207,6 +216,15 @@
    {:filename "precinct.txt"
     :table :precincts
     :tag-name :precinct
+    :xml-references [{:join-table :precinct-polling-locations
+                      :id "precinct_id"
+                      :joined-id "polling_location_id"}
+                     {:join-table :precinct-early-vote-sites
+                      :id "precinct_id"
+                      :joined-id "early_vote_site_id"}
+                     {:join-table :precinct-electoral-districts
+                      :id "precinct_id"
+                      :joined-id "electoral_district_id"}]
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "name" :required true}
               {:name "number"}
@@ -217,6 +235,12 @@
    {:filename "precinct_split.txt"
     :table :precinct-splits
     :tag-name :precinct-split
+    :xml-references [{:join-table :precinct-split-electoral-districts
+                      :id "precinct_split_id"
+                      :joined-id "electoral_district_id"}
+                     {:join-table :precinct-split-polling-locations
+                      :id "precinct_split_id"
+                      :joined-id "polling_location_id"}]
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "name" :required true}
               {:name "precinct_id" :required true :format format/all-digits :references :precincts}
@@ -244,6 +268,9 @@
    {:filename "referendum.txt"
     :table :referendums
     :tag-name :referendum
+    :xml-references [{:join-table :referendum-ballot-responses
+                      :id "referendum_id"
+                      :joined-id "ballot_response_id"}]
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "title" :required true}
               {:name "subtitle"}
@@ -298,6 +325,9 @@
    {:filename "state.txt"
     :table :states
     :tag-name :state
+    :xml-references [{:join-table :state-early-vote-sites
+                      :id "state_id"
+                      :joined-id "early_vote_site_id"}]
     :columns [{:name "id" :required true :format format/all-digits}
               {:name "name" :required true}
               {:name "election_administration_id" :format format/all-digits :references :election-administrations}]}])

--- a/src/vip/data_processor/validation/data_spec/value_format.clj
+++ b/src/vip/data_processor/validation/data_spec/value_format.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.validation.csv.value-format)
+(ns vip.data-processor.validation.data-spec.value-format)
 
 (def all-digits
   {:check #"\A\d+\z"

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -3,7 +3,6 @@
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.csv :refer :all]
             [vip.data-processor.validation.data-spec :refer [data-specs]]
-            [vip.data-processor.validation.csv.value-format :as format]
             [vip.data-processor.db.sqlite :as sqlite]
             [korma.core :as korma])
   (:import [java.io File]))

--- a/test/vip/data_processor/validation/data_spec_test.clj
+++ b/test/vip/data_processor/validation/data_spec_test.clj
@@ -3,7 +3,7 @@
             [vip.data-processor.validation.data-spec :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.csv :as csv]
-            [vip.data-processor.validation.csv.value-format :as format]
+            [vip.data-processor.validation.data-spec.value-format :as format]
             [vip.data-processor.db.sqlite :as sqlite]))
 
 (deftest create-format-rule-test

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -93,4 +93,17 @@
                                            :address_city
                                            :address_state
                                            :address_zip)
-                             (korma/where {:id 20121}))))))))
+                             (korma/where {:id 20121})))))
+      (testing "loads join table data"
+        (let [precinct-polling-locations (korma/select
+                                          (get-in out-ctx [:tables :precinct-polling-locations])
+                                          (korma/where {:precinct_id 10103}))]
+          (is (= #{20121 20122} (set (map :polling_location_id precinct-polling-locations)))))
+        (let [referendum-ballot-responses (korma/select
+                                           (get-in out-ctx [:tables :referendum-ballot-responses])
+                                           (korma/where {:referendum_id 90011}))]
+          (is (= #{120001 120002} (set (map :ballot_response_id referendum-ballot-responses)))))
+        (let [locality-early-vote-sites (korma/select
+                                         (get-in out-ctx [:tables :locality-early-vote-sites]))]
+          (is (= [{:locality_id 101 :early_vote_site_id 30203}]
+                 locality-early-vote-sites)))))))


### PR DESCRIPTION
Pivotal story: [92175628](https://www.pivotaltracker.com/story/show/92175628)

Load "join" data from XML uploads into a SQLite database to the following tables:

* precinct_polling_locations
* precinct_split_electoral_districts
* referendum_ballot_responses
* ballot_candidates
* state_early_vote_sites
* precinct_split_polling_locations
* precinct_electoral_districts
* precinct_early_vote_sites
* locality_early_vote_sites
* custom_ballot_ballot_responses