### PR TITLE
Share database-backed validations between CSV and XML imports

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -234,7 +234,7 @@
               {:name "ballot_style_image_url" :format format/url}]}
    {:filename "precinct_split.txt"
     :table :precinct-splits
-    :tag-name :precinct-split
+    :tag-name :precinct_split
     :xml-references [{:join-table :precinct-split-electoral-districts
                       :id "precinct_split_id"
                       :joined-id "electoral_district_id"}

--- a/src/vip/data_processor/validation/data_spec/value_format.clj
+++ b/src/vip/data_processor/validation/data_spec/value_format.clj
@@ -5,7 +5,7 @@
    :message "Invalid data type"})
 
 (def contest-election-type
-  {:check ["general" "primary" "run-off" "referendum"]
+  {:check ["general" "primary" "run-off" "referendum" "judge retention"]
    :message "Invalid election_type"})
 
 (def date
@@ -21,7 +21,7 @@
    :message "Invalid election_type"})
 
 (def electoral-district-type
-  {:check ["statewide" "state senate" "state house" "fire district" "congressional district" "school district"]
+  {:check ["statewide" "state senate" "state house" "fire district" "congressional district" "school district" "county"]
    :message "Invalid type"})
 
 (def email

--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -11,7 +11,7 @@
 (defn validate-no-duplicated-ids [ctx]
   (let [dupes (dupe-ids/duplicated-ids ctx)]
     (if-not (empty? dupes)
-      (assoc-in ctx [:errors "Duplicate IDs"] dupes)
+      (assoc-in ctx [:errors :import :duplicated-ids] dupes)
       ctx)))
 
 (defn validate-no-duplicated-rows [{:keys [data-specs] :as ctx}]

--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -5,7 +5,8 @@
             [vip.data-processor.validation.db.record-limit :as record-limit]
             [vip.data-processor.validation.db.reverse-references :as rev-refs]
             [vip.data-processor.validation.db.street-segment :as street-segment]
-            [vip.data-processor.validation.db.admin-addresses :as admin-addresses]))
+            [vip.data-processor.validation.db.admin-addresses :as admin-addresses]
+            [vip.data-processor.validation.fips :as fips]))
 
 (defn validate-no-duplicated-ids [ctx]
   (let [dupes (dupe-ids/duplicated-ids ctx)]
@@ -46,3 +47,14 @@
 
 (defn validate-election-administration-addresses [ctx]
   (admin-addresses/validate-addresses ctx))
+
+(def validations
+  [validate-no-duplicated-ids
+   validate-no-duplicated-rows
+   validate-references
+   validate-jurisdiction-references
+   validate-one-record-limit
+   validate-no-unreferenced-rows
+   validate-no-overlapping-street-segments
+   validate-election-administration-addresses
+   fips/validate-valid-source-vip-id])

--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -42,7 +42,7 @@
                       (map set)
                       set)]
     (if (seq overlaps)
-      (assoc-in ctx [:errors "street_segment.txt" :overlaps] overlaps)
+      (assoc-in ctx [:errors :street-segments :overlaps] overlaps)
       ctx)))
 
 (defn validate-election-administration-addresses [ctx]

--- a/src/vip/data_processor/validation/db/admin_addresses.clj
+++ b/src/vip/data_processor/validation/db/admin_addresses.clj
@@ -22,7 +22,7 @@
                            (map :id))
         error-name (keyword (str "incomplete-" (name address-type) "-address"))]
     (if (seq bad-addresses)
-      (assoc-in ctx [:errors "election_administration.txt" error-name]
+      (assoc-in ctx [:errors :election-administrations error-name]
                 bad-addresses)
       ctx)))
 

--- a/src/vip/data_processor/validation/db/duplicate_records.clj
+++ b/src/vip/data_processor/validation/db/duplicate_records.clj
@@ -42,9 +42,9 @@
         sql (find-dupes-sql (:name table) columns-without-id)]
     (korma/exec-raw (:db table) [sql] :results)))
 
-(defn validate-no-duplicated-rows-in-table [ctx {:keys [filename table]}]
-  (let [table (get-in ctx [:tables table])
-        potential-dupes (find-potential-dupes table)]
+(defn validate-no-duplicated-rows-in-table [ctx {:keys [table]}]
+  (let [sql-table (get-in ctx [:tables table])
+        potential-dupes (find-potential-dupes sql-table)]
     (if (seq potential-dupes)
-      (assoc-in ctx [:warnings filename :duplicated-rows] potential-dupes)
+      (assoc-in ctx [:warnings table :duplicated-rows] potential-dupes)
       ctx)))

--- a/src/vip/data_processor/validation/db/record_limit.clj
+++ b/src/vip/data_processor/validation/db/record_limit.clj
@@ -3,26 +3,23 @@
 
 (def single-record-files
   "A list of those files which are allowed only a single record."
-  {:elections "election.txt"
-   :sources "source.txt"
-   :states "state.txt"})
+  [:elections :sources :states])
 
 (defn count-rows [table]
   "Takes a single table and counts the number of rows in it."
   (:cnt (first (korma/select table (korma/aggregate (count "*") :cnt)))))
 
-(defn file-and-count [tables]
-  "Transforms the selected tables into a map of files and counts."
+(defn name-and-count [tables]
+  "Transforms the selected tables into a map of names and counts."
   (map 
-   (fn [[_ table]]
-     {:file (-> table :table keyword single-record-files)
-      :count (count-rows table)})
+   (fn [[table-name table]]
+     {:name table-name :count (count-rows table)})
    tables))
 
 (defn error-if-not-one-row [ctx count]
   "If the count of the rows is not equal to 1, add an error."
   (if-not (= 1 (:count count))
-    (assoc-in ctx [:errors (:file count) :row-constraint]
+    (assoc-in ctx [:errors (:name count) :row-constraint]
               "File needs to contain exactly one row.")
     ctx))
 
@@ -30,9 +27,8 @@
   "Sort through the ctx to select out specific tables as defined
    in single-record-files. Then, count the rows and return errors
    for any that do not have exactly one row."
-  (let [table-keys (-> single-record-files keys vec)
-        tables (select-keys (:tables ctx) table-keys)
-        counts (file-and-count tables)]
+  (let [tables (select-keys (:tables ctx) single-record-files)
+        counts (name-and-count tables)]
     (reduce error-if-not-one-row ctx counts)))
 
 

--- a/src/vip/data_processor/validation/db/references.clj
+++ b/src/vip/data_processor/validation/db/references.clj
@@ -26,7 +26,7 @@
                                           (:references column))]
                 (if (seq unmatched-references)
                   (assoc-in ctx [:errors
-                                 filename
+                                 table
                                  :reference-error
                                  (:name column)]
                             unmatched-references)

--- a/src/vip/data_processor/validation/db/references.clj
+++ b/src/vip/data_processor/validation/db/references.clj
@@ -55,6 +55,6 @@
   (let [unmatched-references (unmatched-jurisdiction-references
                               (:tables ctx) table)]
     (if (seq unmatched-references)
-      (assoc-in ctx [:errors filename :reference-error "jurisdiction_id"]
+      (assoc-in ctx [:errors table :reference-error "jurisdiction_id"]
                 unmatched-references)
       ctx)))

--- a/src/vip/data_processor/validation/db/reverse_references.clj
+++ b/src/vip/data_processor/validation/db/reverse_references.clj
@@ -71,10 +71,5 @@
   (let [tables (:tables ctx)
         unreferenced-rows (find-unreferenced-rows tables table-id references-map)]
     (if (seq unreferenced-rows)
-      (let [filename (->> ctx
-                          :data-specs
-                          (filter #(= table-id (:table %)))
-                          first
-                          :filename)]
-        (assoc-in ctx [:warnings filename :unreferenced-rows] unreferenced-rows))
+      (assoc-in ctx [:warnings table-id :unreferenced-rows] unreferenced-rows)
       ctx)))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -6,8 +6,6 @@
             [vip.data-processor.s3 :as s3]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.csv.file-set :as csv-files]
-            [vip.data-processor.validation.db :as db]
-            [vip.data-processor.validation.fips :as fips]
             [vip.data-processor.validation.xml :as xml]))
 
 (defn read-edn-sqs-message [ctx]
@@ -34,16 +32,7 @@
    (csv/error-on-missing-file "election.txt")
    (csv/error-on-missing-file "source.txt")
    (csv-files/validate-dependencies csv-files/file-dependencies)
-   csv/load-csvs
-   db/validate-no-duplicated-ids
-   db/validate-no-duplicated-rows
-   db/validate-references
-   db/validate-jurisdiction-references
-   db/validate-one-record-limit
-   db/validate-no-unreferenced-rows
-   db/validate-no-overlapping-street-segments
-   db/validate-election-administration-addresses
-   fips/validate-valid-source-vip-id])
+   csv/load-csvs])
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -49,8 +49,8 @@
       (into (map node->key-value content))
       flatten-address-elements))
 
-(defn validate-format-rules [ctx rows {:keys [tag-name columns]}]
-  (let [format-rules (data-spec/create-format-rules tag-name columns)]
+(defn validate-format-rules [ctx rows {:keys [table columns]}]
+  (let [format-rules (data-spec/create-format-rules table columns)]
     (reduce (fn [ctx row]
               (data-spec/apply-format-rules format-rules ctx row (row "id")))
             ctx rows)))

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -52,7 +52,7 @@
 (defn validate-format-rules [ctx rows {:keys [tag-name columns]}]
   (let [format-rules (data-spec/create-format-rules tag-name columns)]
     (reduce (fn [ctx row]
-              (data-spec/apply-format-rules format-rules ctx row (:id row)))
+              (data-spec/apply-format-rules format-rules ctx row (row "id")))
             ctx rows)))
 
 (defn is-tag? [elem tag]

--- a/test-resources/xml/bad-data-values.xml
+++ b/test-resources/xml/bad-data-values.xml
@@ -1,0 +1,444 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <party>Democrat</party>
+    <candidate_url>gopher://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>800-MIX-A-LOT</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin.at.example.com</email>
+    <sort_order>1a</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/duplicated-ids.xml
+++ b/test-resources/xml/duplicated-ids.xml
@@ -1,0 +1,452 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/duplicated-rows.xml
+++ b/test-resources/xml/duplicated-rows.xml
@@ -1,0 +1,451 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80000">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/full-good-run.xml
+++ b/test-resources/xml/full-good-run.xml
@@ -154,13 +154,6 @@ Note that the ID attributes are unique throughout the file.
     <fax>(101) 555-1213</fax>
     <email>rsmith@ohio.gov</email>
   </election_official>
-  <election_official id="3458">
-    <name>Roberta Smith</name>
-    <title>Head of Elections</title>
-    <phone>(101) 555-1212</phone>
-    <fax>(101) 555-1213</fax>
-    <email>rsmith@ohio.gov</email>
-  </election_official>
   <election_official id="1555122">
     <name>Alissa P. Hacker</name>
     <title>Information Technology Specialist</title>
@@ -168,14 +161,6 @@ Note that the ID attributes are unique throughout the file.
     <fax>(101) 555-1236</fax>
     <email>ahacker@ohio.gov</email>
   </election_official>
-  <election_official id="3459">
-    <name>Robert Miller</name>
-    <title>Overseas Voter Contact</title>
-    <phone>(101) 555-1215</phone>
-    <fax>(101) 555-1216</fax>
-    <email>rmiller@ohio.gov</email>
-  </election_official>
-
   <polling_location id="20121">
     <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
     <directions>Enter through gym door.</directions>
@@ -224,37 +209,6 @@ Note that the ID attributes are unique throughout the file.
     <end_date>2012-11-06</end_date>
     <days_times_open>Open all days, all times.</days_times_open>
   </early_vote_site>
-  <contest id="60001">
-    <election_id>1</election_id>
-    <electoral_district_id>70001</electoral_district_id>
-    <type>general</type>
-    <partisan>yes</partisan>
-    <office>State Treasurer</office>
-    <ballot_id>80001</ballot_id>
-    <ballot_placement>1</ballot_placement>
-    <filing_closed_date>2012-05-10</filing_closed_date>
-  </contest>
-  <contest id="60002">
-    <election_id>1</election_id>
-    <electoral_district_id>70001</electoral_district_id>
-    <type>general</type>
-    <partisan>yes</partisan>
-    <office>Attorney General</office>
-    <ballot_id>80002</ballot_id>
-    <ballot_placement>2</ballot_placement>
-  </contest>
-  <contest id="60003">
-    <election_id>1</election_id>
-    <electoral_district_id>70002</electoral_district_id>
-    <type>primary</type>
-    <partisan>yes</partisan>
-    <primary_party>Democrat</primary_party>
-    <electorate_specifications>All voters registered in the Democratic Party by October 20th, 2012.</electorate_specifications>
-    <special>yes</special>
-    <office>State Senate</office>
-    <ballot_id>80003</ballot_id>
-    <ballot_placement>3</ballot_placement>
-  </contest>
   <contest id="60004">
     <election_id>1</election_id>
     <electoral_district_id>70003</electoral_district_id>
@@ -262,17 +216,6 @@ Note that the ID attributes are unique throughout the file.
     <partisan>no</partisan>
     <office>County Commisioner</office>
     <ballot_id>80004</ballot_id>
-    <ballot_placement>4</ballot_placement>
-  </contest>
-  <contest id="60005">
-    <election_id>1</election_id>
-    <electoral_district_id>70003</electoral_district_id>
-    <type>general</type>
-    <partisan>no</partisan>
-    <office>County Supervisor At Large</office>
-    <number_elected>2</number_elected>
-    <number_voting_for>2</number_voting_for>
-    <ballot_id>80005</ballot_id>
     <ballot_placement>4</ballot_placement>
   </contest>
   <contest id="60006">
@@ -283,59 +226,53 @@ Note that the ID attributes are unique throughout the file.
     <ballot_id>80006</ballot_id>
     <ballot_placement>6</ballot_placement>
   </contest>
-  <contest id="60007">
-    <election_id>1</election_id>
-    <electoral_district_id>70003</electoral_district_id>
-    <type>judge retention</type>
-    <partisan>no</partisan>
-    <ballot_id>80007</ballot_id>
-    <ballot_placement>5</ballot_placement>
-  </contest>
   <electoral_district id="70001">
     <name>statewide</name>
     <type>statewide</type>
   </electoral_district>
   <electoral_district id="70002">
     <name>SD-13</name>
-    <type>State Senate</type>
+    <type>state senate</type>
   </electoral_district>
   <electoral_district id="70003">
     <name>Ashland County</name>
-    <type>County</type>
+    <type>county</type>
   </electoral_district>
   <ballot id="80001">
     <candidate_id>90001</candidate_id>
     <candidate_id>90002</candidate_id>
     <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
   </ballot>
   <ballot id="80002">
     <candidate_id>90004</candidate_id>
     <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
   </ballot>
   <ballot id="80003">
     <candidate_id>90006</candidate_id>
     <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
   </ballot>
   <ballot id="80004">
     <candidate_id>90008</candidate_id>
     <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
   </ballot>
   <ballot id="80005">
     <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
   </ballot>
   <ballot id="80006">
     <referendum_id>90011</referendum_id>
-  </ballot>
-  <ballot id="80007">
-    <custom_ballot_id>90012</custom_ballot_id>
-    <write_in>no</write_in>
+    <image_url>http://example.com/6.jpg</image_url>
   </ballot>
   <candidate id="90001">
     <name>Daniel Berlin</name>
     <party>Democrat</party>
     <candidate_url>http://www.dberlin.org</candidate_url>
     <biography>Daniel Berlin grew up somewhere</biography>
-    <phone>123-456-7890</phone>
+    <phone>(123) 456-7890</phone>
     <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
     <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
     <email>dberlin@example.com</email>
@@ -481,7 +418,7 @@ Note that the ID attributes are unique throughout the file.
   <street_segment id="1210003">
     <start_house_number>2</start_house_number>
     <end_house_number>2</end_house_number>
-    <odd_even_both>both</odd_even_both>
+    <odd_even_both>even</odd_even_both>
     <non_house_address>
       <house_number_prefix>NW</house_number_prefix>
       <house_number_suffix>A</house_number_suffix>

--- a/test-resources/xml/incomplete-election-administrations.xml
+++ b/test-resources/xml/incomplete-election-administrations.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip></zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state></state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/invalid-source-vip-id.xml
+++ b/test-resources/xml/invalid-source-vip-id.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>99999</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/non-utf-8.xml
+++ b/test-resources/xml/non-utf-8.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Danÿel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/one-record-limit.xml
+++ b/test-resources/xml/one-record-limit.xml
@@ -1,0 +1,467 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <source id="1">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="2">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <election id="3">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/overlapping-street-segments.xml
+++ b/test-resources/xml/overlapping-street-segments.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/unreferenced-ids.xml
+++ b/test-resources/xml/unreferenced-ids.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>99</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/unreferenced-jurisdictions.xml
+++ b/test-resources/xml/unreferenced-jurisdictions.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>99999</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test-resources/xml/unreferenced-rows.xml
+++ b/test-resources/xml/unreferenced-rows.xml
@@ -1,0 +1,456 @@
+<?xml version="1.0"?>
+<!--
+
+Sample XML file for Voting Information Project (VIP) Spec Version 3.0
+Date: 2011-06-15
+File would be named: vipFeed-39-2012-11-06.xml
+
+A sample file for one state's (Ohio's) election. In this hypothetical version of Ohio, the state comprises only three counties.
+Each county has multiple precincts; one precinct is split; precincts sometimes share the same polling location. One county has a common drop
+location, while another county has a precinct with a specific mail location. The mail-only precinct comprises the entire town of Rural, OH.
+Five candidate contests are occuring in one November election, along with one county referendum, and one judge retention.
+One of the candidate contests is a special state senate primary; the state senate district comprises one full county
+and one precinct split in a neighboring county.
+The other contests are either statewide or countywide; the county contests are non-partisan.
+
+Note that the ID attributes are unique throughout the file.
+
+-->
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>The State of Ohio is the official source of eletion information in Ohio. This feed provides information on election dates, districts, offices, candidates, and precinct boundaries.</description>
+    <organization_url>http://www.sos.state.oh.us/</organization_url>
+    <feed_contact_id>1555122</feed_contact_id>
+    <tou_url>http://www.sos.state.oh.us/vipFeed/terms_of_use.html</tou_url>
+  </source>
+  <election id="1">
+    <date>2012-11-06</date>
+    <election_type>Federal</election_type>
+    <state_id>39</state_id>
+    <statewide>yes</statewide>
+    <registration_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=14</registration_info>
+    <absentee_ballot_info>http://www.sos.state.oh.us/sos/PublicAffairs/VoterInfoGuide.aspx?Section=16</absentee_ballot_info>
+    <results_url>http://www.sos.state.oh.us/sos/ElectionsVoter/electionResults.aspx</results_url>
+    <polling_hours>7am-8pm</polling_hours>
+    <election_day_registration>no</election_day_registration>
+    <registration_deadline>2012-10-01</registration_deadline>
+    <absentee_request_deadline>2012-11-01</absentee_request_deadline>
+  </election>
+  <state id="39">
+    <name>Ohio</name>
+    <election_administration_id>3456</election_administration_id>
+  </state>
+  <locality id="101">
+    <name>Adams</name>
+    <state_id>39</state_id>
+    <type>county</type>
+    <early_vote_site_id>30203</early_vote_site_id>
+  </locality>
+  <locality id="102">
+    <name>Allen</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <locality id="103">
+    <name>Ashland</name>
+    <state_id>39</state_id>
+    <type>county</type>
+  </locality>
+  <precinct id="10101">
+    <name>Fake Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+  </precinct>
+  <precinct id="10102">
+    <name>Psuedo Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10103">
+    <name>SharesTwoOtherLocations Twp</name>
+    <locality_id>101</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <polling_location_id>20121</polling_location_id>
+    <polling_location_id>20122</polling_location_id>
+  </precinct>
+  <precinct id="10201">
+    <name>Bath Twp A</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10202">
+    <name>Bath Twp B</name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <polling_location_id>20201</polling_location_id>
+  </precinct>
+  <precinct id="10203">
+    <name>Rural Twp Mail In </name>
+    <locality_id>102</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <mail_only>yes</mail_only>
+    <early_vote_site_id>30204</early_vote_site_id>
+  </precinct>
+  <precinct id="10301">
+    <name>1-A</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct id="10302">
+    <name>1-B</name>
+    <locality_id>103</locality_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ward>1</ward>
+    <polling_location_id>20301</polling_location_id>
+  </precinct>
+  <precinct_split id="30101">
+    <name>Fake Twp-A</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70002</electoral_district_id>
+    <ballot_style_image_url>http://www.example.com/precinct_split_101_ballot.pdf</ballot_style_image_url>
+  </precinct_split>
+  <precinct_split id="30102">
+    <name>Fake Twp-B</name>
+    <precinct_id>10101</precinct_id>
+    <electoral_district_id>70001</electoral_district_id>
+    <electoral_district_id>70003</electoral_district_id>
+  </precinct_split>
+  <election_administration id="3456">
+    <eo_id>3457</eo_id>
+    <ovc_id>3458</ovc_id>
+    <physical_address><location_name>Government Center</location_name><line1>12 Chad Ct.</line1><city>Columbus</city><state>OH</state><zip>33333</zip></physical_address>
+    <mailing_address><line1>P.O. Box 1776</line1><city>Columbus</city><state>OH</state><zip>33333</zip></mailing_address>
+    <elections_url>http://www.sos.state.oh.us/sos/ElectionsVoter/ohioElections.aspx</elections_url>
+    <registration_url>http://www.elections.oh.us/register.html</registration_url>
+    <am_i_registered_url>http://www.elections.oh.us/check_reg.html</am_i_registered_url>
+    <absentee_url>http://www.elections.oh.us/early_absentee.html</absentee_url>
+    <where_do_i_vote_url>http://www.elections.oh.us/where_vote.html</where_do_i_vote_url>
+    <what_is_on_my_ballot_url>http://www.elections.oh.us/ballot_guide.html</what_is_on_my_ballot_url>
+    <rules_url>http://codes.ohio.gov/orc/35</rules_url>
+    <voter_services>Early voting and absentee ballot request are available beginning October 1. Voter registration is always available.</voter_services>
+    <hours>M-F 9am-6pm Sat 9am-Noon</hours>
+  </election_administration>
+  <election_official id="3457">
+    <name>Robert Smith</name>
+    <phone>(101) 555-1212</phone>
+    <fax>(101) 555-1213</fax>
+    <email>rsmith@ohio.gov</email>
+  </election_official>
+  <election_official id="1555122">
+    <name>Alissa P. Hacker</name>
+    <title>Information Technology Specialist</title>
+    <phone>(101) 555-1235</phone>
+    <fax>(101) 555-1236</fax>
+    <email>ahacker@ohio.gov</email>
+  </election_official>
+  <polling_location id="20121">
+    <address><location_name>Springfield Elementary</location_name><line1>123 Main St.</line1><city>Fake Twp</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through gym door.</directions>
+    <polling_hours>7:30am-8:30pm</polling_hours>
+  </polling_location>
+  <polling_location id="20122">
+    <address><location_name>Adams Church</location_name><line1>123 Main St.</line1><city>Adams</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through door by parking lot.</directions>
+    <photo_url>http://www.seo.gov/photo20122.jpg</photo_url>
+  </polling_location>
+  <polling_location id="20201">
+    <address><location_name>Bath Firehouse Church</location_name><line1>123 State St.</line1><city>Bath</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter through big red door.</directions>
+  </polling_location>
+  <polling_location id="20301">
+    <address><location_name>Ashland City High School</location_name><line1>123 Center St.</line1><city>Ashland</city><state>OH</state><zip>33333</zip></address>
+    <directions>Enter at main doors and take a left.</directions>
+  </polling_location>
+  <early_vote_site id="30203">
+    <name>Adams Early Vote Center</name>
+    <address>
+      <location_name>Adams County Government Center</location_name>
+      <line1>321 Main St.</line1>
+      <line2>Suite 200</line2>
+      <city>Adams</city>
+      <state>OH</state>
+      <zip>42224</zip>
+    </address>
+    <directions>Follow signs to early vote</directions>
+    <voter_services>Early voting is available.</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-04</end_date>
+    <days_times_open>Mon-Fri: 9am - 6pm. Sat. and Sun.: 10am - 7pm.</days_times_open>
+  </early_vote_site>
+  <early_vote_site id="30204">
+    <name>Springfield Ballot Drop</name>
+    <address>
+      <line1>321 Main St.</line1>
+      <city>Springfield</city>
+      <state>OH</state>
+      <zip>44444</zip>
+    </address>
+    <directions>Next to Post Office.</directions>
+    <voter_services>Ballot drop only</voter_services>
+    <start_date>2012-10-01</start_date>
+    <end_date>2012-11-06</end_date>
+    <days_times_open>Open all days, all times.</days_times_open>
+  </early_vote_site>
+  <contest id="60004">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>general</type>
+    <partisan>no</partisan>
+    <office>County Commisioner</office>
+    <ballot_id>80004</ballot_id>
+    <ballot_placement>4</ballot_placement>
+  </contest>
+  <contest id="60006">
+    <election_id>1</election_id>
+    <electoral_district_id>70003</electoral_district_id>
+    <type>referendum</type>
+    <partisan>no</partisan>
+    <ballot_id>80006</ballot_id>
+    <ballot_placement>6</ballot_placement>
+  </contest>
+  <electoral_district id="70001">
+    <name>statewide</name>
+    <type>statewide</type>
+  </electoral_district>
+  <electoral_district id="70002">
+    <name>SD-13</name>
+    <type>state senate</type>
+  </electoral_district>
+  <electoral_district id="70003">
+    <name>Ashland County</name>
+    <type>county</type>
+  </electoral_district>
+  <ballot id="80001">
+    <candidate_id>90001</candidate_id>
+    <candidate_id>90002</candidate_id>
+    <candidate_id>90003</candidate_id>
+    <image_url>http://example.com/1.jpg</image_url>
+  </ballot>
+  <ballot id="80002">
+    <candidate_id>90004</candidate_id>
+    <candidate_id>90005</candidate_id>
+    <image_url>http://example.com/2.jpg</image_url>
+  </ballot>
+  <ballot id="80003">
+    <candidate_id>90006</candidate_id>
+    <candidate_id>90007</candidate_id>
+    <image_url>http://example.com/3.jpg</image_url>
+  </ballot>
+  <ballot id="80004">
+    <candidate_id>90008</candidate_id>
+    <candidate_id>90009</candidate_id>
+    <image_url>http://example.com/4.jpg</image_url>
+  </ballot>
+  <ballot id="80005">
+    <candidate_id>90010</candidate_id>
+    <image_url>http://example.com/5.jpg</image_url>
+  </ballot>
+  <ballot id="80006">
+    <referendum_id>90011</referendum_id>
+    <image_url>http://example.com/6.jpg</image_url>
+  </ballot>
+  <candidate id="90000">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90001">
+    <name>Daniel Berlin</name>
+    <party>Democrat</party>
+    <candidate_url>http://www.dberlin.org</candidate_url>
+    <biography>Daniel Berlin grew up somewhere</biography>
+    <phone>(123) 456-7890</phone>
+    <photo_url>http://www.dberlin.org/dannyb.jpg</photo_url>
+    <filed_mailing_address><line1>123 Fake St.</line1><city>Rockville</city><state>OH</state><zip>20852</zip></filed_mailing_address>
+    <email>dberlin@example.com</email>
+    <sort_order>1</sort_order>
+  </candidate>
+  <candidate id="90002">
+    <name>Berlin Opponent</name>
+    <party>Republican</party>
+    <sort_order>2</sort_order>
+  </candidate>
+  <candidate id="90003">
+    <name>Third Party Person</name>
+    <party>Libertarian</party>
+    <sort_order>3</sort_order>
+  </candidate>
+  <candidate id="90004">
+    <name>Goodie Lawyer</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90005">
+    <name>Betty Lawschool</name>
+    <party>Republican</party>
+  </candidate>
+  <candidate id="90006">
+    <name>Goodie Liberal</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90007">
+    <name>Carl Moderation</name>
+    <party>Democrat</party>
+  </candidate>
+  <candidate id="90008">
+    <name>Justin Fication</name>
+  </candidate>
+  <candidate id="90009">
+    <name>Count E. Betterer</name>
+  </candidate>
+  <candidate id="90010">
+    <name>Runner Solo</name>
+  </candidate>
+  <referendum id="90011">
+    <title>Proposition 37</title>
+    <subtitle>A referendum to ban smoking indoors</subtitle>
+    <brief>A yes vote is a vote to ban smoking indoors.</brief>
+    <text>Shall the State of Ohio ... (full text of referendum as it appears on the ballot).</text>
+    <pro_statement>Vote yes please</pro_statement>
+    <con_statement>Vote no please</con_statement>
+    <passage_threshold>three-fifths</passage_threshold>
+    <effect_of_abstain>Abstaining has no effect</effect_of_abstain>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </referendum>
+  <custom_ballot id="90012">
+    <heading>Should Judge Carlton Smith be retained?</heading>
+    <ballot_response_id>120001</ballot_response_id>
+    <ballot_response_id>120002</ballot_response_id>
+  </custom_ballot>
+  <ballot_response id="120001">
+    <sort_order>1</sort_order>
+    <text>Yes</text>
+  </ballot_response>
+  <ballot_response id="120002">
+    <sort_order>2</sort_order>
+    <text>No</text>
+  </ballot_response>
+  <contest_result id="61004" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <total_votes>1002</total_votes>
+    <total_valid_votes>1000</total_valid_votes>
+    <overvotes>1</overvotes>
+    <blank_votes>1</blank_votes>
+    <accepted_provisional_votes>1</accepted_provisional_votes>
+    <rejected_votes>2</rejected_votes>
+  </contest_result>
+  <ballot_line_result id="91008" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90008</candidate_id>
+    <votes>510</votes>
+    <victorious>Yes</victorious>
+  </ballot_line_result>
+  <ballot_line_result id="91009" certification="certified">
+    <contest_id>60004</contest_id>
+    <jurisdiction_id>70003</jurisdiction_id>
+    <entire_district>Yes</entire_district>
+    <candidate_id>90009</candidate_id>
+    <votes>490</votes>
+    <victorious>No</victorious>
+  </ballot_line_result>
+  <contest_result id="61006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <total_votes>250</total_votes>
+  </contest_result>
+  <ballot_line_result id="62006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120001</ballot_response_id>
+    <votes>150</votes>
+  </ballot_line_result>
+  <ballot_line_result id="63006" certification="certified">
+    <contest_id>60006</contest_id>
+    <jurisdiction_id>10103</jurisdiction_id>
+    <entire_district>No</entire_district>
+    <ballot_response_id>120002</ballot_response_id>
+    <votes>100</votes>
+  </ballot_line_result>
+  <street_segment id="1210001">
+    <start_house_number>1</start_house_number>
+    <end_house_number>10</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_direction>E</street_direction>
+      <street_name>Guinevere</street_name>
+      <street_suffix>Dr</street_suffix>
+      <address_direction>SE</address_direction>
+      <apartment>616S</apartment>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+  </street_segment>
+  <street_segment id="1210002">
+    <start_house_number>1</start_house_number>
+    <end_house_number>9</end_house_number>
+    <odd_even_both>odd</odd_even_both>
+    <non_house_address>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10101</precinct_id>
+    <precinct_split_id>30102</precinct_split_id>
+  </street_segment>
+  <street_segment id="1210003">
+    <start_house_number>2</start_house_number>
+    <end_house_number>2</end_house_number>
+    <odd_even_both>even</odd_even_both>
+    <non_house_address>
+      <house_number_prefix>NW</house_number_prefix>
+      <house_number_suffix>A</house_number_suffix>
+      <street_name>Main</street_name>
+      <street_suffix>Dr</street_suffix>
+      <state>VA</state>
+      <city>Annandale</city>
+      <zip>22003</zip>
+    </non_house_address>
+    <precinct_id>10102</precinct_id>
+  </street_segment>
+  <street_segment id="1210004">
+    <start_house_number>0</start_house_number>
+    <end_house_number>9999999</end_house_number>
+    <odd_even_both>both</odd_even_both>
+    <non_house_address>
+      <street_name>*</street_name>
+      <city>Rural</city>
+      <state>OH</state>
+      <zip>43321</zip>
+    </non_house_address>
+    <precinct_id>10203</precinct_id>
+  </street_segment>
+</vip_object>

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -83,10 +83,10 @@
           out-ctx (pipeline/run-pipeline ctx)]
       (is (= [2 3]
              (map :id (get-in out-ctx
-                              [:warnings "ballot.txt" :unreferenced-rows]))))
+                              [:warnings :ballots :unreferenced-rows]))))
       (is (= [13 14]
              (map :id (get-in out-ctx
-                              [:warnings "candidate.txt" :unreferenced-rows])))))))
+                              [:warnings :candidates :unreferenced-rows])))))))
 
 (deftest validate-no-overlapping-street-segments-test
   (let [ctx (merge {:input (csv-inputs ["overlapping-street-segments/street_segment.txt"])

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -16,9 +16,9 @@
                                  validate-no-duplicated-ids]}
                      (sqlite/temp-db "duplicate-ids"))
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:errors "Duplicate IDs" 8675309]))
-      (is (get-in out-ctx [:errors "Duplicate IDs" 5882300]))
-      (is (not (get-in out-ctx [:errors "Duplicate IDs" 7]))))))
+      (is (get-in out-ctx [:errors :import :duplicated-ids 8675309]))
+      (is (get-in out-ctx [:errors :import :duplicated-ids 5882300]))
+      (is (not (get-in out-ctx [:errors :import :duplicated-ids 7]))))))
 
 (deftest validate-no-duplicated-rows-test
   (testing "finds possibly duplicated rows in a table and warns"

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -96,7 +96,7 @@
                    (sqlite/temp-db "overlapping-street-segments"))
         out-ctx (pipeline/run-pipeline ctx)]
     (is (= #{#{11 12} #{13 14} #{15 16} #{17 18} #{19 20}}
-           (get-in out-ctx [:errors "street_segment.txt" :overlaps])))))
+           (get-in out-ctx [:errors :street-segments :overlaps])))))
 
 (deftest validate-election-administration-addresses-test
   (testing "errors are returned if either the physical or mailing address is incomplete"

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -54,7 +54,7 @@
                                  validate-references]}
                      (sqlite/temp-db "bad-references"))
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (= 1 (count (get-in out-ctx [:errors "ballot.txt" :reference-error "referendum_id"])))))))
+      (is (= 1 (count (get-in out-ctx [:errors :ballots :reference-error "referendum_id"])))))))
 
 (deftest validate-jurisdiction-references-test
   (testing "finds bad jurisdiction references"

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -30,9 +30,9 @@
                      (sqlite/temp-db "duplicate-ids"))
           out-ctx (pipeline/run-pipeline ctx)]
       (is (= #{3100047456984 3100047456989 3100047466988 3100047466990}
-             (set (map :id (get-in out-ctx [:warnings "candidate.txt" :duplicated-rows])))))
+             (set (map :id (get-in out-ctx [:warnings :candidates :duplicated-rows])))))
       (is (= #{{:candidate_id 3100047456987, :ballot_id 410004745} {:candidate_id 3100047466988, :ballot_id 410004746}}
-             (set (get-in out-ctx [:warnings "ballot_candidate.txt" :duplicated-rows])))))))
+             (set (get-in out-ctx [:warnings :ballot-candidates :duplicated-rows])))))))
 
 (deftest validate-one-record-limit-test
   (testing "validates that only one row exists in certain files"

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -69,7 +69,7 @@
                                  validate-jurisdiction-references]}
                      (sqlite/temp-db "bad-jurisdiction-references"))
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (= [100 101] (map :id (get-in out-ctx [:errors "ballot_line_result.txt" :reference-error "jurisdiction_id"])))))))
+      (is (= [100 101] (map :id (get-in out-ctx [:errors :ballot-line-results :reference-error "jurisdiction_id"])))))))
 
 (deftest validate-no-unreferenced-rows-test
   (testing "finds rows not referenced"

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -42,7 +42,7 @@
                                  validate-one-record-limit]}
                      (sqlite/temp-db "too-many-records"))
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (= (get-in out-ctx [:errors "election.txt" :row-constraint])
+      (is (= (get-in out-ctx [:errors :elections :row-constraint])
              "File needs to contain exactly one row.")))))
 
 (deftest validate-references-test

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -106,7 +106,7 @@
                                  validate-election-administration-addresses]}
                      (sqlite/temp-db "incomplete-addresses"))
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:errors "election_administration.txt"
+      (is (get-in out-ctx [:errors :election-administrations
                            :incomplete-physical-address]))
-      (is (get-in out-ctx [:errors "election_administration.txt"
+      (is (get-in out-ctx [:errors :election-administrations
                            :incomplete-mailing-address])))))

--- a/test/vip/data_processor/validation/fips_test.clj
+++ b/test/vip/data_processor/validation/fips_test.clj
@@ -3,16 +3,24 @@
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.fips :refer :all]
             [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.validation.xml :as xml]
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.pipeline :as pipeline]))
 
 (deftest validate-valid-source-vip-id-test
-  (testing "adds an error if the source's vip_id is bad"
+  (testing "adds an error if the source's vip_id is bad from a csv"
     (let [ctx (merge {:input (csv-inputs ["invalid-source-vip-id/source.txt"])
                       :pipeline [(data-spec/add-data-specs data-spec/data-specs)
                                  csv/load-csvs
                                  validate-valid-source-vip-id]}
-                     (sqlite/temp-db "invalid-source-vip-id"))
+                     (sqlite/temp-db "invalid-source-vip-id-csv"))
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:errors :source :invalid-vip-id])))))
+      (is (get-in out-ctx [:errors :source :invalid-vip-id]))))
+  (testing "adds an error if the source's vip_id is bad from a xml"
+    (let [ctx (merge {:input (xml-input "invalid-source-vip-id.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [xml/load-xml validate-valid-source-vip-id]}
+                     (sqlite/temp-db "invalid-source-vip-id-xml"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (= "99999" (get-in out-ctx [:errors :source :invalid-vip-id]))))))

--- a/test/vip/data_processor/validation/transforms_test.clj
+++ b/test/vip/data_processor/validation/transforms_test.clj
@@ -4,6 +4,7 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
+            [vip.data-processor.validation.db :as db]
             [vip.data-processor.validation.transforms :refer :all]
             [vip.data-processor.db.sqlite :as sqlite]
             [clojure.java.io :as io]
@@ -16,8 +17,9 @@
           filenames (->> csv/csv-filenames
                          (map #(io/as-file (io/resource (str "csv/full-good-run/" %))))
                          (remove nil?))
-          ctx (merge {:input filenames :pipeline (concat [data-spec/add-data-specs data-spec/data-specs]
-                                                         csv-validations)} db)
+          ctx (merge {:input filenames :pipeline (concat [(data-spec/add-data-specs data-spec/data-specs)]
+                                                         csv-validations
+                                                         db/validations)} db)
           results-ctx (pipeline/run-pipeline ctx)]
       (is (nil? (:stop results-ctx)))
       (is (nil? (:exception results-ctx)))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -150,3 +150,15 @@
                      (sqlite/temp-db "unreferenced-jurisdictions"))
           out-ctx (pipeline/run-pipeline ctx)]
       (is (get-in out-ctx [:errors :ballot-line-results :reference-error])))))
+
+(deftest validate-one-record-limit-test
+  (testing "returns an error if particular nodes are duplicated more than once"
+    (let [ctx (merge {:input (xml-input "one-record-limit.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml db/validate-one-record-limit]}
+                     (sqlite/temp-db "one-record-limit"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (= "File needs to contain exactly one row."
+             (get-in out-ctx [:errors :elections :row-constraint])))
+      (is (= "File needs to contain exactly one row."
+             (get-in out-ctx [:errors :sources :row-constraint]))))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -108,7 +108,7 @@
     (let [ctx (merge {:input (xml-input "full-good-run.xml")
                       :data-specs data-spec/data-specs
                       :pipeline (concat [load-xml] db/validations)}
-                     (sqlite/temp-db "load-xml-test"))
+                     (sqlite/temp-db "full-good-xml"))
           out-ctx (pipeline/run-pipeline ctx)]
       (is (nil? (:stop out-ctx)))
       (is (nil? (:exception out-ctx)))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -163,6 +163,15 @@
       (is (= "File needs to contain exactly one row."
              (get-in out-ctx [:errors :sources :row-constraint]))))))
 
+(deftest validate-no-unreferenced-rows
+  (testing "returns a warning if it finds rows that are unreferenced"
+    (let [ctx (merge {:input (xml-input "unreferenced-rows.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml db/validate-no-unreferenced-rows]}
+                     (sqlite/temp-db "unreferenced-rows"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:warnings :candidates :unreferenced-rows])))))
+
 (deftest validate-no-overlapping-street-segments
   (testing "returns an error if street segments overlap"
     (let [ctx (merge {:input (xml-input "overlapping-street-segments.xml")

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -141,3 +141,12 @@
                      (sqlite/temp-db "unreferenced-ids"))
           out-ctx (pipeline/run-pipeline ctx)]
       (is (get-in out-ctx [:errors :localities :reference-error])))))
+
+(deftest validate-jurisdiction-references-test
+  (testing "returns an error if there are unreferenced jurisdiction references"
+    (let [ctx (merge {:input (xml-input "unreferenced-jurisdictions.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml db/validate-jurisdiction-references]}
+                     (sqlite/temp-db "unreferenced-jurisdictions"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:errors :ballot-line-results :reference-error])))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -101,7 +101,14 @@
         (let [locality-early-vote-sites (korma/select
                                          (get-in out-ctx [:tables :locality-early-vote-sites]))]
           (is (= [{:locality_id 101 :early_vote_site_id 30203}]
-                 locality-early-vote-sites)))))))
+                 locality-early-vote-sites))))))
+  (testing "adds errors for non-UTF-8 data"
+    (let [ctx (merge {:input (xml-input "non-utf-8.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml]}
+                     (sqlite/temp-db "non-utf-8"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:errors :candidates "90001"])))))
 
 (deftest full-good-run-test
   (testing "a good XML file produces no erorrs or warnings"

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -113,3 +113,13 @@
       (is (nil? (:stop out-ctx)))
       (is (nil? (:exception out-ctx)))
       (assert-no-problems out-ctx []))))
+
+(deftest validate-no-duplicated-ids-test
+  (testing "returns an error when there is a duplicated id"
+    (let [ctx (merge {:input (xml-input "duplicated-ids.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml db/validate-no-duplicated-ids]}
+                     (sqlite/temp-db "duplicated-ids"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (= #{"precincts" "localities"}
+             (set (get-in out-ctx [:errors :import :duplicated-ids 101])))))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -132,3 +132,12 @@
                      (sqlite/temp-db "duplicated-rows"))
           out-ctx (pipeline/run-pipeline ctx)]
       (is (not (empty? (get-in out-ctx [:warnings :ballots :duplicated-rows])))))))
+
+(deftest validate-references-test
+  (testing "returns an error if there are unreferenced objects"
+    (let [ctx (merge {:input (xml-input "unreferenced-ids.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml db/validate-references]}
+                     (sqlite/temp-db "unreferenced-ids"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:errors :localities :reference-error])))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -123,3 +123,12 @@
           out-ctx (pipeline/run-pipeline ctx)]
       (is (= #{"precincts" "localities"}
              (set (get-in out-ctx [:errors :import :duplicated-ids 101])))))))
+
+(deftest validate-no-duplicated-rows-test
+  (testing "returns a warning if two nodes have the same data"
+    (let [ctx (merge {:input (xml-input "duplicated-rows.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml db/validate-no-duplicated-rows]}
+                     (sqlite/temp-db "duplicated-rows"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (not (empty? (get-in out-ctx [:warnings :ballots :duplicated-rows])))))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -162,3 +162,12 @@
              (get-in out-ctx [:errors :elections :row-constraint])))
       (is (= "File needs to contain exactly one row."
              (get-in out-ctx [:errors :sources :row-constraint]))))))
+
+(deftest validate-no-overlapping-street-segments
+  (testing "returns an error if street segments overlap"
+    (let [ctx (merge {:input (xml-input "overlapping-street-segments.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml db/validate-no-overlapping-street-segments]}
+                     (sqlite/temp-db "overlapping-street-segments"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:errors :street-segments :overlaps])))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -200,3 +200,17 @@
                            :incomplete-physical-address]))
       (is (get-in out-ctx [:errors :election-administrations
                            :incomplete-mailing-address])))))
+
+(deftest validate-data-formats
+  (let [ctx (merge {:input (xml-input "bad-data-values.xml")
+                    :data-specs data-spec/data-specs
+                    :pipeline [load-xml]}
+                   (sqlite/temp-db "bad-data-values"))
+        out-ctx (pipeline/run-pipeline ctx)]
+    (testing "adds fatal errors for missing required fields"
+      (is (get-in out-ctx [:fatal :candidates "90001" "name"])))
+    (testing "adds errors for values that fail format validation"
+      (is (get-in out-ctx [:errors :candidates "90001" "candidate_url"]))
+      (is (get-in out-ctx [:errors :candidates "90001" "phone"]))
+      (is (get-in out-ctx [:errors :candidates "90001" "email"]))
+      (is (get-in out-ctx [:errors :candidates "90001" "sort_order"])))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -171,3 +171,16 @@
                      (sqlite/temp-db "overlapping-street-segments"))
           out-ctx (pipeline/run-pipeline ctx)]
       (is (get-in out-ctx [:errors :street-segments :overlaps])))))
+
+(deftest validate-election-administration-addresses
+  (testing "returns an error if either the physical or mailing address is incomplete"
+    (let [ctx (merge {:input (xml-input "incomplete-election-administrations.xml")
+                      :data-specs data-spec/data-specs
+                      :pipeline [load-xml
+                                 db/validate-election-administration-addresses]}
+                     (sqlite/temp-db "incomplete-election-administrations"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:errors :election-administrations
+                           :incomplete-physical-address]))
+      (is (get-in out-ctx [:errors :election-administrations
+                           :incomplete-mailing-address])))))


### PR DESCRIPTION
This PR extends previously CSV-only validations to cover XML imports as well. They are:

* [91442062](https://www.pivotaltracker.com/story/show/91442062): Duplicate IDs
* [91442218](https://www.pivotaltracker.com/story/show/91442218): Duplicate records (same data in two elements, but with different IDs)
* [91442334](https://www.pivotaltracker.com/story/show/91442334): References to other elements by ID actually point to elements with that ID
* [91442448](https://www.pivotaltracker.com/story/show/91442448): Only one election, source and state element each
* [91444288](https://www.pivotaltracker.com/story/show/91444288): Street segment overlaps
* [91444426](https://www.pivotaltracker.com/story/show/91444426): Complete addresses
* [91444350](https://www.pivotaltracker.com/story/show/91444350): `vip_id`s are valid FIPS codes
* [91442524](https://www.pivotaltracker.com/story/show/91442524): Orphan elements
* [91444694](https://www.pivotaltracker.com/story/show/91444694): Invalid UTF-8 byte sequences
* [91441516](https://www.pivotaltracker.com/story/show/91441516): Formats of data (email, phone, etc.)
* [91441204](https://www.pivotaltracker.com/story/show/91441204): Required tags

The "full-good-run.xml" file has been updated to pass all validations without any warnings or errors (very minor changes required). All other test XML files are based on that file edited to fail a particular validation.

The majority of this PR is creating tests and test files. The work of actually moving these validations from "just CSV" to "both CSV and XML" is in e9763a4.