### PR TITLE
XML generation: the beginning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ reported upon.
 
 ### lein
 
-Copy `dev-resources/config.edn.sample` to `dev-resources/config.edn`
-and set the values inside as necessary. Then:
+To run the processor against a local .zip file run the following:
 
 ```sh
-$ lein trampoline run
+$ lein run ~/path/to/upload.zip
 ```
+
+Currently this will validate the data and produce the XML output but
+without any reporting whatsoever. Once the reporting infrastructure is
+in place, a report will be generated so you can see errors and
+warnings generated during validations.
 
 ### Docker
 

--- a/dev-resources/log4j.properties
+++ b/dev-resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out

--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -1,0 +1,24 @@
+(ns dev.core
+  (:require [clojure.java.io :as io]
+            [clojure.pprint :as pprint]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.output.xml :as xml-output]
+            [vip.data-processor.validation.data-spec :as data-spec]
+            [vip.data-processor.validation.db :as db]
+            [vip.data-processor.validation.transforms :as t]
+            [vip.data-processor.validation.zip :as zip]))
+
+(def pipeline
+  (concat [zip/unzip
+           zip/extracted-contents
+           t/attach-sqlite-db
+           (data-spec/add-data-specs data-spec/data-specs)
+           t/xml-csv-branch]
+          db/validations
+          xml-output/pipeline))
+
+(defn -main [zip-filename]
+  (let [zip (java.io.File. zip-filename)
+        result (pipeline/process pipeline zip)]
+    (when-let [xml-output-file (:xml-output-file result)]
+      (println "XML:" (.toString xml-output-file)))))

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,8 @@
                  [org.clojure/java.jdbc "0.3.5"]
                  [org.postgresql/postgresql "9.4-1200-jdbc4" :exclusions [org.slf4j/slf4j-simple]]
                  [org.xerial/sqlite-jdbc "3.8.7"]]
-  :profiles {:test {:resource-paths ["test-resources"]}
+  :profiles {:test {:resource-paths ["test-resources"]
+                    :dependencies [[com.github.kyleburton/clj-xpath "1.4.4"]]}
              :dev {:source-paths ["dev-src"]
                    :main dev.core}}
   :main vip.data-processor)

--- a/project.clj
+++ b/project.clj
@@ -18,5 +18,7 @@
                  [org.clojure/java.jdbc "0.3.5"]
                  [org.postgresql/postgresql "9.4-1200-jdbc4" :exclusions [org.slf4j/slf4j-simple]]
                  [org.xerial/sqlite-jdbc "3.8.7"]]
-  :profiles {:test {:resource-paths ["test-resources"]}}
+  :profiles {:test {:resource-paths ["test-resources"]}
+             :dev {:source-paths ["dev-src"]
+                   :main dev.core}}
   :main vip.data-processor)

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject vip.data-processor "0.1.0-SNAPSHOT"
   :description "Voting Information Project Data Processor"
-  :dependencies [[org.clojure/clojure "1.7.0-alpha5"]
+  :dependencies [[org.clojure/clojure "1.7.0-beta1"]
                  [org.slf4j/slf4j-log4j12 "1.7.10"]
                  [org.clojure/data.csv "0.1.2"]
                  [org.clojure/data.xml "0.0.8"]

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
                  [org.clojure/data.csv "0.1.2"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/tools.logging "0.3.1"]
+                 [org.apache.directory.studio/org.apache.commons.lang "2.6"]
                  [com.novemberain/langohr "3.0.1"]
                  [joda-time "2.7"]
                  [clj-aws-s3 "0.3.10" :exclusions [joda-time]]

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -8,7 +8,8 @@
             [vip.data-processor.validation.transforms :as t]
             [vip.data-processor.validation.zip :as zip]
             [vip.data-processor.queue :as q]
-            [vip.data-processor.db.postgres :as psql])
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.output.xml :as xml-output])
   (:gen-class))
 
 (def download-pipeline
@@ -23,7 +24,8 @@
   (concat download-pipeline
           [(data-spec/add-data-specs data-spec/data-specs)
            t/xml-csv-branch]
-          db/validations))
+          db/validations
+          xml-output/pipeline))
 
 (defn consume []
   (sqs/consume-messages (sqs/client)

--- a/src/vip/data_processor/output/address.clj
+++ b/src/vip/data_processor/output/address.clj
@@ -1,0 +1,18 @@
+(ns vip.data-processor.output.address
+  (:require [vip.data-processor.output.xml-helpers :refer :all]))
+
+(defn address-parts [address-type object]
+  (letfn [(address-key [address-part]
+            (keyword (str (name address-type) "_" (name address-part))))]
+    (->> [:location_name :line1 :line2 :line3 :city :state :zip
+          :house_number :house_number_prefix :house_number_suffix
+          :street_direction :street_name :street_suffix :address_direction
+          :apartment]
+         (map (fn [address-part]
+                {:tag address-part :content [(str (get object (address-key address-part)))]}))
+         remove-empties)))
+
+(defn address [address-type object]
+  (let [parts (address-parts address-type object)]
+    (when-not (empty? parts)
+      {:tag address-type :content parts})))

--- a/src/vip/data_processor/output/ballot_response.clj
+++ b/src/vip/data_processor/output/ballot_response.clj
@@ -1,0 +1,14 @@
+(ns vip.data-processor.output.ballot-response
+  (:require [vip.data-processor.output.xml-helpers :refer :all]
+            [korma.core :as korma]))
+
+(defn ->xml [{:keys [id
+                     text
+                     sort_order]}]
+  (let [children [(xml-node text)
+                  (xml-node sort_order)]]
+    (simple-xml :ballot_response id children)))
+
+(defn xml-nodes [ctx]
+  (let [sql-table (get-in ctx [:tables :ballot-responses])]
+    (map ->xml (korma/select sql-table))))

--- a/src/vip/data_processor/output/candidate.clj
+++ b/src/vip/data_processor/output/candidate.clj
@@ -1,0 +1,28 @@
+(ns vip.data-processor.output.candidate
+  (:require [vip.data-processor.output.address :refer [address]]
+            [vip.data-processor.output.xml-helpers :refer :all]
+            [korma.core :as korma]))
+
+(defn ->xml [{:keys [id
+                      name
+                      party
+                      candidate_url
+                      biography
+                      phone
+                      photo_url
+                      email
+                      sort_order] :as candidate}]
+  (let [children [(address :filed_mailing_address candidate)
+                  (xml-node name)
+                  (xml-node party)
+                  (xml-node candidate_url)
+                  (xml-node biography)
+                  (xml-node phone)
+                  (xml-node photo_url)
+                  (xml-node email)
+                  (xml-node sort_order)]]
+    (simple-xml :candidate id children)))
+
+(defn xml-nodes [ctx]
+  (let [sql-table (get-in ctx [:tables :candidates])]
+    (map ->xml (korma/select sql-table))))

--- a/src/vip/data_processor/output/contest.clj
+++ b/src/vip/data_processor/output/contest.clj
@@ -1,0 +1,36 @@
+(ns vip.data-processor.output.contest
+  (:require [vip.data-processor.output.xml-helpers :refer :all]
+            [korma.core :as korma]))
+
+(defn ->xml [{:keys [id
+                     ballot_id
+                     ballot_placement
+                     election_id
+                     electoral_district_id
+                     electorate_specifications
+                     filing_closed_date
+                     number_elected
+                     number_voting_for
+                     office
+                     partisan
+                     primary_party
+                     special
+                     type]}]
+  (let [children [(xml-node ballot_id)
+                  (xml-node ballot_placement)
+                  (xml-node election_id)
+                  (xml-node electoral_district_id)
+                  (xml-node electorate_specifications)
+                  (xml-node filing_closed_date)
+                  (xml-node number_elected)
+                  (xml-node number_voting_for)
+                  (xml-node office)
+                  (boolean-xml-node partisan)
+                  (xml-node primary_party)
+                  (boolean-xml-node special)
+                  (xml-node type)]]
+    (simple-xml :contest id children)))
+
+(defn xml-nodes [ctx]
+  (let [sql-table (get-in ctx [:tables :contests])]
+    (map ->xml (korma/select sql-table))))

--- a/src/vip/data_processor/output/early_vote_site.clj
+++ b/src/vip/data_processor/output/early_vote_site.clj
@@ -1,0 +1,24 @@
+(ns vip.data-processor.output.early-vote-site
+  (:require [vip.data-processor.output.address :refer [address]]
+            [vip.data-processor.output.xml-helpers :refer :all]
+            [korma.core :as korma]))
+
+(defn ->xml [{:keys [id
+                     name
+                     directions
+                     voter_services
+                     start_date
+                     end_date
+                     days_times_open] :as early-vote-site}]
+  (let [children [(address :address early-vote-site)
+                  (xml-node name)
+                  (xml-node directions)
+                  (xml-node voter_services)
+                  (xml-node start_date)
+                  (xml-node end_date)
+                  (xml-node days_times_open)]]
+    (simple-xml :early_vote_site id children)))
+
+(defn xml-nodes [ctx]
+  (let [sql-table (get-in ctx [:tables :early-vote-sites])]
+    (map ->xml (korma/select sql-table))))

--- a/src/vip/data_processor/output/polling_location.clj
+++ b/src/vip/data_processor/output/polling_location.clj
@@ -1,0 +1,18 @@
+(ns vip.data-processor.output.polling-location
+  (:require [vip.data-processor.output.address :refer [address]]
+            [vip.data-processor.output.xml-helpers :refer :all]
+            [korma.core :as korma]))
+
+(defn ->xml [{:keys [id
+                     directions
+                     polling_hours
+                     photo_url] :as polling-location}]
+  (let [children [(address :address polling-location)
+                  (xml-node directions)
+                  (xml-node polling_hours)
+                  (xml-node photo_url)]]
+    (simple-xml :polling_location id children)))
+
+(defn xml-nodes [ctx]
+  (let [sql-table (get-in ctx [:tables :polling-locations])]
+    (map ->xml (korma/select sql-table))))

--- a/src/vip/data_processor/output/state.clj
+++ b/src/vip/data_processor/output/state.clj
@@ -1,0 +1,26 @@
+(ns vip.data-processor.output.state
+  (:require [vip.data-processor.output.xml-helpers :refer :all]
+            [korma.core :as korma]))
+
+(defn ->xml [{:keys [id
+                     name
+                     election_administration_id]}
+             early-vote-site-ids]
+  (let [early-vote-site-nodes (map #(assoc {:tag :early_vote_site} :content [%])
+                                   early-vote-site-ids)
+        children (concat [(xml-node name)
+                          (xml-node election_administration_id)]
+                         early-vote-site-nodes)]
+    (simple-xml :state id children)))
+
+(defn xml-nodes [ctx]
+  (let [sql-table (get-in ctx [:tables :states])
+        state-early-vote-sites-table (get-in ctx [:tables :state-early-vote-sites])
+        states (korma/select sql-table)
+        state-id (-> states first :id)
+        early-vote-site-ids (as-> state-early-vote-sites-table
+                                early-vote-sites
+                              (korma/select early-vote-sites
+                                            (korma/where {:state_id state-id}))
+                              (map :early_vote_site_id early-vote-sites))]
+    (map #(->xml % early-vote-site-ids) states)))

--- a/src/vip/data_processor/output/street_segment.clj
+++ b/src/vip/data_processor/output/street_segment.clj
@@ -1,0 +1,41 @@
+(ns vip.data-processor.output.street-segment
+  (:require [vip.data-processor.output.address :refer [address]]
+            [vip.data-processor.output.xml-helpers :refer :all]
+            [korma.core :as korma]))
+
+(defn ->xml [{:keys [id
+                     start_house_number
+                     end_house_number
+                     odd_even_both
+                     start_apartment_number
+                     end_apartment_number
+                     precinct_id
+                     precinct_split_id] :as street-segment}]
+  (let [children [(address :non_house_address street-segment)
+                  (xml-node start_house_number)
+                  (xml-node end_house_number)
+                  (xml-node odd_even_both)
+                  (xml-node start_apartment_number)
+                  (xml-node end_apartment_number)
+                  (xml-node precinct_id)
+                  (xml-node precinct_split_id)]]
+    (simple-xml :street_segment id children)))
+
+(def chunk-size 1000)
+
+(defn xml-nodes [ctx]
+  (let [sql-table (get-in ctx [:tables :street-segments])
+        total (-> (korma/select sql-table
+                                (korma/aggregate (count "*") :cnt))
+                  first
+                  :cnt)]
+    (letfn [(chunked-sexps [page]
+              (let [offset (* page chunk-size)]
+                (when (< offset total)
+                  (concat
+                   (let [street-segments (korma/select sql-table
+                                                       (korma/offset offset)
+                                                       (korma/limit chunk-size))]
+                     (map ->xml street-segments))
+                   (chunked-sexps (inc page))))))]
+      (chunked-sexps 0))))

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -17,7 +17,8 @@
             [clojure.string :as string]
             [clojure.java.io :as io]
             [clojure.walk :as walk]
-            [vip.data-processor.output.candidate :as candidate])
+            [vip.data-processor.output.candidate :as candidate]
+            [vip.data-processor.output.early-vote-site :as early-vote-site])
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [org.apache.commons.lang StringEscapeUtils]))
@@ -81,4 +82,5 @@
 (def pipeline
   [create-xml-file
    (add-xml-children candidate/xml-nodes)
+   (add-xml-children early-vote-site/xml-nodes)
    write-xml])

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -1,0 +1,82 @@
+(ns vip.data-processor.output.xml
+  "Generating the XML output for an import. XML generation is handled
+  by clojure.xml, so XML elements must be represented by the kinds of
+  maps it expects:
+
+  {:tag :tag-name, :attrs {:map-of :attributes} :content [{:more :elements} ...]}
+
+  The pipeline to add child elements to the main vip_object element is
+  mostly governed by the `add-xml-children` function. Functions passed
+  to `add-xml-children` take a processing context and return a
+  sequence of XML elements to add as children to the vip_object
+  element.
+
+  `write-xml` lazily writes the XML file, so processing does not need
+  to take place all in memory."
+  (:require [clojure.xml :as xml]
+            [clojure.string :as string]
+            [clojure.java.io :as io]
+            [clojure.walk :as walk])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]
+           [org.apache.commons.lang StringEscapeUtils]))
+
+(def vip-object-attrs
+  {:xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+   :xsi:noNamespaceSchemaLocation "http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd"
+   :schemaVersion "3.0"})
+
+(def vip-object
+  {:tag :vip_object
+   :attrs vip-object-attrs
+   :content []})
+
+(defn create-xml-file [{:keys [filename] :as ctx}]
+  (assoc ctx
+         :xml-output-file
+         (Files/createTempFile filename ".xml" (into-array FileAttribute []))))
+
+(defn- escape-content
+  "For use in walking xml element maps."
+  [form]
+  (if (and (vector? form)
+           (= :content (first form))
+           (every? string? (second form)))
+    [:content (map #(StringEscapeUtils/escapeXml %) (second form))]
+    form))
+
+(defn write-xml
+  "Writes out the XML elements of `xml-children` as children of the
+  base `vip_object` element. Uses `do-seq` so that `xml-children` can
+  be lazy and larger than memory."
+  [{:keys [xml-output-file xml-children] :as ctx}]
+  (with-open [out-file (io/writer (.toFile xml-output-file))]
+    (let [[opening-tag closing-tag] (-> vip-object
+                                        xml/emit-element
+                                        with-out-str
+                                        (string/split #"\n"))]
+      (.write out-file "<?xml version='1.0' encoding='UTF-8'?>\n")
+      (.write out-file opening-tag)
+      (doseq [xml-child (:xml-children ctx)]
+        (let [xml-child (walk/postwalk escape-content xml-child)
+              xml-str (-> xml-child
+                          xml/emit-element
+                          with-out-str
+                          (string/replace #"(>)\n|\n(<)" "$1$2"))]
+          (.write out-file xml-str)))
+      (.write out-file closing-tag)))
+  ctx)
+
+(defn add-xml-children
+  "Takes a function that takes a proecssing context and returns
+  top-level clojure.xml-style maps . Returns a processing function
+  that calls the passed function and lazily adds the returned maps to
+  the :xml-children key of the context."
+  [xml-fn]
+  (fn [ctx]
+    (let [children (xml-fn ctx)]
+      (update ctx :xml-children #(lazy-cat % %2) children))))
+
+(def pipeline
+  [create-xml-file
+   write-xml])

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -19,6 +19,7 @@
             [clojure.walk :as walk]
             [vip.data-processor.output.ballot-response :as ballot-response]
             [vip.data-processor.output.candidate :as candidate]
+            [vip.data-processor.output.contest :as contest]
             [vip.data-processor.output.early-vote-site :as early-vote-site]
             [vip.data-processor.output.polling-location :as polling-location]
             [vip.data-processor.output.state :as state]
@@ -87,6 +88,7 @@
   [create-xml-file
    (add-xml-children ballot-response/xml-nodes)
    (add-xml-children candidate/xml-nodes)
+   (add-xml-children contest/xml-nodes)
    (add-xml-children early-vote-site/xml-nodes)
    (add-xml-children polling-location/xml-nodes)
    (add-xml-children state/xml-nodes)

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -16,7 +16,8 @@
   (:require [clojure.xml :as xml]
             [clojure.string :as string]
             [clojure.java.io :as io]
-            [clojure.walk :as walk])
+            [clojure.walk :as walk]
+            [vip.data-processor.output.candidate :as candidate])
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [org.apache.commons.lang StringEscapeUtils]))
@@ -79,4 +80,5 @@
 
 (def pipeline
   [create-xml-file
+   (add-xml-children candidate/xml-nodes)
    write-xml])

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -18,7 +18,8 @@
             [clojure.java.io :as io]
             [clojure.walk :as walk]
             [vip.data-processor.output.candidate :as candidate]
-            [vip.data-processor.output.early-vote-site :as early-vote-site])
+            [vip.data-processor.output.early-vote-site :as early-vote-site]
+            [vip.data-processor.output.polling-location :as polling-location])
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [org.apache.commons.lang StringEscapeUtils]))
@@ -83,4 +84,5 @@
   [create-xml-file
    (add-xml-children candidate/xml-nodes)
    (add-xml-children early-vote-site/xml-nodes)
+   (add-xml-children polling-location/xml-nodes)
    write-xml])

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -19,7 +19,8 @@
             [clojure.walk :as walk]
             [vip.data-processor.output.candidate :as candidate]
             [vip.data-processor.output.early-vote-site :as early-vote-site]
-            [vip.data-processor.output.polling-location :as polling-location])
+            [vip.data-processor.output.polling-location :as polling-location]
+            [vip.data-processor.output.state :as state])
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [org.apache.commons.lang StringEscapeUtils]))
@@ -85,4 +86,5 @@
    (add-xml-children candidate/xml-nodes)
    (add-xml-children early-vote-site/xml-nodes)
    (add-xml-children polling-location/xml-nodes)
+   (add-xml-children state/xml-nodes)
    write-xml])

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -17,6 +17,7 @@
             [clojure.string :as string]
             [clojure.java.io :as io]
             [clojure.walk :as walk]
+            [vip.data-processor.output.ballot-response :as ballot-response]
             [vip.data-processor.output.candidate :as candidate]
             [vip.data-processor.output.early-vote-site :as early-vote-site]
             [vip.data-processor.output.polling-location :as polling-location]
@@ -84,6 +85,7 @@
 
 (def pipeline
   [create-xml-file
+   (add-xml-children ballot-response/xml-nodes)
    (add-xml-children candidate/xml-nodes)
    (add-xml-children early-vote-site/xml-nodes)
    (add-xml-children polling-location/xml-nodes)

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -20,7 +20,8 @@
             [vip.data-processor.output.candidate :as candidate]
             [vip.data-processor.output.early-vote-site :as early-vote-site]
             [vip.data-processor.output.polling-location :as polling-location]
-            [vip.data-processor.output.state :as state])
+            [vip.data-processor.output.state :as state]
+            [vip.data-processor.output.street-segment :as street-segment])
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [org.apache.commons.lang StringEscapeUtils]))
@@ -87,4 +88,5 @@
    (add-xml-children early-vote-site/xml-nodes)
    (add-xml-children polling-location/xml-nodes)
    (add-xml-children state/xml-nodes)
+   (add-xml-children street-segment/xml-nodes)
    write-xml])

--- a/src/vip/data_processor/output/xml_helpers.clj
+++ b/src/vip/data_processor/output/xml_helpers.clj
@@ -4,6 +4,13 @@
   (let [tag (keyword name)]
     `{:tag ~tag :content [(str ~name)]}))
 
+(defmacro boolean-xml-node [name]
+  (let [tag (keyword name)]
+    `{:tag ~tag :content [(condp = ~name
+                            1 "yes"
+                            0 "no"
+                            nil)]}))
+
 (defn empty-content? [c]
   (or (nil? c)
       (empty? (first (:content c)))))

--- a/src/vip/data_processor/output/xml_helpers.clj
+++ b/src/vip/data_processor/output/xml_helpers.clj
@@ -1,0 +1,18 @@
+(ns vip.data-processor.output.xml-helpers)
+
+(defmacro xml-node [name]
+  (let [tag (keyword name)]
+    `{:tag ~tag :content [(str ~name)]}))
+
+(defn empty-content? [c]
+  (or (nil? c)
+      (empty? (first (:content c)))))
+
+(defn remove-empties [content]
+  (remove empty-content? content))
+
+(defn simple-xml
+  ([tag content]
+   {:tag tag :content (remove-empties content)})
+  ([tag id content]
+   {:tag tag :attrs {:id id} :content (remove-empties content)}))

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -47,7 +47,7 @@
              :fatal {}
              :pipeline pipeline}
         result (run-pipeline ctx)]
-    (log/info (select-keys result [:errors :warnings :critical :fatal :db]))
+    (log/info (select-keys result [:errors :warnings :critical :fatal :db :xml-output-file]))
     (when-let [ex (:exception result)]
       (log/error (with-out-str (stacktrace/print-stack-trace ex)))
       (throw (ex-info "Exception during processing" {:exception ex

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -48,6 +48,9 @@
       (are [path text] (= text (xpath/$x:text path xml-doc))
            "/vip_object/candidate[@id=10000]/name" "Gail H. Timberlake"
            "/vip_object/candidate[@id=10004]/party" "Republican"
+           "/vip_object/contest[@id=20000]/partisan" "no"
+           "/vip_object/contest[@id=20000]/special" "no"
+           "/vip_object/contest[@id=20002]/office" "Member Board of Supervisors"
            "/vip_object/state/name" "Virginia"
            "/vip_object/state/election_administration_id" "40133"
            "/vip_object/street_segment[@id=2000005]/non_house_address/street_name" "Neptune"

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -1,0 +1,24 @@
+(ns vip.data-processor.output.xml-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.output.xml :refer :all]
+            [clojure.xml :as xml])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(deftest create-xml-file-test
+  (testing "adds an :xml-output-file key to a context"
+    (let [ctx {:filename "create-xml-test"}
+          out-ctx (create-xml-file ctx)]
+      (is (:xml-output-file out-ctx)))))
+
+(deftest write-xml-test
+  (testing "writes XML to :xml-output-file generated from :xml-children"
+    (let [temp-file (Files/createTempFile "write-xml-test" ".xml" (into-array FileAttribute []))
+          xml-children [{:tag :foo :attrs {:bar "baz"} :content ["test"]}]
+          ctx {:xml-output-file temp-file
+               :xml-children xml-children}
+          out-ctx (write-xml ctx)
+          xml (xml/parse (.toString temp-file))]
+      (is (= :vip_object (:tag xml)))
+      (is (= vip-object-attrs (:attrs xml)))
+      (is (= xml-children (:content xml))))))

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -1,7 +1,14 @@
 (ns vip.data-processor.output.xml-test
   (:require [clojure.test :refer :all]
             [vip.data-processor.output.xml :refer :all]
-            [clojure.xml :as xml])
+            [vip.data-processor.db.sqlite :as sqlite]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.validation.data-spec :as data-spec]
+            [vip.data-processor.validation.transforms :as transforms]
+            [clojure.java.io :as io]
+            [clojure.xml :as xml]
+            [clj-xpath.core :as xpath])
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]))
 
@@ -21,4 +28,29 @@
           xml (xml/parse (.toString temp-file))]
       (is (= :vip_object (:tag xml)))
       (is (= vip-object-attrs (:attrs xml)))
-      (is (= xml-children (:content xml))))))
+      (is (= xml-children (:content xml)))))
+  (testing "generates XML from an import"
+    (let [db (sqlite/temp-db "xml-output")
+          filenames (->> csv/csv-filenames
+                         (map #(io/as-file (io/resource (str "csv/full-good-run/" %))))
+                         (remove nil?))
+          ctx (merge {:input filenames
+                      :pipeline (concat [(data-spec/add-data-specs
+                                          data-spec/data-specs)]
+                                        transforms/csv-validations
+                                        pipeline)} db)
+          results-ctx (pipeline/run-pipeline ctx)
+          xml-doc (-> results-ctx
+                      :xml-output-file
+                      .toString
+                      slurp
+                      xpath/xml->doc)]
+      (are [path text] (= text (xpath/$x:text path xml-doc))
+           "/vip_object/candidate[@id=10000]/name" "Gail H. Timberlake"
+           "/vip_object/candidate[@id=10004]/party" "Republican"
+           "/vip_object/state/name" "Virginia"
+           "/vip_object/state/election_administration_id" "40133"
+           "/vip_object/street_segment[@id=2000005]/non_house_address/street_name" "Neptune"
+           "/vip_object/street_segment[@id=2000005]/odd_even_both" "both"
+           "/vip_object/polling_location[@id=80006]/address/location_name" "Huguenot Public Safety Building"
+           "/vip_object/polling_location[@id=80006]/polling_hours" "6:00 AM - 7:00 PM"))))


### PR DESCRIPTION
This PR encompasses multiple Pivotal stories:

* [91964544](https://www.pivotaltracker.com/story/show/91964544): Create an XML file with the `vip_object` root element.
* [91989758](https://www.pivotaltracker.com/story/show/91989758): Create `<ballot_response>` elements in XML export
* [91989988](https://www.pivotaltracker.com/story/show/91989988): Create `<candidate>` elements in XML export
* [91977400](https://www.pivotaltracker.com/story/show/91977400): Create `<contest>` elements in XML export
* [91989892](https://www.pivotaltracker.com/story/show/91989892): Create `<early_vote_site>` elements in XML export
* [91999456](https://www.pivotaltracker.com/story/show/91999456): Create `<polling_location>` elements in XML export
* [91986644](https://www.pivotaltracker.com/story/show/91986644): Create `<state>` elements in XML export
* [91988054](https://www.pivotaltracker.com/story/show/91988054): Create `<street_segment>` elements in XML export

Hopefully, between docstrings and commits like dac5d6f, it should be easy for someone to follow along adding more elements to the export.
