### PR TITLE
Init processing table

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -16,14 +16,14 @@
            t/attach-sqlite-db
            (data-spec/add-data-specs data-spec/data-specs)
            t/xml-csv-branch]
+          [psql/start-run]
           db/validations
           xml-output/pipeline))
 
 (defn -main [zip-filename]
   (psql/initialize)
   (let [zip (java.io.File. zip-filename)
-        result (-> (pipeline/process pipeline zip)
-                   (psql/start-run))]
+        result (pipeline/process pipeline zip)]
     (when-let [xml-output-file (:xml-output-file result)]
       (println "XML:" (.toString xml-output-file))
       (let [filename (xml-filename result)

--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -6,7 +6,9 @@
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.db :as db]
             [vip.data-processor.validation.transforms :as t]
-            [vip.data-processor.validation.zip :as zip]))
+            [vip.data-processor.validation.zip :as zip]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.s3 :refer [xml-filename]]))
 
 (def pipeline
   (concat [zip/unzip
@@ -18,7 +20,12 @@
           xml-output/pipeline))
 
 (defn -main [zip-filename]
+  (psql/initialize)
   (let [zip (java.io.File. zip-filename)
-        result (pipeline/process pipeline zip)]
+        result (-> (pipeline/process pipeline zip)
+                   (psql/start-run))]
     (when-let [xml-output-file (:xml-output-file result)]
-      (println "XML:" (.toString xml-output-file)))))
+      (println "XML:" (.toString xml-output-file))
+      (let [filename (xml-filename result)
+            results (assoc result :generated-xml-filename filename)]
+        (psql/complete-run results)))))

--- a/project.clj
+++ b/project.clj
@@ -21,5 +21,6 @@
   :profiles {:test {:resource-paths ["test-resources"]
                     :dependencies [[com.github.kyleburton/clj-xpath "1.4.4"]]}
              :dev {:source-paths ["dev-src"]
+                   :resource-paths ["dev-resources"]
                    :main dev.core}}
   :main vip.data-processor)

--- a/resources/migrations/20150211-01-create-results-table.up.sql
+++ b/resources/migrations/20150211-01-create-results-table.up.sql
@@ -1,3 +1,5 @@
-CREATE TABLE results (upload character varying(255),
+CREATE TABLE results (id serial PRIMARY KEY,
+                      start_time timestamp with time zone,
+                      filename character varying(255),
                       complete boolean,
-                      completed_at timestamp with time zone);
+                      end_time timestamp with time zone);

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -15,6 +15,7 @@
 (def download-pipeline
   [t/read-edn-sqs-message
    t/assert-filename
+   psql/start-run
    t/attach-sqlite-db
    t/download-from-s3
    zip/unzip
@@ -33,12 +34,10 @@
                           (q/publish {:initial-input message
                                       :status :started}
                                      "processing.started")
-                          (let [result (pipeline/process pipeline message)
-                                filename (:filename result)]
-                            (korma/insert psql/results
-                                          (korma/values {:upload filename
-                                                         :complete true
-                                                         :completed_at (korma/sqlfn now)})))
+                          (let [result (pipeline/process pipeline message)]
+                            (psql/complete-run result)
+                            (log/info "New run completed:"
+                                      (psql/get-run result)))
                           (q/publish {:initial-input message
                                       :status :complete}
                                      "processing.complete"))))

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -23,3 +23,22 @@
                                         (assoc :db (config :postgres :user)))))
   (korma/defentity results
     (korma/database results-db)))
+
+(defn start-run [ctx]
+  (let [results (korma/insert results
+                              (korma/values {:start_time (korma/sqlfn now)
+                                             :complete false}))]
+    (assoc ctx :import-id (:id results))))
+
+(defn complete-run [ctx]
+  (let [id (:import-id ctx)
+        filename (:filename ctx)]
+    (korma/update results
+                  (korma/set-fields {:filename filename
+                                     :complete true
+                                     :end_time (korma/sqlfn now)})
+                  (korma/where {:id id}))))
+
+(defn get-run [ctx]
+  (korma/select results
+                (korma/where {:id (:import-id ctx)})))

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -32,7 +32,7 @@
 
 (defn complete-run [ctx]
   (let [id (:import-id ctx)
-        filename (:filename ctx)]
+        filename (:generated-xml-filename ctx)]
     (korma/update results
                   (korma/set-fields {:filename filename
                                      :complete true


### PR DESCRIPTION
[Pivotal Card 1](https://www.pivotaltracker.com/story/show/91446926)
[Pivotal Card 2](https://www.pivotaltracker.com/story/show/91447160)

This work:

1. Initializes a processing table called `results` 
1. Loads basic information about the run to that table such as start and end time.

Also added code to `dev.core` and the `project.clj` that allows for a `dev-resources/config.edn` file to be included so this can be run locally. The config file only needs to be super simple and should look like:
```
{:postgres {:host "127.0.0.1"
            :port "5432"
            :user "YOUR PSQL USERNAME"
            :password "YOUR PSQL PASSWORD"}}
```
If you're not sure of this information but have access to the `psql` command, run it and then run `\conninfo` and you'll see how you're logged in.