### PR TITLE
Track temp files and delete them in the end

### DIFF
--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -2,6 +2,7 @@
   (:require [clojure.tools.logging :as log]
             [democracyworks.squishy :as sqs]
             [korma.core :as korma]
+            [vip.data-processor.cleanup :as cleanup]
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.db :as db]
@@ -31,7 +32,8 @@
           [s3/upload-to-s3]
           [psql/insert-validations
            psql/import-from-sqlite
-           psql/store-stats]))
+           psql/store-stats
+           cleanup/cleanup]))
 
 (defn consume []
   (sqs/consume-messages (sqs/client)

--- a/src/vip/data_processor/cleanup.clj
+++ b/src/vip/data_processor/cleanup.clj
@@ -1,0 +1,11 @@
+(ns vip.data-processor.cleanup
+  (:require [clojure.tools.logging :as log]))
+
+(defn cleanup [{:keys [to-be-cleaned] :as ctx}]
+  (doseq [file to-be-cleaned]
+    (let [file (if (instance? java.nio.file.Path file)
+                 (.toFile file)
+                 file)]
+      (when (.exists file)
+        (.delete file))))
+  ctx)

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -78,9 +78,10 @@
    :content []})
 
 (defn create-xml-file [{:keys [filename] :as ctx}]
-  (assoc ctx
-         :xml-output-file
-         (Files/createTempFile filename ".xml" (into-array FileAttribute []))))
+  (let [xml-file (Files/createTempFile filename ".xml" (into-array FileAttribute []))]
+    (-> ctx
+        (assoc :xml-output-file xml-file)
+        (update :to-be-cleaned conj xml-file))))
 
 (def ^:const SPACE " ")
 (def ^:const OPEN-VALUE "=\"")

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -17,12 +17,18 @@
     (assoc ctx :stop "No filename!")))
 
 (defn attach-sqlite-db [ctx]
-  (merge ctx (sqlite/temp-db (:filename ctx))))
+  (let [db (sqlite/temp-db (:filename ctx))
+        db-file (get-in db [:db :db])]
+    (-> ctx
+        (merge db)
+        (update :to-be-cleaned conj db-file))))
 
 (defn download-from-s3 [ctx]
   (let [filename (get-in ctx [:input :filename])
         file (s3/download filename)]
-    (assoc ctx :input file)))
+    (-> ctx
+        (update :to-be-cleaned conj file)
+        (assoc :input file))))
 
 (def xml-validations
   [xml/load-xml])

--- a/src/vip/data_processor/validation/zip.clj
+++ b/src/vip/data_processor/validation/zip.clj
@@ -32,9 +32,11 @@
     (if (xml-file? path)
       (assoc ctx :input
              [(.toFile path)])
-      (assoc ctx :input
-             (-> path
-                 (.resolve "data")
-                 .toFile
-                 .listFiles
-                 seq)))))
+      (let [files (-> path
+                      (.resolve "data")
+                      .toFile
+                      .listFiles
+                      seq)]
+        (-> ctx
+            (assoc :input files)
+            (update :to-be-cleaned concat files))))))

--- a/test/vip/data_processor/cleanup_test.clj
+++ b/test/vip/data_processor/cleanup_test.clj
@@ -1,0 +1,24 @@
+(ns vip.data-processor.cleanup-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.cleanup :refer :all]))
+
+(deftest cleanup-test
+  (testing "Removes files in :to-be-cleaned"
+    (let [file-that-exists (java.io.File/createTempFile (name (gensym)) ".tmp")
+          file-that-does-not-exist (java.io.File. (str file-that-exists ".nope"))
+          path-that-exists (.toPath (java.io.File/createTempFile (name (gensym)) ".tmp"))
+          path-that-does-not-exist (.toPath (java.io.File. (str path-that-exists ".nope")))
+          ctx {:to-be-cleaned [file-that-exists
+                               file-that-does-not-exist
+                               path-that-exists
+                               path-that-does-not-exist]}]
+      (is (.exists file-that-exists))
+      (is (not (.exists file-that-does-not-exist)))
+      (is (.exists (.toFile path-that-exists)))
+      (is (not (.exists (.toFile path-that-does-not-exist))))
+      (testing "after cleanup"
+        (cleanup ctx)
+        (testing "removes files that had existed"
+          (is (not (.exists file-that-exists))))
+        (testing "removes paths that had existed"
+          (is (not (.exists (.toFile path-that-exists)))))))))


### PR DESCRIPTION
Pivotal story: [95561156](https://www.pivotaltracker.com/story/show/95561156)

Adds a function to the end of the pipeline that cleans up temporary files created during a run (download, extracted files, generated XML), so as to take some pressure off the OS from doing it itself.