### PR TITLE
Create "public_id" for each run

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -17,7 +17,8 @@
            t/attach-sqlite-db
            (data-spec/add-data-specs data-spec/data-specs)
            t/xml-csv-branch]
-          [psql/start-run]
+          [psql/start-run
+           psql/store-public-id]
           db/validations
           xml-output/pipeline
           [psql/insert-validations

--- a/resources/migrations/20150211-01-create-results-table.up.sql
+++ b/resources/migrations/20150211-01-create-results-table.up.sql
@@ -1,4 +1,5 @@
 CREATE TABLE results (id serial PRIMARY KEY,
+                      public_id character varying(255) UNIQUE,
                       start_time timestamp with time zone,
                       filename character varying(255),
                       complete boolean,

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -26,7 +26,8 @@
 (def pipeline
   (concat download-pipeline
           [(data-spec/add-data-specs data-spec/data-specs)
-           t/xml-csv-branch]
+           t/xml-csv-branch
+           psql/store-public-id]
           db/validations
           xml-output/pipeline
           [s3/upload-to-s3]

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -47,6 +47,13 @@
                                              :complete false}))]
     (assoc ctx :import-id (:id results))))
 
+(defn build-public-id [date election-type state import-id]
+  (let [nil-or-empty? (some-fn nil? empty?)
+        good-parts (remove nil-or-empty? [date election-type state])]
+    (if (empty? good-parts)
+      (str "invalid-" import-id)
+      (str/join "-" (concat good-parts [import-id])))))
+
 (defn generate-public-id [{:keys [import-id] :as ctx}]
   (let [state (-> ctx
                  (get-in [:tables :states])
@@ -57,7 +64,7 @@
                                          (get-in [:tables :elections])
                                          (korma/select (korma/fields :date :election_type))
                                          first)]
-    (str/join "-" [date election_type state import-id])))
+    (build-public-id date election_type state import-id)))
 
 (defn store-public-id [ctx]
   (let [id (:import-id ctx)

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -1,0 +1,23 @@
+(ns vip.data-processor.db.postgres-test
+  (:require [vip.data-processor.db.postgres :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest build-public-id-test
+  (testing "builds public ids with as much information as it has"
+    (is (= "2015-06-18-federal-Ohio-4" (build-public-id "2015-06-18" "federal" "Ohio" 4)))
+    (is (= "federal-Ohio-4" (build-public-id nil "federal" "Ohio" 4)))
+    (is (= "2015-06-18-Ohio-4" (build-public-id "2015-06-18" nil "Ohio" 4)))
+    (is (= "2015-06-18-federal-4" (build-public-id "2015-06-18" "federal" nil 4)))
+    (is (= "2015-06-18-4" (build-public-id "2015-06-18" nil nil 4)))
+    (is (= "federal-4" (build-public-id nil "federal" nil 4)))
+    (is (= "Ohio-4" (build-public-id nil nil "Ohio" 4)))
+    (is (= "2015-06-18-federal-Ohio-4" (build-public-id "2015-06-18" "federal" "Ohio" 4)))
+    (is (= "federal-Ohio-4" (build-public-id "" "federal" "Ohio" 4)))
+    (is (= "2015-06-18-Ohio-4" (build-public-id "2015-06-18" "" "Ohio" 4)))
+    (is (= "2015-06-18-federal-4" (build-public-id "2015-06-18" "federal" "" 4)))
+    (is (= "2015-06-18-4" (build-public-id "2015-06-18" "" "" 4)))
+    (is (= "federal-4" (build-public-id "" "federal" "" 4)))
+    (is (= "Ohio-4" (build-public-id "" "" "Ohio" 4))))
+  (testing "gives an 'invalid' named id if all of date, election-type and state are nil"
+    (is (= "invalid-4" (build-public-id nil nil nil 4)))
+    (is (= "invalid-4" (build-public-id "" nil "" 4)))))


### PR DESCRIPTION
Pivotal story: [96666240](https://www.pivotaltracker.com/story/show/96666240)

Creates a new column inside of the results table that contains a more readable _unique_ ID that's generated based on the election date, the election type, and the state. The unique identifier ends with the row's id itself.