### PR TITLE
Friday itch scratching

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -12,12 +12,12 @@
             [democracyworks.squishy.data-readers]))
 
 (def pipeline
-  (concat [zip/assoc-file
+  (concat [psql/start-run
+           zip/assoc-file
            zip/extracted-contents
            t/attach-sqlite-db
            (data-spec/add-data-specs data-spec/data-specs)
-           t/xml-csv-branch]
-          [psql/start-run
+           t/xml-csv-branch
            psql/store-public-id]
           db/validations
           xml-output/pipeline

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -47,10 +47,9 @@
              :fatal {}
              :pipeline pipeline}
         result (run-pipeline ctx)]
-    (log/info (select-keys result [:errors :warnings :critical :fatal :db :xml-output-file]))
+    (log/info (select-keys result [:import-id :db :xml-output-file]))
     (when-let [ex (:exception result)]
       (log/error (with-out-str (stacktrace/print-stack-trace ex)))
       (throw (ex-info "Exception during processing" {:exception ex
-                                                     :initial-ctx ctx
-                                                     :final-ctx result})))
+                                                     :initial-ctx ctx})))
     result))


### PR DESCRIPTION
* Reduces the noise while running the processor (especially helpful for huge imports with tons of errors)
* Updates the dev processor pipeline to add a row to the results table right away instead of waiting until after all the data has been loaded