### PR TITLE
Be more memory conscious

### DIFF
--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -134,7 +134,7 @@
                    errors)))))
    [:warnings :errors :critical :fatal]))
 
-(def statement-parameter-limit 3000)
+(def statement-parameter-limit 10000)
 (def bulk-import (partial db.util/bulk-import statement-parameter-limit))
 
 (defn insert-validations [ctx]
@@ -152,7 +152,7 @@
                        :columns)]
       (bulk-import (ent import-entities)
                    (->> table
-                        (db.util/select-*-lazily 100)
+                        (db.util/select-*-lazily 5000)
                         (map #(assoc % :results_id import-id))
                         (data-spec/coerce-rows columns)))))
   ctx)

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -153,8 +153,11 @@
                        first
                        :columns)
           vals (data-spec/coerce-rows columns vals)]
-      (when (seq vals)
-        (bulk-import (ent import-entities) vals))))
+      (bulk-import (ent import-entities)
+                   (->> table
+                        (db.util/select-*-lazily 100)
+                        (map #(assoc % :results_id import-id))
+                        (data-spec/coerce-rows columns)))))
   ctx)
 
 (defn store-stats [{:keys [import-id] :as ctx}]

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -146,13 +146,10 @@
 (defn import-from-sqlite [{:keys [import-id db data-specs] :as ctx}]
   (doseq [ent db.util/import-entity-names]
     (let [table (get-in ctx [:tables ent])
-          vals (korma/select table)
-          vals (map #(assoc % :results_id import-id) vals)
           columns (->> data-specs
                        (filter #(= ent (:table %)))
                        first
-                       :columns)
-          vals (data-spec/coerce-rows columns vals)]
+                       :columns)]
       (bulk-import (ent import-entities)
                    (->> table
                         (db.util/select-*-lazily 100)

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -102,4 +102,4 @@
 
 (defn load-xml [ctx]
   (let [xml-file (first (:input ctx))]
-    (reduce load-elements ctx (partition-by-n :tag 100 (:content (xml/parse (io/reader xml-file)))))))
+    (reduce load-elements ctx (partition-by-n :tag 5000 (:content (xml/parse (io/reader xml-file)))))))


### PR DESCRIPTION
* `db.util/select-*-lazily` loads rows from a database as a chunked lazy sequence
* Importing from sqlite to postgres now uses `select-*-lazily` so that it doesn't pull gigantic tables into memory
* Validating CSV value formats and #-of-values violations now happens as rows from the CSV are being read. Before, we had been inadvertently doing those checks by realizing the entirety of the CSV in memory, which was causing problems for very large files.
* Limits for how many XML elements to read in at a time was raised, as it was too small.

Fixes bug [98585266](https://www.pivotaltracker.com/story/show/98585266)