### PR TITLE
Remove NOT NULL constraints on non-id columns

### DIFF
--- a/resources/migrations/20150715-01-drop-not-nulls.down.sql
+++ b/resources/migrations/20150715-01-drop-not-nulls.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE elections ALTER COLUMN election_day_registration SET NOT NULL;
+ALTER TABLE elections ALTER COLUMN statewide SET NOT NULL;
+ALTER TABLE contest_results ALTER COLUMN entire_district SET NOT NULL;
+ALTER TABLE ballot_line_results ALTER COLUMN entire_district SET NOT NULL;

--- a/resources/migrations/20150715-01-drop-not-nulls.up.sql
+++ b/resources/migrations/20150715-01-drop-not-nulls.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE elections ALTER COLUMN election_day_registration DROP NOT NULL;
+ALTER TABLE elections ALTER COLUMN statewide DROP NOT NULL;
+ALTER TABLE contest_results ALTER COLUMN entire_district DROP NOT NULL;
+ALTER TABLE ballot_line_results ALTER COLUMN entire_district DROP NOT NULL;

--- a/resources/processing-migrations/00-create-elections.up.sql
+++ b/resources/processing-migrations/00-create-elections.up.sql
@@ -2,7 +2,7 @@ CREATE TABLE elections (id INTEGER PRIMARY KEY,
                         absentee_ballot_info TEXT,
                         absentee_request_deadline DATE,
                         date DATE,
-                        election_day_registration BOOLEAN NOT NULL CHECK (election_day_registration IN (0,1)),
+                        election_day_registration BOOLEAN CHECK (election_day_registration IN (0,1,NULL)),
                         election_type VARCHAR(20), -- should this be a reference to an election_types table?
                                                    -- Is there a known list of good values?
                         polling_hours TEXT,
@@ -10,4 +10,4 @@ CREATE TABLE elections (id INTEGER PRIMARY KEY,
                         registration_info TEXT,
                         results_url TEXT,
                         state_id INT,
-                        statewide BOOLEAN NOT NULL CHECK (statewide IN (0,1)));
+                        statewide BOOLEAN CHECK (statewide IN (0,1,NULL)));

--- a/resources/processing-migrations/28-contest-results.up.sql
+++ b/resources/processing-migrations/28-contest-results.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE contest_results (id INTEGER PRIMARY KEY,
                               contest_id INTEGER,
                               jurisdiction_id INTEGER,
-                              entire_district BOOLEAN NOT NULL CHECK (entire_district IN (0,1)),
+                              entire_district BOOLEAN CHECK (entire_district IN (0,1,NULL)),
                               total_votes INTEGER,
                               total_valid_votes INTEGER,
                               overvotes INTEGER,

--- a/resources/processing-migrations/29-create-ballot-line-results.up.sql
+++ b/resources/processing-migrations/29-create-ballot-line-results.up.sql
@@ -1,10 +1,10 @@
 CREATE TABLE ballot_line_results (id INTEGER PRIMARY KEY,
                                   contest_id INTEGER,
                                   jurisdiction_id INTEGER,
-                                  entire_district BOOLEAN NOT NULL CHECK (entire_district IN (0,1)),
+                                  entire_district BOOLEAN CHECK (entire_district IN (0,1,NULL)),
                                   candidate_id INTEGER,
                                   ballot_response_id INTEGER,
                                   votes INTEGER,
                                   overvotes INTEGER,
-                                  victorious BOOLEAN CHECK (victorious IN (0,1)),
+                                  victorious BOOLEAN CHECK (victorious IN (0,1,NULL)),
                                   certification TEXT);


### PR DESCRIPTION
There were NOT NULL constraints on columns that are either NULLable, or are often provided in imports without values.

The "processing-migrations" migrations don't need a separate migration to remove the constraint and can be edited in place because they are run on a fresh database for each import.

Pivotal bug [99134060](https://www.pivotaltracker.com/story/show/99134060)