### PR TITLE
Fix import to Postgres when value types are bad

### DIFF
--- a/test/vip/data_processor/validation/data_spec_test.clj
+++ b/test/vip/data_processor/validation/data_spec_test.clj
@@ -94,3 +94,30 @@
     (testing "reports errors for values with the Unicode replacement character"
       (is (= (get-in out-ctx [:errors :sources 2 "name"])
              ["Is not valid UTF-8."]))))))
+
+(deftest coerce-integer-test
+  (testing "returns the number if passed an integer"
+    (are [n] (= n (coerce-integer n))
+      1
+      0
+      1000
+      12))
+  (testing "parses strings and returns integers"
+    (are [s n] (= n (coerce-integer s))
+      "1" 1
+      "0" 0
+      "1234" 1234
+      "8" 8))
+  (testing "returns nil for strings not parsable as integers"
+    (are [s] (nil? (coerce-integer s))
+      "nope"
+      "not a number"
+      "1x3"
+      "eleven"))
+  (testing "returns nil for anything else"
+    (are [v] (nil? (coerce-integer v))
+      nil
+      :symbol
+      'keyword
+      {:map 1}
+      #{2 3 5})))


### PR DESCRIPTION
If a feed has a value that isn't an integer in a field that requires an integer, the import would fail when importing the data into postgres. Non-integers (and non-dates for date fields, and non-yes/no for boolean fields) will no longer throw an exception and instead insert nil into the database. An error is already logged for the type mismatch.

Pivotal bug [99541752](https://www.pivotaltracker.com/story/show/99541752)