### PR TITLE
Better validate electoral district types

### DIFF
--- a/src/vip/data_processor/validation/data_spec/value_format.clj
+++ b/src/vip/data_processor/validation/data_spec/value_format.clj
@@ -21,7 +21,28 @@
    :message "Invalid election_type"})
 
 (def electoral-district-type
-  {:check ["statewide" "state senate" "state house" "fire district" "congressional district" "school district" "county"]
+  {:check #"\A(?ix: state(?:wide)? |
+                    u\.?s\.?\ senate |
+                    u\.?s\.?\ (?:rep(?:resentative)?|house) |
+                    congressional |
+                    (?:[a-tv-z][a-tv-z]|ut|state)\ senate |
+                    (?:[a-tv-z][a-rt-z]|ut|state)\ (?:rep(?:resentative)?|house(?:\ of\ delegates)?) |
+                    house\ of\ delegates |
+                    house |
+                    county(?:wide)? |
+                    county\ offices |
+                    mayor |
+                    municipality |
+                    county\ commission(?:er)? |
+                    ward |
+                    school |
+                    school\ district |
+                    school\ member\ district |
+                    local\ school\ board |
+                    prosecutorial\ district |
+                    superior\ court |
+                    town(?:ship)? |
+                    sanitary)\z"
    :message "Invalid type"})
 
 (def email

--- a/test/vip/data_processor/validation/data_spec/value_format_test.clj
+++ b/test/vip/data_processor/validation/data_spec/value_format_test.clj
@@ -1,0 +1,29 @@
+(ns vip.data-processor.validation.data-spec.value-format-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.validation.data-spec.value-format :refer :all]))
+
+(deftest electoral-district-type-regex-test
+  (let [electoral-district-type-regex (:check electoral-district-type)]
+    (testing "matches a lot of expected values"
+      (are [s] (re-matches electoral-district-type-regex s)
+        "state"
+        "statewide"
+        "STATEWIDE"
+        "u.s. senate"
+        "us rep"
+        "u.s. house"
+        "congressional"
+        "state senate"
+        "ut senate"
+        "house"
+        "county"
+        "countywide"
+        "school member district"
+        "town"
+        "township"
+        "sanitary"))
+    (testing "does not match any random string"
+      (are [s] (nil? (re-matches electoral-district-type-regex s))
+        "parliament"
+        "prom court"
+        "Kang v Kodos"))))


### PR DESCRIPTION
Use the "official" electoral district type regex.

Pivotal story: [99558306](https://www.pivotaltracker.com/story/show/99558306)