### PR TITLE
Lower sqlite statement parameter limit to 500

### DIFF
--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -32,5 +32,5 @@
             (recur (conj columns (.getString result-set "name")))
             columns))))))
 
-(def statement-parameter-limit 999)
+(def statement-parameter-limit 500)
 (def bulk-import (partial util/bulk-import statement-parameter-limit))


### PR DESCRIPTION
500 is the SQLITE_MAX_COMPOUND_SELECT limit, which is being surpassed somehow in some inserts. Perhaps there's a way to know when to use the SQLITE_MAX_COMPOUND_SELECT and when to use the SQLITE_MAX_VARIABLE_NUMBER (999), but until then... this.