### PR TITLE
Check for in-file dupe ids during import

### DIFF
--- a/test-resources/csv/in-file-duplicate-ids/contest.txt
+++ b/test-resources/csv/in-file-duplicate-ids/contest.txt
@@ -1,0 +1,9 @@
+election_id,electoral_district_id,type,partisan,primary_party,electorate_specifications,special,office,filing_closed_date,number_elected,number_voting_for,ballot_id,ballot_placement,id
+500002681,100000486,"2015 Palo Alto County School Election",,,,,"PAC At Large Vote for 2",,2,2,500027598,,1
+500002606,100000409,"SCHOOL ELECTION #19",,,,,"Howard-Winn School Board Director, District 2",,1,1,500027499,2,2
+500002684,100000639,"2015 SCHOOL ELECTIONS",,,,,"Durant School Board Director",,3,3,500027208,1,3
+750001764,100000337,"Regular School Election",,,,,"DIRECTOR",,2,2,500027233,2,4
+500002707,100000330,"School Election 2015",,,,,"North Kossuth School Director at Large",,1,1,500027264,,5
+500002723,100000557,"Sioux County Regular School Election",,,,,"MOC DD 4",,1,1,500027399,3,6
+500002723,100000557,"Sioux County Regular School Election",,,,,"MOC DD 4",,1,1,500027391,3,3
+750001750,1000050649,"2015 Wapello County School Election",,,,,"EBF DD3",,1,1,750014237,,5


### PR DESCRIPTION
Duplicate ids _within_ a file were causing the CSV importer to blow up as it tried to insert values into a table. Now, we try the insert, catch an error, and if it's because of a UNIQUE constraint on an id column, it retries, but without any ids already in the table or within the chunk it's working on.

This results in rows not being imported, so it adds a fatal error for each duplicated id.

[Pivotal story](https://www.pivotaltracker.com/story/show/101913786)