### PR TITLE
Safe sqlite db path

### DIFF
--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -6,11 +6,11 @@
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]))
 
-(defn create-temp-db-file [prefix]
-  (Files/createTempFile (str prefix "-") ".db" (into-array FileAttribute [])))
+(defn create-temp-db-file [import-id]
+  (Files/createTempFile (str "import-" import-id "-") ".db" (into-array FileAttribute [])))
 
-(defn temp-db [upload-filename]
-  (let [temp-file (create-temp-db-file upload-filename)
+(defn temp-db [import-id]
+  (let [temp-file (create-temp-db-file import-id)
         url (str "jdbc:sqlite:" temp-file)
         db (db/sqlite3 {:db temp-file})]
     (j/migrate-db {:db {:type :sql

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -17,7 +17,7 @@
     (assoc ctx :stop "No filename!")))
 
 (defn attach-sqlite-db [ctx]
-  (let [db (sqlite/temp-db (:filename ctx))
+  (let [db (sqlite/temp-db (:import-id ctx))
         db-file (get-in db [:db :db])]
     (-> ctx
         (merge db)


### PR DESCRIPTION
Use the import's id as the basis for the SQLite db path instead of the original filename so we don't run into a java.net.URISyntaxException.

[Pivotal story](https://www.pivotaltracker.com/story/show/101067048)