### PR TITLE
remove invalid extensions

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -17,6 +17,7 @@
            zip/extracted-contents
            t/attach-sqlite-db
            (data-spec/add-data-specs data-spec/data-specs)
+           t/remove-invalid-extensions
            t/xml-csv-branch
            psql/store-public-id]
           db/validations

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -26,6 +26,7 @@
 (def pipeline
   (concat download-pipeline
           [(data-spec/add-data-specs data-spec/data-specs)
+           t/remove-invalid-extensions
            t/xml-csv-branch
            psql/store-public-id]
           db/validations

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -40,6 +40,14 @@
    (csv-files/validate-dependencies csv-files/file-dependencies)
    csv/load-csvs])
 
+(defn remove-invalid-extensions [ctx]
+  (let [files (:input ctx)
+        valid-extensions #{"csv" "txt" "xml"}]
+    (assoc ctx :input 
+           (remove #(not (some valid-extensions
+                               (-> % .getName 
+                                   (s/split #"\.")))) files))))
+
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx
                              :input

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -42,11 +42,16 @@
 
 (defn remove-invalid-extensions [ctx]
   (let [files (:input ctx)
-        valid-extensions #{"csv" "txt" "xml"}]
-    (assoc ctx :input 
-           (remove #(not (some valid-extensions
-                               (-> % .getName 
-                                   (s/split #"\.")))) files))))
+        valid-extensions #{"csv" "txt" "xml"}
+        invalid-fn (fn [file] 
+                     (not (some valid-extensions
+                                (-> file .getName 
+                                    (s/split #"\.")))))
+        {valid-files false invalid-files true} (group-by invalid-fn files)]
+    (-> ctx 
+        (assoc :input valid-files)
+        (assoc-in [:warnings :import :global :invalid-extensions] 
+                  (map #(.getName %) invalid-files)))))
 
 (defn xml-csv-branch [ctx]
   (let [file-extensions (->> ctx

--- a/test/vip/data_processor/validation/transforms_test.clj
+++ b/test/vip/data_processor/validation/transforms_test.clj
@@ -24,3 +24,13 @@
       (is (nil? (:stop results-ctx)))
       (is (nil? (:exception results-ctx)))
       (assert-no-problems results-ctx []))))
+
+(deftest remove-invalid-extensions-test
+  (testing "removes non-csv, txt, or xml files from :input"
+    (let [ctx {:input [(File. "good-file.xml")
+                       (File. "not-so-good-file.xls")]}
+          results-ctx (remove-invalid-extensions ctx)]
+      (is (= 1 (count (:input results-ctx))))
+      (is (= "good-file.xml" (-> results-ctx :input first .getName))))))
+
+

--- a/test/vip/data_processor/validation/transforms_test.clj
+++ b/test/vip/data_processor/validation/transforms_test.clj
@@ -28,9 +28,11 @@
 (deftest remove-invalid-extensions-test
   (testing "removes non-csv, txt, or xml files from :input"
     (let [ctx {:input [(File. "good-file.xml")
-                       (File. "not-so-good-file.xls")]}
+                       (File. "not-so-good-file.xls")
+                       (File. "logo.ai")]}
           results-ctx (remove-invalid-extensions ctx)]
       (is (= 1 (count (:input results-ctx))))
-      (is (= "good-file.xml" (-> results-ctx :input first .getName))))))
+      (is (= "good-file.xml" (-> results-ctx :input first .getName)))
+      (is (= #{"not-so-good-file.xls" "logo.ai"} (set (get-in results-ctx [:warnings :import :global :invalid-extensions])))))))
 
 


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/99943928)

Checks for any files within the feed that is not a csv, txt, or xml and removes those files from the :input.