### PR TITLE
Format filename and public

### DIFF
--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -51,7 +51,9 @@
 (defn build-public-id [date election-type state import-id]
   (let [nil-or-empty? (some-fn nil? empty?)
         formatted-date (util/format-date date)
-        good-parts (remove nil-or-empty? [formatted-date election-type state])]
+        good-parts (->> [formatted-date election-type state]
+                        (remove nil-or-empty?)
+                        (map #(str/trim %)))]
     (if (empty? good-parts)
       (str "invalid-" import-id)
       (str/join "-" (concat good-parts [import-id])))))

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -50,7 +50,8 @@
 
 (defn build-public-id [date election-type state import-id]
   (let [nil-or-empty? (some-fn nil? empty?)
-        good-parts (remove nil-or-empty? [date election-type state])]
+        formatted-date (util/format-date date)
+        good-parts (remove nil-or-empty? [formatted-date election-type state])]
     (if (empty? good-parts)
       (str "invalid-" import-id)
       (str/join "-" (concat good-parts [import-id])))))

--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -3,7 +3,8 @@
             [clojure.java.io :as io]
             [turbovote.resource-config :refer [config]]
             [korma.core :as korma]
-            [clojure.string :refer [join]])
+            [clojure.string :refer [join]]
+            [vip.data-processor.util :as util])
   (:import [java.io File]
            [java.nio.file Files CopyOption StandardCopyOption]
            [java.nio.file.attribute FileAttribute]
@@ -44,7 +45,8 @@
                          (< (count fips) 5) (format "%05d" (Integer/parseInt fips))
                          :else fips)
         election-date (->> (get-in ctx [:tables :elections])
-                           korma/select first :date)]
+                           korma/select first :date
+                           util/format-date)]
     (join "-" ["vipfeed" fips election-date])))
 
 (defn upload-to-s3

--- a/src/vip/data_processor/util.clj
+++ b/src/vip/data_processor/util.clj
@@ -12,9 +12,12 @@
   ;; making it through to the database. This fix will keep
   ;; the entire feed from breaking Metis while we investigate
   ;; the issue.
-  (let [format-fn (fn [d] (->> d java.util.Date.
-                               (.format 
-                                (java.text.SimpleDateFormat. 
-                                 "yyyy-MM-dd"))))]
+  (let [format-fn (fn [d] (try (->> d java.util.Date.
+                                    (.format 
+                                     (java.text.SimpleDateFormat. 
+                                      "yyyy-MM-dd")))
+                               (catch Throwable _
+                                 nil)))]
     (if (and (seq date) (re-find #"\/" date))
-      (format-fn date) date)))
+      (format-fn date) 
+      date)))

--- a/src/vip/data_processor/util.clj
+++ b/src/vip/data_processor/util.clj
@@ -6,3 +6,15 @@
     (assoc a ks m)))
 
 (defn flatten-keys [m] (flatten-keys* {} [] m))
+
+(defn format-date [date]
+  ;; Currently, invalid date formats (eg. 8/7/2015) are somehow
+  ;; making it through to the database. This fix will keep
+  ;; the entire feed from breaking Metis while we investigate
+  ;; the issue.
+  (let [format-fn (fn [d] (->> d java.util.Date.
+                               (.format 
+                                (java.text.SimpleDateFormat. 
+                                 "yyyy-MM-dd"))))]
+    (if (and (seq date) (re-find #"\/" date))
+      (format-fn date) date)))

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -17,7 +17,8 @@
     (is (= "2015-06-18-federal-4" (build-public-id "2015-06-18" "federal" "" 4)))
     (is (= "2015-06-18-4" (build-public-id "2015-06-18" "" "" 4)))
     (is (= "federal-4" (build-public-id "" "federal" "" 4)))
-    (is (= "Ohio-4" (build-public-id "" "" "Ohio" 4))))
+    (is (= "Ohio-4" (build-public-id "" "" "Ohio" 4)))
+    (is (= "2015-06-18-federal-Ohio-4" (build-public-id "6/18/2015" "federal" "Ohio" 4))))
   (testing "gives an 'invalid' named id if all of date, election-type and state are nil"
     (is (= "invalid-4" (build-public-id nil nil nil 4)))
     (is (= "invalid-4" (build-public-id "" nil "" 4)))))

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -18,7 +18,8 @@
     (is (= "2015-06-18-4" (build-public-id "2015-06-18" "" "" 4)))
     (is (= "federal-4" (build-public-id "" "federal" "" 4)))
     (is (= "Ohio-4" (build-public-id "" "" "Ohio" 4)))
-    (is (= "2015-06-18-federal-Ohio-4" (build-public-id "6/18/2015" "federal" "Ohio" 4))))
+    (is (= "2015-06-18-federal-Ohio-4" (build-public-id "6/18/2015" "federal" "Ohio" 4)))
+    (is (= "federal-Ohio-4" (build-public-id "" "federal " "Ohio " 4))))
   (testing "gives an 'invalid' named id if all of date, election-type and state are nil"
     (is (= "invalid-4" (build-public-id nil nil nil 4)))
     (is (= "invalid-4" (build-public-id "" nil "" 4)))))

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -19,6 +19,7 @@
     (is (= "federal-4" (build-public-id "" "federal" "" 4)))
     (is (= "Ohio-4" (build-public-id "" "" "Ohio" 4)))
     (is (= "2015-06-18-federal-Ohio-4" (build-public-id "6/18/2015" "federal" "Ohio" 4)))
+    (is (= "federal-Ohio-4" (build-public-id "//////" "federal" "Ohio" 4)))
     (is (= "federal-Ohio-4" (build-public-id "" "federal " "Ohio " 4))))
   (testing "gives an 'invalid' named id if all of date, election-type and state are nil"
     (is (= "invalid-4" (build-public-id nil nil nil 4)))


### PR DESCRIPTION
Fixes formatting for public id and filename. In particular, trims spacing on elements and formats date correctly.