### PR TITLE
Don't try to insert nothing

### DIFF
--- a/src/vip/data_processor/db/util.clj
+++ b/src/vip/data_processor/db/util.clj
@@ -98,7 +98,8 @@
                                             (or (existing-ids id)
                                                 (local-dupe-ids id)))
                                           chunk-values)]
-       (korma/insert sql-table (korma/values chunk-without-dupe-ids))
+       (when (seq chunk-without-dupe-ids)
+         (korma/insert sql-table (korma/values chunk-without-dupe-ids)))
        (reduce (fn [ctx dupe-id]
                  (assoc-in ctx [:fatal table dupe-id :duplicate-ids]
                            ["Duplicate id"]))


### PR DESCRIPTION
Fixes a bug where if, like, an entire bulk import chunk is nothing but duplicate ids, it doesn't try to insert nothing.