### PR TITLE
Strip non-word characters from header names

### DIFF
--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -46,10 +46,11 @@
     (do
       (log/info "Loading" filename)
       (with-open [in-file (io/reader file-to-load :encoding "UTF-8")]
-        (let [headers (-> in-file
-                          .readLine
-                          csv/read-csv
-                          first)
+        (let [headers (->> in-file
+                           .readLine
+                           csv/read-csv
+                           first
+                           (map #(clojure.string/replace % #"\W" "")))
               headers-count (count headers)
               sql-table (get-in ctx [:tables table])
               column-names (map :name columns)

--- a/test-resources/csv/byte-order-marker/source.txt
+++ b/test-resources/csv/byte-order-marker/source.txt
@@ -1,0 +1,2 @@
+﻿name,vip_id,datetime,description,organization_url,feed_contact_id,tou_url,id
+Colorado Secretary of State,8,2014-05-19T12:05:21,"The Secretary of State's office is the source for state election information in Colorado. This feed provides information on election dates, districts, and precinct boundaries",http://www.elections.colorado.gov,,,100

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -92,3 +92,17 @@
                                   (korma/fields :id)
                                   (korma/order :id :ASC)))))
         (assert-error-format out-ctx)))))
+
+(deftest byte-order-marker-test
+  (let [db (sqlite/temp-db "byte-order-marker")
+        ctx (merge {:input (csv-inputs ["byte-order-marker/source.txt"])
+                    :data-specs data-specs}
+                   db)
+        out-ctx (load-csvs ctx)]
+    (testing "loads successfully"
+      (is (= ["Colorado Secretary of State"]
+             (map :name
+                  (korma/select
+                   (get-in out-ctx [:tables :sources])
+                   (korma/fields :name)))))
+      (assert-error-format out-ctx))))


### PR DESCRIPTION
This ends up fixing a problem where a byte order marker would be read as part of a header's name, and should also help other classes of header mistakes (extraneous spaces, accidental hyphens).

Pivotal story: [103447542](https://www.pivotaltracker.com/story/show/103447542)