### PR TITLE
Make CSV filename matching case insensitive

### DIFF
--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -17,7 +17,7 @@
   (.getName file))
 
 (defn good-filename? [file]
-  (let [filename (file-name file)]
+  (let [filename (clojure.string/lower-case (file-name file))]
     (contains? csv-filenames filename)))
 
 (defn-traced remove-bad-filenames [ctx]
@@ -35,7 +35,7 @@
 (defn find-input-file [ctx filename]
   (->> ctx
        :input
-       (filter #(= filename (.getName %)))
+       (filter #(= filename (clojure.string/lower-case (.getName %))))
        first))
 
 (defn-traced bulk-import-and-validate-csv

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -106,3 +106,16 @@
                    (get-in out-ctx [:tables :sources])
                    (korma/fields :name)))))
       (assert-error-format out-ctx))))
+
+(deftest find-input-file-test
+  (let [election-file (File. "/data/election.txt")
+        state-file    (File. "/data/state.txt")
+        upper-case-source (File. "/data/Source.txt")
+        ctx {:input [election-file state-file upper-case-source]}]
+    (testing "finds files from their name"
+      (is (= election-file (find-input-file ctx "election.txt")))
+      (is (= state-file    (find-input-file ctx "state.txt"))))
+    (testing "returns nil if not found"
+      (is (nil? (find-input-file ctx "DOES_NOT_EXIST.txt"))))
+    (testing "finds files without regard to the file's case"
+      (is (= upper-case-source (find-input-file ctx "source.txt"))))))


### PR DESCRIPTION
Allow CSVs to be named "election.txt", "Election.txt", "ELECTION.TXT", or whatever.

Pivotal story: [103614990](https://www.pivotaltracker.com/story/show/103614990)