### PR TITLE
[CS] vip_id is a string of digits, not a number

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -370,7 +370,7 @@
     :stats true
     :columns [{:name "id" :required true :format format/all-digits :coerce coerce-integer}
               {:name "name" :required true}
-              {:name "vip_id" :required true :format format/all-digits :coerce coerce-integer}
+              {:name "vip_id" :required true :format format/all-digits}
               {:name "datetime" :required true :format format/datetime :coerce coerce-date}
               {:name "description"}
               {:name "organization_url" :format format/url}

--- a/test-resources/csv/low-number-vip-id/source.txt
+++ b/test-resources/csv/low-number-vip-id/source.txt
@@ -1,0 +1,2 @@
+name,vip_id,datetime,description,organization_url,feed_contact_id,tou_url,id
+Alabama,01,2015-01-21T18:13:25,It's Alabama!,,,,1

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -119,3 +119,17 @@
       (is (nil? (find-input-file ctx "DOES_NOT_EXIST.txt"))))
     (testing "finds files without regard to the file's case"
       (is (= upper-case-source (find-input-file ctx "source.txt"))))))
+
+(deftest low-number-vip-id-test
+  (let [db (sqlite/temp-db "low-number-vip-id-test")
+        ctx (merge {:input (csv-inputs ["low-number-vip-id/source.txt"])
+                    :data-specs data-specs}
+                   db)
+        out-ctx (load-csvs ctx)]
+    (testing "does not mangle the vip_id"
+      (is (= ["01"]
+             (map :vip_id
+                  (korma/select
+                   (get-in out-ctx [:tables :sources])
+                   (korma/fields :vip_id)))))
+      (assert-error-format out-ctx))))


### PR DESCRIPTION
Fixes a problem where low a vip_id would be converted to a number ("01" -> 1), causing a validation to fail (bad vip_id) erroneously.

Pivotal bug: [105597372](https://www.pivotaltracker.com/story/show/105597372)