### PR TITLE
Use id in format rule check if available

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -401,19 +401,20 @@
                  (instance? clojure.lang.IFn check) check
                  (instance? java.util.regex.Pattern check) (fn [val] (re-find check val))
                  :else (constantly true))]
-    (fn [ctx element id]
-      (let [val (element name)]
+    (fn [ctx element id-or-line-number]
+      (let [identifier (or (get element "id") id-or-line-number)
+            val (element name)]
         (cond
           (empty? val)
           (if required
-            (assoc-in ctx [:fatal scope id name] [(str "Missing " name)])
+            (assoc-in ctx [:fatal scope identifier name] [(str "Missing " name)])
             ctx)
 
           (invalid-utf-8? val)
-          (assoc-in ctx [:errors scope id name] ["Is not valid UTF-8."])
+          (assoc-in ctx [:errors scope identifier name] ["Is not valid UTF-8."])
 
           (not (test-fn val))
-          (assoc-in ctx [:errors scope id name] [(str message ": " val)])
+          (assoc-in ctx [:errors scope identifier name] [(str message ": " val)])
 
           :else ctx)))))
 

--- a/test/vip/data_processor/validation/data_spec_test.clj
+++ b/test/vip/data_processor/validation/data_spec_test.clj
@@ -29,65 +29,81 @@
         (is (= (map (comp class :date) result) [java.sql.Date java.sql.Date nil]))))))
 
 (deftest create-format-rule-test
-  (let [column "id"
+  (let [column "name"
         filename "test.txt"
+        id "3"
         line-number 7
         ctx {}]
-    (testing "required column"
-      (let [format-rule (create-format-rule filename {:name column :required true :format format/all-digits})]
-        (testing "if the required column is missing, adds a fatal error"
-          (let [result-ctx (format-rule ctx {column ""} line-number)]
-            (is (= (ffirst (get-in result-ctx [:fatal filename line-number]))
-                column))))
-        (testing "if the column doesn't have the right format, adds an error"
-          (let [result-ctx (format-rule ctx {column "asdf"} line-number)]
-            (is (= (ffirst (get-in result-ctx [:errors filename line-number]))
-                column))))
-        (testing "if the required column is there and matches the format, is okay"
-          (let [result-ctx (format-rule ctx {column "1234"} line-number)]
-            (is (= ctx result-ctx))))))
-    (testing "optional column"
-      (let [format-rule (create-format-rule filename {:name column :format format/all-digits})]
-        (testing "if it's not there, it's okay"
-          (let [result-ctx (format-rule ctx {} line-number)]
-            (is (= ctx result-ctx))))
-        (testing "if it is there"
-          (testing "it matches the format, everything's okay"
-            (let [result-ctx (format-rule ctx {column "1234"} line-number)]
+    (testing "with an id, uses the id"
+      (testing "required column"
+        (let [format-rule (create-format-rule filename {:name column :required true :format format/all-digits})]
+          (testing "if the required column is missing, adds a fatal error"
+            (let [result-ctx (format-rule ctx {column "" "id" id} line-number)]
+              (is (= (ffirst (get-in result-ctx [:fatal filename id]))
+                     column))))
+          (testing "if the column doesn't have the right format, adds an error"
+            (let [result-ctx (format-rule ctx {column "asdf" "id" id} line-number)]
+              (is (= (ffirst (get-in result-ctx [:errors filename id]))
+                     column))))
+          (testing "if the required column is there and matches the format, is okay"
+            (let [result-ctx (format-rule ctx {column "1234" "id" id} line-number)]
+              (is (= ctx result-ctx))))))
+      (testing "optional column"
+        (let [format-rule (create-format-rule filename {:name column :format format/all-digits})]
+          (testing "if it's not there, it's okay"
+            (let [result-ctx (format-rule ctx {} line-number)]
               (is (= ctx result-ctx))))
-          (testing "it doesn't match the format, you get an error"
+          (testing "if it is there"
+            (testing "it matches the format, everything's okay"
+              (let [result-ctx (format-rule ctx {column "1234" "id" id} line-number)]
+                (is (= ctx result-ctx))))
+            (testing "it doesn't match the format, you get an error"
+              (let [result-ctx (format-rule ctx {column "asdf" "id" id} line-number)]
+                (is (= (ffirst (get-in result-ctx [:errors filename id]))
+                       column)))))))
+      (testing "a check that is a list of options"
+        (let [format-rule (create-format-rule filename {:name column :format format/yes-no})]
+          (testing "matches"
+            (is (= ctx (format-rule ctx {column "yes" "id" id} line-number)))
+            (is (= ctx (format-rule ctx {column "no" "id" id} line-number))))
+          (testing "non-matches"
+            (is (= (ffirst (get-in (format-rule ctx {column "YEP!" "id" id} line-number) [:errors filename id]))
+                   column))
+            (is (= (ffirst (get-in (format-rule ctx {column "no way" "id" id} line-number) [:errors filename id]))
+                   column)))
+          (testing "matches of all kinds of cases"
+            (is (= ctx (format-rule ctx {column "YES" "id" id} line-number)))
+            (is (= ctx (format-rule ctx {column "NO" "id" id} line-number)))
+            (is (= ctx (format-rule ctx {column "Yes" "id" id} line-number))))))
+      (testing "a check that is a function"
+        (let [palindrome? (fn [v] (= v (clojure.string/reverse v)))
+              format-rule (create-format-rule filename {:name column :format {:check palindrome? :message "Not a palindrome"}})]
+          (testing "matches"
+            (is (= ctx (format-rule ctx {column "able was I ere I saw elba" "id" id} line-number)))
+            (is (= ctx (format-rule ctx {column "racecar" "id" id} line-number))))
+          (testing "non-matches"
+            (is (= (ffirst (get-in (format-rule ctx {column "abcdefg" "id" id} line-number) [:errors filename id]))
+                   column))
+            (is (= (ffirst (get-in (format-rule ctx {column "cleveland" "id" id} line-number) [:errors filename id]))
+                   column)))))
+      (testing "if there's no check function, everything is okay"
+        (let [format-rule (create-format-rule filename {:name column})]
+          (is (= ctx (format-rule ctx {column "hi" "id" id} line-number)))
+          (is (= ctx (format-rule ctx {"id" id} line-number))))))
+    (testing "without an id, uses the line number"
+      (testing "required column"
+        (let [format-rule (create-format-rule filename {:name column :required true :format format/all-digits})]
+          (testing "if the required column is missing, adds a fatal error"
+            (let [result-ctx (format-rule ctx {column ""} line-number)]
+              (is (= (ffirst (get-in result-ctx [:fatal filename line-number]))
+                     column))))
+          (testing "if the column doesn't have the right format, adds an error"
             (let [result-ctx (format-rule ctx {column "asdf"} line-number)]
               (is (= (ffirst (get-in result-ctx [:errors filename line-number]))
-                  column)))))))
-    (testing "a check that is a list of options"
-      (let [format-rule (create-format-rule filename {:name column :format format/yes-no})]
-        (testing "matches"
-          (is (= ctx (format-rule ctx {column "yes"} line-number)))
-          (is (= ctx (format-rule ctx {column "no"} line-number))))
-        (testing "non-matches"
-          (is (= (ffirst (get-in (format-rule ctx {column "YEP!"} line-number) [:errors filename line-number]))
-              column))
-          (is (= (ffirst (get-in (format-rule ctx {column "no way"} line-number) [:errors filename line-number]))
-                 column)))
-        (testing "matches of all kinds of cases"
-          (is (= ctx (format-rule ctx {column "YES"} line-number)))
-          (is (= ctx (format-rule ctx {column "NO"} line-number)))
-          (is (= ctx (format-rule ctx {column "Yes"} line-number))))))
-    (testing "a check that is a function"
-      (let [palindrome? (fn [v] (= v (clojure.string/reverse v)))
-            format-rule (create-format-rule filename {:name column :format {:check palindrome? :message "Not a palindrome"}})]
-        (testing "matches"
-          (is (= ctx (format-rule ctx {column "able was I ere I saw elba"} line-number)))
-          (is (= ctx (format-rule ctx {column "racecar"} line-number))))
-        (testing "non-matches"
-          (is (= (ffirst (get-in (format-rule ctx {column "abcdefg"} line-number) [:errors filename line-number]))
-              column))
-          (is (= (ffirst (get-in (format-rule ctx {column "cleveland"} line-number) [:errors filename line-number]))
-              column)))))
-    (testing "if there's no check function, everything is okay"
-      (let [format-rule (create-format-rule filename {:name column})]
-        (is (= ctx (format-rule ctx {column "hi"} line-number)))
-        (is (= ctx (format-rule ctx {} line-number)))))))
+                     column))))
+          (testing "if the required column is there and matches the format, is okay"
+            (let [result-ctx (format-rule ctx {column "1234"} line-number)]
+              (is (= ctx result-ctx)))))))))
 
 (deftest invalid-utf-8-test
   (testing "marks any value with a Unicode replacement character as invalid UTF-8 because that's what we assume we get"
@@ -96,7 +112,7 @@
                    (sqlite/temp-db "invalid-utf-8"))
           out-ctx (csv/load-csvs ctx)]
     (testing "reports errors for values with the Unicode replacement character"
-      (is (= (get-in out-ctx [:errors :sources 2 "name"])
+      (is (= (get-in out-ctx [:errors :sources "1" "name"])
              ["Is not valid UTF-8."]))))))
 
 (deftest coerce-integer-test


### PR DESCRIPTION
If an element being checked with a format rule has an `"id"` key, use that as the identifier, otherwise use whatever was passed as `id-or-line-number` (which will presumably be the line number at that point).

Pivotal bug: [105713556](https://www.pivotaltracker.com/story/show/105713556)