### PR TITLE
Election id approval

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -19,7 +19,8 @@
            (data-spec/add-data-specs data-spec/data-specs)
            t/remove-invalid-extensions
            t/xml-csv-branch
-           psql/store-public-id]
+           psql/store-public-id
+           psql/store-election-id]
           db/validations
           xml-output/pipeline
           [psql/insert-validations

--- a/resources/migrations/20151022-000-approval-table.down.sql
+++ b/resources/migrations/20151022-000-approval-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE election_approvals;

--- a/resources/migrations/20151022-000-approval-table.up.sql
+++ b/resources/migrations/20151022-000-approval-table.up.sql
@@ -1,0 +1,2 @@
+CREATE TABLE election_approvals (election_id character varying(255) PRIMARY KEY,
+                                 approved_result_id int REFERENCES results(id));

--- a/resources/migrations/20151026-add-column-election-id-to-results.down.sql
+++ b/resources/migrations/20151026-add-column-election-id-to-results.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE results
+DROP COLUMN election_id;

--- a/resources/migrations/20151026-add-column-election-id-to-results.up.sql
+++ b/resources/migrations/20151026-add-column-election-id-to-results.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE results
+ADD COLUMN election_id character varying(255)
+              REFERENCES election_approvals(election_id);

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -29,7 +29,8 @@
           [(data-spec/add-data-specs data-spec/data-specs)
            t/remove-invalid-extensions
            t/xml-csv-branch
-           psql/store-public-id]
+           psql/store-public-id
+           psql/store-election-id]
           db/validations
           xml-output/pipeline
           [s3/upload-to-s3]

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -38,6 +38,8 @@
     (korma/database results-db))
   (korma/defentity statistics
     (korma/database results-db))
+  (korma/defentity election_approvals
+    (korma/database results-db))
   (def import-entities
     (db.util/make-entities results-db db.util/import-entity-names)))
 

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -21,7 +21,7 @@
                  :migrator "resources/migrations"}))
 
 (declare results-db results
-         validations-db validations
+         validations
          import-entities
          statistics)
 
@@ -31,12 +31,11 @@
   (let [opts (-> :postgres
                  config
                  (assoc :db (config :postgres :database)))]
-    (db/defdb results-db (db/postgres opts))
-    (db/defdb validations-db (db/postgres opts)))
+    (db/defdb results-db (db/postgres opts)))
   (korma/defentity results
     (korma/database results-db))
   (korma/defentity validations
-    (korma/database validations-db))
+    (korma/database results-db))
   (korma/defentity statistics
     (korma/database results-db))
   (def import-entities

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -54,3 +54,12 @@
         (is (= 1 (->> values
                     (filter #(= "bad-format" (:error_type %)))
                     count)))))))
+
+(deftest election-id-test
+  (testing "election-id generation"
+   (is (= "2015-10-10-LOUISIANA-GENERAL"
+          (build-election-id "2015-10-10" "LOUISIANA" "GENERAL")))
+   (is (= "2015-10-10-LOUISIANA-GENERAL"
+          (build-election-id "2015-10-10" "LOUISIANA   " "GENERAL")))
+   (is (nil? (build-election-id "2015-10-10" "LOUISIANA" nil)))
+   (is (nil? (build-election-id "2015-10-10" "" "GENERAL")))))


### PR DESCRIPTION
We need to store a new piece of information called the "election-id". It uniquely identifies an election across all imports. This election-id can be tagged "approved" which we store in the database in a table called election_approvals. We reference that table from the results table by election-id.

[Pivotal Card](https://www.pivotaltracker.com/story/show/103355828)