### PR TITLE
Make the processor less CPU hungry

### DIFF
--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -72,4 +72,4 @@
                                    (log/info "VIP Data Processor shutting down...")
                                    (q/publish {:id id :event "stopping"} "qa-engine.status")
                                    (future-cancel consumer))))
-      (while true))))
+      @consumer)))


### PR DESCRIPTION
`(while true)` churns at ~100% CPU usage, while trying to deref the SQS processing future does not. That future should never deref, so it's safe.

And, if the future throws an exception, the processor will now shut down (whereas before it would just sit there no longer doing work). That's nice.