### PR TITLE
Ignore ballots when checking for duped rows

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -48,6 +48,7 @@
     :table :ballots
     :tag-name :ballot
     :stats true
+    :ignore-duplicate-records true
     :xml-references [{:join-table :ballot-candidates
                       :id "ballot_id"
                       :joined-id "candidate_id"}]

--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -16,7 +16,8 @@
             ctx dupes)))
 
 (defn-traced validate-no-duplicated-rows [{:keys [data-specs] :as ctx}]
-  (reduce dupe-records/validate-no-duplicated-rows-in-table ctx data-specs))
+  (let [tables-to-check (remove :ignore-duplicate-records data-specs)]
+    (reduce dupe-records/validate-no-duplicated-rows-in-table ctx tables-to-check)))
 
 (defn-traced validate-one-record-limit [ctx]
   (record-limit/tables-allow-only-one-record ctx))

--- a/test-resources/csv/duplicate-rows/ballot.txt
+++ b/test-resources/csv/duplicate-rows/ballot.txt
@@ -1,0 +1,4 @@
+referendum_id,custom_ballot_id,write_in,image_url,id
+,,yes,,1
+,,yes,,2
+,,yes,,3

--- a/test-resources/xml/duplicated-rows.xml
+++ b/test-resources/xml/duplicated-rows.xml
@@ -319,6 +319,15 @@ Note that the ID attributes are unique throughout the file.
   <candidate id="90010">
     <name>Runner Solo</name>
   </candidate>
+  <candidate id="900101">
+    <name>Doug Kinney</name>
+  </candidate>
+  <candidate id="900102">
+    <name>Doug Kinney</name>
+  </candidate>
+  <candidate id="900103">
+    <name>Doug Kinney</name>
+  </candidate>
   <referendum id="90011">
     <title>Proposition 37</title>
     <subtitle>A referendum to ban smoking indoors</subtitle>

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -25,7 +25,8 @@
 (deftest validate-no-duplicated-rows-test
   (testing "finds possibly duplicated rows in a table and warns"
     (let [ctx (merge {:input (csv-inputs ["duplicate-rows/candidate.txt"
-                                          "duplicate-rows/ballot_candidate.txt"])
+                                          "duplicate-rows/ballot_candidate.txt"
+                                          "duplicate-rows/ballot.txt"])
                       :pipeline [(data-spec/add-data-specs data-spec/data-specs)
                                  csv/load-csvs
                                  validate-no-duplicated-rows]}
@@ -35,6 +36,9 @@
         (is (get-in out-ctx [:warnings :candidates id :duplicate-rows])))
       (is (= #{{:candidate_id 3100047456987, :ballot_id 410004745} {:candidate_id 3100047466988, :ballot_id 410004746}}
              (set (get-in out-ctx [:warnings :ballot-candidates nil :duplicate-rows]))))
+      (testing "does not add errors for ballots"
+        (doseq [id [1 2 3]]
+          (is (nil? (get-in out-ctx [:warnings :ballots id :duplicate-rows])))))
       (assert-error-format out-ctx))))
 
 (deftest validate-one-record-limit-test

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -152,8 +152,11 @@
                       :pipeline [load-xml db/validate-no-duplicated-rows]}
                      (sqlite/temp-db "duplicated-rows"))
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:warnings :ballots 80000 :duplicate-rows]))
-      (is (get-in out-ctx [:warnings :ballots 80001 :duplicate-rows]))
+      (doseq [id [900101 900102 900103]]
+        (is (get-in out-ctx [:warnings :candidates id :duplicate-rows])))
+      (testing "except for ballots"
+        (doseq [id [80000 80001]]
+          (is (nil? (get-in out-ctx [:warnings :ballots id :duplicate-rows])))))
       (assert-error-format out-ctx))))
 
 (deftest validate-references-test


### PR DESCRIPTION
Add a key to the `ballots` data specification called `:ignore-duplicate-rows`. Then filter out tables with the `:ignore-duplicate-rows` key when checking for duplicate rows.

Pivotal story: [106141074](https://www.pivotaltracker.com/story/show/106141074)