### PR TITLE
Ignore unreferenced contests

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -105,6 +105,7 @@
     :table :contests
     :tag-name :contest
     :stats true
+    :ignore-unreferenced-rows true
     :columns [{:name "id" :required :critical :format format/all-digits :coerce coerce-integer}
               {:name "election_id" :required :critical :format format/all-digits :references :elections :coerce coerce-integer}
               {:name "electoral_district_id" :required :critical :format format/all-digits :references :electoral-districts :coerce coerce-integer}

--- a/src/vip/data_processor/validation/db/reverse_references.clj
+++ b/src/vip/data_processor/validation/db/reverse_references.clj
@@ -61,7 +61,7 @@
     (korma/exec query)))
 
 (defn find-all-referenced-tables [data-specs]
-  (into {} (for [data-spec data-specs
+  (into {} (for [data-spec (remove :ignore-unreferenced-rows data-specs)
                  :let [table (:table data-spec)
                        references (find-referencing-tables table data-specs)]
                  :when (seq references)]

--- a/test-resources/csv/unreferenced-rows/contest.txt
+++ b/test-resources/csv/unreferenced-rows/contest.txt
@@ -1,0 +1,2 @@
+election_id,electoral_district_id,type,partisan,primary_party,electorate_specifications,special,office,filing_closed_date,number_elected,number_voting_for,ballot_id,ballot_placement,id
+30000,60001,general,no,,,no,Unreferenced Contest,1900-01-01,1,1,200001,10,100

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -91,6 +91,7 @@
   (testing "finds rows not referenced"
     (let [ctx (merge {:input (csv-inputs ["unreferenced-rows/ballot.txt"
                                           "unreferenced-rows/candidate.txt"
+                                          "unreferenced-rows/contest.txt"
                                           "unreferenced-rows/ballot_candidate.txt"])
                       :pipeline [(data-spec/add-data-specs data-spec/data-specs)
                                  csv/load-csvs
@@ -101,6 +102,8 @@
       (is (get-in out-ctx [:warnings :ballots 3 :unreferenced-row]))
       (is (get-in out-ctx [:warnings :candidates 13 :unreferenced-row]))
       (is (get-in out-ctx [:warnings :candidates 14 :unreferenced-row]))
+      (testing "except for contests"
+        (is (nil? (get-in out-ctx [:warnings :contests 100 :unreferenced-row]))))
       (assert-error-format out-ctx))))
 
 (deftest validate-no-overlapping-street-segments-test


### PR DESCRIPTION
Contests are routinely unreferenced and it's not a problem. So stop warning about it.

Pivotal story: [106057398](https://www.pivotaltracker.com/story/show/106057398)