### PR TITLE
Insert all the data into the database

### DIFF
--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.db
   (:require [vip.data-processor.validation.db.duplicate-records :as dupe-records]
             [vip.data-processor.validation.db.duplicate-ids :as dupe-ids]
+            [vip.data-processor.validation.db.precinct :as precinct]
             [vip.data-processor.validation.db.references :as refs]
             [vip.data-processor.validation.db.record-limit :as record-limit]
             [vip.data-processor.validation.db.reverse-references :as rev-refs]
@@ -61,4 +62,5 @@
    validate-no-unreferenced-rows
    validate-no-overlapping-street-segments
    validate-election-administration-addresses
+   precinct/validate-no-missing-polling-locations
    fips/validate-valid-source-vip-id])

--- a/src/vip/data_processor/validation/db/precinct.clj
+++ b/src/vip/data_processor/validation/db/precinct.clj
@@ -1,0 +1,23 @@
+(ns vip.data-processor.validation.db.precinct
+  (:require [korma.core :as korma]))
+
+(defn validate-no-missing-polling-locations
+  "Precincts are missing a polling location if they are not mail only
+  and don't have a reference in precinct_polling_locations."
+  [ctx]
+  (let [{:keys [precincts precinct-polling-locations]} (:tables ctx)
+        bad-precincts (korma/select
+                       precincts
+                       (korma/fields :id)
+                       (korma/where (or {:mail_only 0}
+                                        {:mail_only nil}))
+                       (korma/where {:id [not-in
+                                          (korma/subselect
+                                           precinct-polling-locations
+                                           (korma/modifier "DISTINCT")
+                                           (korma/fields :precinct_id))]}))]
+    (reduce (fn [ctx bad-precinct-row]
+              (assoc-in ctx [:warnings :precincts
+                             (:id bad-precinct-row) :missing-polling-location]
+                        ["Missing polling location"]))
+            ctx bad-precincts)))

--- a/test-resources/csv/missing-polling-locations/polling_location.txt
+++ b/test-resources/csv/missing-polling-locations/polling_location.txt
@@ -1,0 +1,3 @@
+address_location_name,address_line1,address_line2,address_line3,address_city,address_state,address_zip,directions,polling_hours,photo_url,id
+Macon Vol. Fire Dept.,6377 Old Buckingham Rd,,,Powhatan,VA,23139,,6:00 AM - 7:00 PM,,80000
+ST. MARK MISSIONARY BAPTIST CHURCH,2714 Frederick Blvd,,,Portsmouth,VA,237046818,,6:00 AM - 7:00 PM,,80001

--- a/test-resources/csv/missing-polling-locations/precinct.txt
+++ b/test-resources/csv/missing-polling-locations/precinct.txt
@@ -1,0 +1,5 @@
+name,number,locality_id,ward,mail_only,ballot_style_image_url,id
+Mail Only Precinct,0034,70123,,yes,,1
+Has Polling Locations,0020,70123,,,,2
+Not Mail Only and No Polling Locations,0021,70123,,,,3
+Explicitly Not Mail Only and No Polling Locations,0022,70123,,no,,4

--- a/test-resources/csv/missing-polling-locations/precinct_polling_location.txt
+++ b/test-resources/csv/missing-polling-locations/precinct_polling_location.txt
@@ -1,0 +1,3 @@
+precinct_id,polling_location_id
+2,80000
+2,80001

--- a/test/vip/data_processor/db/util_test.clj
+++ b/test/vip/data_processor/db/util_test.clj
@@ -20,3 +20,15 @@
               key-count (fn [coll] (apply + (map count coll)))
               no-more-than-n-keys? (fn [coll] (>= n (key-count coll)))]
           (is (every? no-more-than-n-keys? chunked)))))))
+
+(deftest hydrate-rows-test
+  (testing "Makes all rows have the same keys (the superset of all keys)"
+    (let [rows [{"id" 1}
+                {"id" 2 "name" "2nd Precinct"}
+                {"id" 3 "mail_only" 1}]
+          hydrated-rows (hydrate-rows rows)]
+      (doseq [key ["id" "name" "mail_only"]
+              row hydrated-rows]
+        (is (contains? row key)))
+      (is (nil? (get (first rows) "name")))
+      (is (nil? (get (first rows) "mail_only"))))))

--- a/test/vip/data_processor/validation/db/precinct_test.clj
+++ b/test/vip/data_processor/validation/db/precinct_test.clj
@@ -1,0 +1,23 @@
+(ns vip.data-processor.validation.db.precinct-test
+  (:require [vip.data-processor.validation.db.precinct :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [clojure.test :refer :all]
+            [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.validation.data-spec :as data-spec]
+            [vip.data-processor.db.sqlite :as sqlite]
+            [vip.data-processor.pipeline :as pipeline]))
+
+(deftest validate-no-missing-polling-locations-test
+  (testing "finds precincts without polling locations"
+    (let [ctx (merge {:input (csv-inputs ["missing-polling-locations/precinct.txt"
+                                          "missing-polling-locations/polling_location.txt"
+                                          "missing-polling-locations/precinct_polling_location.txt"])
+                      :pipeline [(data-spec/add-data-specs data-spec/data-specs)
+                                 csv/load-csvs
+                                 validate-no-missing-polling-locations]}
+                     (sqlite/temp-db "missing-polling-locations"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:warnings :precincts 3 :missing-polling-location]))
+      (is (get-in out-ctx [:warnings :precincts 4 :missing-polling-location]))
+      (is (nil? (get-in out-ctx [:warnings :precincts 2 :missing-polling-location])))
+      (is (nil? (get-in out-ctx [:warnings :precincts 1 :missing-polling-location]))))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -132,7 +132,12 @@
           out-ctx (pipeline/run-pipeline ctx)]
       (is (nil? (:stop out-ctx)))
       (is (nil? (:exception out-ctx)))
-      (assert-no-problems out-ctx []))))
+      (assert-no-problems out-ctx [])
+      (testing "inserts values for columns not in the first element of a type"
+        (let [mail-only-precinct (first
+                                  (korma/select (get-in out-ctx [:tables :precincts])
+                                                (korma/where {:id 10203})))]
+          (is (= 1 (:mail_only mail-only-precinct))))))))
 
 (deftest validate-no-duplicated-ids-test
   (testing "returns an error when there is a duplicated id"


### PR DESCRIPTION
When inserting multiple rows into a database with korma, the keys of the first row determine which columns get values. So if a later row has a key the first one doesn't, the associated value will not be inserted into the database! This is very bad!

This is only an issue with XML importing, since during a CSV import each row (by virtue of how they're constructed) will share all keys with every other row.

This patch updates `bulk-import` to make all rows share all keys. Only the first row could be updated, but I'd like to protect myself if korma started using, say, the last row to figure out which columns to bother with.

No pivotal story. Found during other work.