### PR TITLE
Non-mail precincts need a polling location

### DIFF
--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.db
   (:require [vip.data-processor.validation.db.duplicate-records :as dupe-records]
             [vip.data-processor.validation.db.duplicate-ids :as dupe-ids]
+            [vip.data-processor.validation.db.precinct :as precinct]
             [vip.data-processor.validation.db.references :as refs]
             [vip.data-processor.validation.db.record-limit :as record-limit]
             [vip.data-processor.validation.db.reverse-references :as rev-refs]
@@ -61,4 +62,5 @@
    validate-no-unreferenced-rows
    validate-no-overlapping-street-segments
    validate-election-administration-addresses
+   precinct/validate-no-missing-polling-locations
    fips/validate-valid-source-vip-id])

--- a/src/vip/data_processor/validation/db/precinct.clj
+++ b/src/vip/data_processor/validation/db/precinct.clj
@@ -1,0 +1,23 @@
+(ns vip.data-processor.validation.db.precinct
+  (:require [korma.core :as korma]))
+
+(defn validate-no-missing-polling-locations
+  "Precincts are missing a polling location if they are not mail only
+  and don't have a reference in precinct_polling_locations."
+  [ctx]
+  (let [{:keys [precincts precinct-polling-locations]} (:tables ctx)
+        bad-precincts (korma/select
+                       precincts
+                       (korma/fields :id)
+                       (korma/where (or {:mail_only 0}
+                                        {:mail_only nil}))
+                       (korma/where {:id [not-in
+                                          (korma/subselect
+                                           precinct-polling-locations
+                                           (korma/modifier "DISTINCT")
+                                           (korma/fields :precinct_id))]}))]
+    (reduce (fn [ctx bad-precinct-row]
+              (assoc-in ctx [:warnings :precincts
+                             (:id bad-precinct-row) :missing-polling-location]
+                        ["Missing polling location"]))
+            ctx bad-precincts)))

--- a/test-resources/csv/missing-polling-locations/polling_location.txt
+++ b/test-resources/csv/missing-polling-locations/polling_location.txt
@@ -1,0 +1,3 @@
+address_location_name,address_line1,address_line2,address_line3,address_city,address_state,address_zip,directions,polling_hours,photo_url,id
+Macon Vol. Fire Dept.,6377 Old Buckingham Rd,,,Powhatan,VA,23139,,6:00 AM - 7:00 PM,,80000
+ST. MARK MISSIONARY BAPTIST CHURCH,2714 Frederick Blvd,,,Portsmouth,VA,237046818,,6:00 AM - 7:00 PM,,80001

--- a/test-resources/csv/missing-polling-locations/precinct.txt
+++ b/test-resources/csv/missing-polling-locations/precinct.txt
@@ -2,3 +2,4 @@ name,number,locality_id,ward,mail_only,ballot_style_image_url,id
 Mail Only Precinct,0034,70123,,yes,,1
 Has Polling Locations,0020,70123,,,,2
 Not Mail Only and No Polling Locations,0021,70123,,,,3
+Explicitly Not Mail Only and No Polling Locations,0022,70123,,no,,4

--- a/test-resources/csv/missing-polling-locations/precinct.txt
+++ b/test-resources/csv/missing-polling-locations/precinct.txt
@@ -1,0 +1,4 @@
+name,number,locality_id,ward,mail_only,ballot_style_image_url,id
+Mail Only Precinct,0034,70123,,yes,,1
+Has Polling Locations,0020,70123,,,,2
+Not Mail Only and No Polling Locations,0021,70123,,,,3

--- a/test-resources/csv/missing-polling-locations/precinct_polling_location.txt
+++ b/test-resources/csv/missing-polling-locations/precinct_polling_location.txt
@@ -1,0 +1,3 @@
+precinct_id,polling_location_id
+2,80000
+2,80001

--- a/test/vip/data_processor/validation/db/precinct_test.clj
+++ b/test/vip/data_processor/validation/db/precinct_test.clj
@@ -18,5 +18,6 @@
                      (sqlite/temp-db "missing-polling-locations"))
           out-ctx (pipeline/run-pipeline ctx)]
       (is (get-in out-ctx [:warnings :precincts 3 :missing-polling-location]))
+      (is (get-in out-ctx [:warnings :precincts 4 :missing-polling-location]))
       (is (nil? (get-in out-ctx [:warnings :precincts 2 :missing-polling-location])))
       (is (nil? (get-in out-ctx [:warnings :precincts 1 :missing-polling-location]))))))

--- a/test/vip/data_processor/validation/db/precinct_test.clj
+++ b/test/vip/data_processor/validation/db/precinct_test.clj
@@ -1,0 +1,22 @@
+(ns vip.data-processor.validation.db.precinct-test
+  (:require [vip.data-processor.validation.db.precinct :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [clojure.test :refer :all]
+            [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.validation.data-spec :as data-spec]
+            [vip.data-processor.db.sqlite :as sqlite]
+            [vip.data-processor.pipeline :as pipeline]))
+
+(deftest validate-no-missing-polling-locations-test
+  (testing "finds precincts without polling locations"
+    (let [ctx (merge {:input (csv-inputs ["missing-polling-locations/precinct.txt"
+                                          "missing-polling-locations/polling_location.txt"
+                                          "missing-polling-locations/precinct_polling_location.txt"])
+                      :pipeline [(data-spec/add-data-specs data-spec/data-specs)
+                                 csv/load-csvs
+                                 validate-no-missing-polling-locations]}
+                     (sqlite/temp-db "missing-polling-locations"))
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (get-in out-ctx [:warnings :precincts 3 :missing-polling-location]))
+      (is (nil? (get-in out-ctx [:warnings :precincts 2 :missing-polling-location])))
+      (is (nil? (get-in out-ctx [:warnings :precincts 1 :missing-polling-location]))))))


### PR DESCRIPTION
Adds a warning for every precinct that are not "mail_only" and are not referenced in the `precinct_polling_locations` table.

Pivotal story: [105526462](https://www.pivotaltracker.com/story/show/105526462)

Note: the error text is a front-end concern and will be addressed in Metis.