### PR TITLE
Sub-namespace xml output namespaces for v3.0.

### DIFF
--- a/src/vip/data_processor/db/util.clj
+++ b/src/vip/data_processor/db/util.clj
@@ -127,7 +127,7 @@
     (map (partial hydrate-row ks) rows)))
 
 (defn bulk-import [statement-parameter-limit ctx table rows]
-  (log/info "Bulk importing" (:alias table))
+  (log/info "Bulk importing" (:alias table (:name table)))
   (reduce (fn [ctx rows]
             (if (empty? rows)
               ctx

--- a/src/vip/data_processor/output/v3_0/address.clj
+++ b/src/vip/data_processor/output/v3_0/address.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.address
+(ns vip.data-processor.output.v3-0.address
   (:require [vip.data-processor.output.xml-helpers :refer :all]))
 
 (defn address-parts [address-type object]

--- a/src/vip/data_processor/output/v3_0/ballot.clj
+++ b/src/vip/data_processor/output/v3_0/ballot.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.ballot
+(ns vip.data-processor.output.v3-0.ballot
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/ballot_line_result.clj
+++ b/src/vip/data_processor/output/v3_0/ballot_line_result.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.ballot-line-result
+(ns vip.data-processor.output.v3-0.ballot-line-result
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/ballot_response.clj
+++ b/src/vip/data_processor/output/v3_0/ballot_response.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.ballot-response
+(ns vip.data-processor.output.v3-0.ballot-response
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/candidate.clj
+++ b/src/vip/data_processor/output/v3_0/candidate.clj
@@ -1,5 +1,5 @@
-(ns vip.data-processor.output.candidate
-  (:require [vip.data-processor.output.address :refer [address]]
+(ns vip.data-processor.output.v3-0.candidate
+  (:require [vip.data-processor.output.v3-0.address :refer [address]]
             [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/contest.clj
+++ b/src/vip/data_processor/output/v3_0/contest.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.contest
+(ns vip.data-processor.output.v3-0.contest
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/contest_result.clj
+++ b/src/vip/data_processor/output/v3_0/contest_result.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.contest-result
+(ns vip.data-processor.output.v3-0.contest-result
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/custom_ballot.clj
+++ b/src/vip/data_processor/output/v3_0/custom_ballot.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.custom-ballot
+(ns vip.data-processor.output.v3-0.custom-ballot
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/early_vote_site.clj
+++ b/src/vip/data_processor/output/v3_0/early_vote_site.clj
@@ -1,5 +1,5 @@
-(ns vip.data-processor.output.early-vote-site
-  (:require [vip.data-processor.output.address :refer [address]]
+(ns vip.data-processor.output.v3-0.early-vote-site
+  (:require [vip.data-processor.output.v3-0.address :refer [address]]
             [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/election.clj
+++ b/src/vip/data_processor/output/v3_0/election.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.election
+(ns vip.data-processor.output.v3-0.election
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/election_administration.clj
+++ b/src/vip/data_processor/output/v3_0/election_administration.clj
@@ -1,6 +1,6 @@
-(ns vip.data-processor.output.election-administration
+(ns vip.data-processor.output.v3-0.election-administration
   (:require [vip.data-processor.output.xml-helpers :refer :all]
-            [vip.data-processor.output.address :refer :all]
+            [vip.data-processor.output.v3-0.address :refer :all]
             [korma.core :as korma]))
 
 (defn ->xml [{:keys [id

--- a/src/vip/data_processor/output/v3_0/election_official.clj
+++ b/src/vip/data_processor/output/v3_0/election_official.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.election-official
+(ns vip.data-processor.output.v3-0.election-official
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/electoral_district.clj
+++ b/src/vip/data_processor/output/v3_0/electoral_district.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.electoral-district
+(ns vip.data-processor.output.v3-0.electoral-district
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/locality.clj
+++ b/src/vip/data_processor/output/v3_0/locality.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.locality
+(ns vip.data-processor.output.v3-0.locality
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/polling_location.clj
+++ b/src/vip/data_processor/output/v3_0/polling_location.clj
@@ -1,5 +1,5 @@
-(ns vip.data-processor.output.polling-location
-  (:require [vip.data-processor.output.address :refer [address]]
+(ns vip.data-processor.output.v3-0.polling-location
+  (:require [vip.data-processor.output.v3-0.address :refer [address]]
             [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/precinct.clj
+++ b/src/vip/data_processor/output/v3_0/precinct.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.precinct
+(ns vip.data-processor.output.v3-0.precinct
   (:require [korma.core :as korma]
             [vip.data-processor.output.xml-helpers :refer :all]))
 

--- a/src/vip/data_processor/output/v3_0/precinct_split.clj
+++ b/src/vip/data_processor/output/v3_0/precinct_split.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.precinct-split
+(ns vip.data-processor.output.v3-0.precinct-split
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/referendum.clj
+++ b/src/vip/data_processor/output/v3_0/referendum.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.referendum
+(ns vip.data-processor.output.v3-0.referendum
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/source.clj
+++ b/src/vip/data_processor/output/v3_0/source.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.source
+(ns vip.data-processor.output.v3-0.source
   (:require [korma.core :as korma]
             [vip.data-processor.output.xml-helpers :refer :all]))
 

--- a/src/vip/data_processor/output/v3_0/state.clj
+++ b/src/vip/data_processor/output/v3_0/state.clj
@@ -1,4 +1,4 @@
-(ns vip.data-processor.output.state
+(ns vip.data-processor.output.v3-0.state
   (:require [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/street_segment.clj
+++ b/src/vip/data_processor/output/v3_0/street_segment.clj
@@ -1,6 +1,6 @@
-(ns vip.data-processor.output.street-segment
+(ns vip.data-processor.output.v3-0.street-segment
   (:require [vip.data-processor.db.util :as util]
-            [vip.data-processor.output.address :refer [address]]
+            [vip.data-processor.output.v3-0.address :refer [address]]
             [vip.data-processor.output.xml-helpers :refer :all]
             [korma.core :as korma]))
 

--- a/src/vip/data_processor/output/v3_0/xml.clj
+++ b/src/vip/data_processor/output/v3_0/xml.clj
@@ -1,0 +1,52 @@
+(ns vip.data-processor.output.v3-0.xml
+  (:require [vip.data-processor.output.v3-0.ballot :as ballot]
+            [vip.data-processor.output.v3-0.ballot-line-result :as ballot-line-result]
+            [vip.data-processor.output.v3-0.ballot-response :as ballot-response]
+            [vip.data-processor.output.v3-0.candidate :as candidate]
+            [vip.data-processor.output.v3-0.contest :as contest]
+            [vip.data-processor.output.v3-0.contest-result :as contest-result]
+            [vip.data-processor.output.v3-0.custom-ballot :as custom-ballot]
+            [vip.data-processor.output.v3-0.early-vote-site :as early-vote-site]
+            [vip.data-processor.output.v3-0.election :as election]
+            [vip.data-processor.output.v3-0.election-administration :as election-administration]
+            [vip.data-processor.output.v3-0.election-official :as election-official]
+            [vip.data-processor.output.v3-0.electoral-district :as electoral-district]
+            [vip.data-processor.output.v3-0.locality :as locality]
+            [vip.data-processor.output.v3-0.polling-location :as polling-location]
+            [vip.data-processor.output.v3-0.precinct :as precinct]
+            [vip.data-processor.output.v3-0.precinct-split :as precinct-split]
+            [vip.data-processor.output.v3-0.referendum :as referendum]
+            [vip.data-processor.output.v3-0.source :as source]
+            [vip.data-processor.output.v3-0.state :as state]
+            [vip.data-processor.output.v3-0.street-segment :as street-segment]))
+
+(def xml-node-fns [ballot/xml-nodes
+                   ballot-line-result/xml-nodes
+                   ballot-response/xml-nodes
+                   candidate/xml-nodes
+                   contest/xml-nodes
+                   contest-result/xml-nodes
+                   custom-ballot/xml-nodes
+                   early-vote-site/xml-nodes
+                   election/xml-nodes
+                   election-administration/xml-nodes
+                   election-official/xml-nodes
+                   electoral-district/xml-nodes
+                   locality/xml-nodes
+                   polling-location/xml-nodes
+                   precinct/xml-nodes
+                   precinct-split/xml-nodes
+                   referendum/xml-nodes
+                   source/xml-nodes
+                   state/xml-nodes
+                   street-segment/xml-nodes])
+
+(def vip-object-attrs
+  {:xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+   :xsi:noNamespaceSchemaLocation "http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd"
+   :schemaVersion "3.0"})
+
+(def vip-object
+  {:tag :vip_object
+   :attrs vip-object-attrs
+   :content []})


### PR DESCRIPTION
Segregate the xml output namespaces into a subnamespace to make room for many, many, many new versions.

This is mostly just moving code into new namespaces (renaming files, moving a few things, and renaming usage). There is also a little bit of logic change that we noticed that had to do with outputting a `nil` where we should have defaulted to the table name (in `vip/data_processor/db/util.clj`).


[Pivotal Card](https://www.pivotaltracker.com/story/show/107858778)