### PR TITLE
Determine XML import version and branch

### DIFF
--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -31,7 +31,8 @@
         (assoc :input file))))
 
 (def xml-validations
-  [xml/load-xml])
+  [xml/determine-spec-version
+   xml/branch-on-spec-version])
 
 (def csv-validations
   [csv/remove-bad-filenames


### PR DESCRIPTION
If it's a supported version (just 3.0 for now), load the XML and proceed as usual. Otherwise, stop.