### PR TITLE
Branch on 5.0 csv import

### DIFF
--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -130,3 +130,15 @@
         (assoc ctx :spec-version version)))
     (assoc-in ctx [:fatal :sources :global :missing-csv]
               ["source.txt is missing"])))
+
+(defn unsupported-version [{:keys [spec-version] :as ctx}]
+  (assoc ctx :stop (str "Unsupported CSV version: " spec-version)))
+
+(def version-pipelines
+  {"3.0" [load-csvs]
+   "5.0" [unsupported-version]})
+
+(defn branch-on-spec-version [{:keys [spec-version] :as ctx}]
+  (if-let [pipeline (get version-pipelines spec-version)]
+    (update ctx :pipeline (partial concat pipeline))
+    (unsupported-version ctx)))

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -37,8 +37,9 @@
 (def csv-validations
   [csv/remove-bad-filenames
    csv/error-on-missing-files
+   csv/determine-spec-version
    (csv-files/validate-dependencies csv-files/v3-0-file-dependencies) ; TODO: validate file depenencies based import version
-   csv/load-csvs])
+   csv/branch-on-spec-version])
 
 (defn remove-invalid-extensions [ctx]
   (let [files (:input ctx)

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -137,16 +137,16 @@
     (with-open [reader (util/bom-safe-reader xml-file)]
       (let [vip-object (xml/parse reader)
             version (get-in vip-object [:attrs :schemaVersion])]
-        (assoc ctx :schema-version version)))))
+        (assoc ctx :spec-version version)))))
 
-(defn unsupported-version [{:keys [schema-version] :as ctx}]
-  (assoc ctx :stop (str "Unsupported XML version: " schema-version)))
+(defn unsupported-version [{:keys [spec-version] :as ctx}]
+  (assoc ctx :stop (str "Unsupported XML version: " spec-version)))
 
 (def version-pipelines
   {"3.0" [load-xml]
    "5.0" [unsupported-version]})
 
-(defn branch-on-spec-version [{:keys [schema-version] :as ctx}]
-  (if-let [pipeline (get version-pipelines schema-version)]
+(defn branch-on-spec-version [{:keys [spec-version] :as ctx}]
+  (if-let [pipeline (get version-pipelines spec-version)]
     (update ctx :pipeline (partial concat pipeline))
     (unsupported-version ctx)))

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -137,16 +137,16 @@
     (with-open [reader (util/bom-safe-reader xml-file)]
       (let [vip-object (xml/parse reader)
             version (get-in vip-object [:attrs :schemaVersion])]
-        (assoc ctx :xml-version version)))))
+        (assoc ctx :schema-version version)))))
 
-(defn unsupported-version [{:keys [xml-version] :as ctx}]
-  (assoc ctx :stop (str "Unsupported XML version: " xml-version)))
+(defn unsupported-version [{:keys [schema-version] :as ctx}]
+  (assoc ctx :stop (str "Unsupported XML version: " schema-version)))
 
 (def version-pipelines
   {"3.0" [load-xml]
    "5.0" [unsupported-version]})
 
-(defn branch-on-spec-version [{:keys [xml-version] :as ctx}]
-  (if-let [pipeline (get version-pipelines xml-version)]
+(defn branch-on-spec-version [{:keys [schema-version] :as ctx}]
+  (if-let [pipeline (get version-pipelines schema-version)]
     (update ctx :pipeline (partial concat pipeline))
     (unsupported-version ctx)))

--- a/test-resources/csv/5-0/spec-version/source.txt
+++ b/test-resources/csv/5-0/spec-version/source.txt
@@ -1,0 +1,2 @@
+name,vip_id,date_time,description,organization_uri,feed_contact_information_id,terms_of_use_uri,version,id
+"State Board of Elections, Commonwealth of Virginia",51,2013-10-24T14:25:28,SBE is the official source for Virginia data,http://www.sbe.virginia.gov/,,,5.0,src1

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -4,6 +4,7 @@
             [vip.data-processor.validation.csv :refer :all]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
             [vip.data-processor.db.sqlite :as sqlite]
+            [vip.data-processor.pipeline :as pipeline]
             [korma.core :as korma])
   (:import [java.io File]))
 
@@ -143,3 +144,19 @@
     (let [ctx {:input (csv-inputs ["5-0/spec-version/source.txt"])}
           out-ctx (determine-spec-version ctx)]
       (is (= "5.0" (get out-ctx :spec-version))))))
+
+(deftest branch-on-spec-version-test
+  (testing "adds load-csvs to the front of the pipeline for 3.0 feeds"
+    (let [ctx {:spec-version "3.0"}
+          out-ctx (branch-on-spec-version ctx)]
+      (is (= load-csvs (first (:pipeline out-ctx))))))
+  (testing "stops with unsupported version for 5.0 feeds"
+    (let [ctx {:spec-version "5.0"
+               :pipeline [branch-on-spec-version]}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (.startsWith (:stop out-ctx) "Unsupported CSV version"))))
+  (testing "stops with unsupported version for other versions"
+    (let [ctx {:spec-version "2.0"  ; 2.0 is too old
+               :pipeline [branch-on-spec-version]}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (.startsWith (:stop out-ctx) "Unsupported CSV version")))))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -133,3 +133,13 @@
                    (get-in out-ctx [:tables :sources])
                    (korma/fields :vip_id)))))
       (assert-error-format out-ctx))))
+
+(deftest determine-spec-version-test
+  (testing "finds and assocs the version of the csv feed for 3.0 files"
+    (let [ctx {:input (csv-inputs ["full-good-run/source.txt"])}
+          out-ctx (determine-spec-version ctx)]
+      (is (= "3.0" (get out-ctx :spec-version)))))
+  (testing "finds and assocs the version of the csv feed for 5.0 files"
+    (let [ctx {:input (csv-inputs ["5-0/spec-version/source.txt"])}
+          out-ctx (determine-spec-version ctx)]
+      (is (= "5.0" (get out-ctx :spec-version))))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -273,20 +273,20 @@
   (testing "finds and assocs the schemaVersion of the xml feed"
     (let [ctx {:input (xml-input "full-good-run.xml")}
           out-ctx (determine-spec-version ctx)]
-      (is (= "3.0" (get out-ctx :schema-version))))))
+      (is (= "3.0" (get out-ctx :spec-version))))))
 
 (deftest branch-on-spec-version-test
   (testing "adds load-xml to the front of the pipeline for 3.0 feeds"
-    (let [ctx {:schema-version "3.0"}
+    (let [ctx {:spec-version "3.0"}
           out-ctx (branch-on-spec-version ctx)]
       (is (= load-xml (first (:pipeline out-ctx))))))
   (testing "stops with unsupported version for 5.0 feeds"
-    (let [ctx {:schema-version "5.0"
+    (let [ctx {:spec-version "5.0"
                :pipeline [branch-on-spec-version]}
           out-ctx (pipeline/run-pipeline ctx)]
       (is (.startsWith (:stop out-ctx) "Unsupported XML version"))))
   (testing "stops with unsupported version for other versions"
-    (let [ctx {:schema-version "2.0"  ; 2.0 is too old
+    (let [ctx {:spec-version "2.0"  ; 2.0 is too old
                :pipeline [branch-on-spec-version]}
           out-ctx (pipeline/run-pipeline ctx)]
       (is (.startsWith (:stop out-ctx) "Unsupported XML version")))))

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -273,20 +273,20 @@
   (testing "finds and assocs the schemaVersion of the xml feed"
     (let [ctx {:input (xml-input "full-good-run.xml")}
           out-ctx (determine-spec-version ctx)]
-      (is (= "3.0" (get out-ctx :xml-version))))))
+      (is (= "3.0" (get out-ctx :schema-version))))))
 
 (deftest branch-on-spec-version-test
   (testing "adds load-xml to the front of the pipeline for 3.0 feeds"
-    (let [ctx {:xml-version "3.0"}
+    (let [ctx {:schema-version "3.0"}
           out-ctx (branch-on-spec-version ctx)]
       (is (= load-xml (first (:pipeline out-ctx))))))
   (testing "stops with unsupported version for 5.0 feeds"
-    (let [ctx {:xml-version "5.0"
+    (let [ctx {:schema-version "5.0"
                :pipeline [branch-on-spec-version]}
           out-ctx (pipeline/run-pipeline ctx)]
       (is (.startsWith (:stop out-ctx) "Unsupported XML version"))))
   (testing "stops with unsupported version for other versions"
-    (let [ctx {:xml-version "2.0"  ; 2.0 is too old
+    (let [ctx {:schema-version "2.0"  ; 2.0 is too old
                :pipeline [branch-on-spec-version]}
           out-ctx (pipeline/run-pipeline ctx)]
       (is (.startsWith (:stop out-ctx) "Unsupported XML version")))))


### PR DESCRIPTION
Read spec version from the source.txt file (assuming 3.0 if there's no version—per the story and per the 3.0 CSV not reporting its version), and branch based on the result.

Stops processing on unsupported spec version.

Also, normalize naming between XML and CSV version checking.

Pivotal story: [111607092](https://www.pivotaltracker.com/story/show/111607092)