### PR TITLE
Add xml tree index

### DIFF
--- a/resources/migrations/20160126-create-5-0-xml-import-table.down.sql
+++ b/resources/migrations/20160126-create-5-0-xml-import-table.down.sql
@@ -1,1 +1,0 @@
-DROP TABLE v5_0_xml_values;

--- a/resources/migrations/20160126-create-xml-tree-values-table.down.sql
+++ b/resources/migrations/20160126-create-xml-tree-values-table.down.sql
@@ -1,1 +1,4 @@
+DROP INDEX xml_tree_values_result_path_idx;
+DROP INDEX xml_tree_values_gist_path_idx;
+
 DROP TABLE xml_tree_values;

--- a/resources/migrations/20160126-create-xml-tree-values-table.down.sql
+++ b/resources/migrations/20160126-create-xml-tree-values-table.down.sql
@@ -1,4 +1,3 @@
 DROP INDEX xml_tree_values_result_path_idx;
-DROP INDEX xml_tree_values_gist_path_idx;
 
 DROP TABLE xml_tree_values;

--- a/resources/migrations/20160126-create-xml-tree-values-table.down.sql
+++ b/resources/migrations/20160126-create-xml-tree-values-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE xml_tree_values;

--- a/resources/migrations/20160126-create-xml-tree-values-table.up.sql
+++ b/resources/migrations/20160126-create-xml-tree-values-table.up.sql
@@ -4,3 +4,6 @@ CREATE TABLE xml_tree_values (results_id BIGINT REFERENCES results (id) NOT NULL
                               path ltree NOT NULL,
                               value TEXT,
                               parent_with_id ltree);
+
+CREATE INDEX xml_tree_values_result_path_idx ON xml_tree_values (results_id, path);
+CREATE INDEX xml_tree_values_gist_path_idx ON xml_tree_values USING GIST (path);

--- a/resources/migrations/20160126-create-xml-tree-values-table.up.sql
+++ b/resources/migrations/20160126-create-xml-tree-values-table.up.sql
@@ -1,6 +1,6 @@
-CREATE EXTENSION ltree;
+CREATE EXTENSION IF NOT EXISTS ltree;
 
-CREATE TABLE v5_0_xml_values (results_id BIGINT REFERENCES results (id) NOT NULL,
+CREATE TABLE xml_tree_values (results_id BIGINT REFERENCES results (id) NOT NULL,
                               path ltree NOT NULL,
                               value TEXT,
                               parent_with_id ltree);

--- a/resources/migrations/20160126-create-xml-tree-values-table.up.sql
+++ b/resources/migrations/20160126-create-xml-tree-values-table.up.sql
@@ -6,4 +6,3 @@ CREATE TABLE xml_tree_values (results_id BIGINT REFERENCES results (id) NOT NULL
                               parent_with_id ltree);
 
 CREATE INDEX xml_tree_values_result_path_idx ON xml_tree_values (results_id, path);
-CREATE INDEX xml_tree_values_gist_path_idx ON xml_tree_values USING GIST (path);

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -40,8 +40,8 @@
     (korma/database results-db))
   (korma/defentity election_approvals
     (korma/database results-db))
-  (korma/defentity v5-0-xml-values
-    (korma/table "v5_0_xml_values")
+  (korma/defentity xml-tree-values
+    (korma/table "xml_tree_values")
     (korma/database results-db))
   (def v3-0-import-entities
     (db.util/make-entities "3.0" results-db db.util/import-entity-names)))

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -229,7 +229,7 @@
                                          (update :parent_with_id path->ltree)
                                          (assoc :results_id import-id)))
                                    chunk))))]
-        (korma/insert postgres/v5-0-xml-values
+        (korma/insert postgres/xml-tree-values
                       (korma/values pvs))))))
 
 (defn determine-spec-version [ctx]


### PR DESCRIPTION
Add an indexes on the XML import table to improve queries.

Also, because the table isn't limited to 5.0 feeds, renames `v5_0_xml_values` to `xml_tree_values`.

Why just one index? Well, it appears we only need one. Naturally, a B-Tree index on `(results_id, path)` is used by queries like `SELECT * FROM xml_tree_values WHERE results_id = ? AND path = ?;` directly.

We assumed that adding a GIST index on `path` would help queries like `SELECT * FROM xml_tree_values WHERE results_id = ? AND path ~ ?;`, however a GIST index on that column cannot be part of a multi-column index that includes the `results_id` (because GIST doesn't work on integers). By providing a GIST index on `path`, the query planner uses it, though without being able to constrain the index to to `results_id` first.

On the other hand, without that index, Postgres can use the index on `results_id` to produce a much constrained working set, then filter them for the matches on `path`, which (based on some benchmarking) works better for us. Thus, _not_ indexing it performs better (for this use case, with our kind of data).

Pivotal story: [112938309](https://www.pivotaltracker.com/story/show/112938309)