### PR TITLE
Validate uniqueness of ids in imported 5.0 feeds

### DIFF
--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -50,11 +50,15 @@
     (db.util/make-entities "3.0" results-db db.util/import-entity-names)))
 
 (defn ltree-match
-  "Helper function for generating WHERE clases using ~"
+  "Helper function for generating WHERE clases using ~. Accepts a keyword as a
+  table alias, or a korma entity"
   [table column path]
-  (korma/raw (str (korma.sql.engine/table-alias table)
-                  "." (name column)
-                  " ~ '" path "'")))
+  (let [tablename (if (keyword? table)
+                    (name table)
+                    (korma.sql.engine/table-alias table))]
+    (korma/raw (str tablename
+                    "." (name column)
+                    " ~ '" path "'"))))
 
 (defn start-run [ctx]
   (let [results (korma/insert results

--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -1,5 +1,7 @@
 (ns vip.data-processor.validation.v5
-  (:require [vip.data-processor.validation.v5.email :as email]))
+  (:require [vip.data-processor.validation.v5.email :as email]
+            [vip.data-processor.validation.v5.id :as id]))
 
 (def validations
-  [email/validate-emails])
+  [email/validate-emails
+   id/validate-unique-ids])

--- a/src/vip/data_processor/validation/v5/id.clj
+++ b/src/vip/data_processor/validation/v5/id.clj
@@ -19,5 +19,5 @@
     (reduce (fn [ctx row]
               (let [id (:value row)
                     path (-> row :path .getValue)]
-                (update-in ctx [:fatal :id :duplicates id] conj path)))
+                (assoc-in ctx [:fatal :id :duplicates path] id)))
             ctx duplicate-ids)))

--- a/src/vip/data_processor/validation/v5/id.clj
+++ b/src/vip/data_processor/validation/v5/id.clj
@@ -1,0 +1,23 @@
+(ns vip.data-processor.validation.v5.id
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]))
+
+(defn duplicate-ids [import-id]
+  (korma/select [postgres/xml-tree-values :first]
+    (korma/fields :first.value :first.path)
+    (korma/where {:first.results_id import-id :second.results_id import-id})
+    (korma/where (postgres/ltree-match :first :path "VipObject.0.*.id"))
+    (korma/where (postgres/ltree-match :second :path "VipObject.0.*.id"))
+    (korma/join :inner [postgres/xml-tree-values :second]
+                (and
+                 (= :first.value :second.value)
+                 (not= :first.path :second.path)))))
+
+(defn validate-unique-ids
+  [{:keys [import-id] :as ctx}]
+  (let [duplicate-ids (duplicate-ids import-id)]
+    (reduce (fn [ctx row]
+              (let [id (:value row)
+                    path (-> row :path .getValue)]
+                (update-in ctx [:fatal :id :duplicates id] conj path)))
+            ctx duplicate-ids)))

--- a/test-resources/xml/v5-duplicate-ids.xml
+++ b/test-resources/xml/v5-duplicate-ids.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<VipObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.0" xsi:noNamespaceSchemaLocation="http://votinginfoproject.github.com/vip-specification/vip_spec.xsd">
+  <ElectionAuthority id="super-duper"></ElectionAuthority>
+  <ElectionAuthority id="super-duper"></ElectionAuthority>
+  <ElectionAuthority id="you-nique"></ElectionAuthority>
+  <ElectionAuthority id="mo-nique"></ElectionAuthority>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -17,10 +17,11 @@
         out-ctx (pipeline/run-pipeline ctx)]
 
     (testing "duplicate IDs are flagged"
-      (is (= (set (get-in out-ctx [:fatal :id :duplicates "super-duper"]))
-             #{"VipObject.0.ElectionAuthority.0.id"
-               "VipObject.0.ElectionAuthority.1.id"})))
+      (is (= (get-in out-ctx [:fatal :id :duplicates "VipObject.0.ElectionAuthority.0.id"])
+             "super-duper"))
+      (is (= (get-in out-ctx [:fatal :id :duplicates "VipObject.0.ElectionAuthority.1.id"])
+             "super-duper")))
 
     (testing "unique IDs are not flagged"
-      (is (not (get-in out-ctx [:fatal :id :duplicated "you-nique"])))
-      (is (not (get-in out-ctx [:fatal :id :duplicated "mo-nique"]))))))
+      (is (not (get-in out-ctx [:fatal :id :duplicated "VipObject.0.ElectionAuthority.2.id"])))
+      (is (not (get-in out-ctx [:fatal :id :duplicated "VipObject.0.ElectionAuthority.3.id"]))))))

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -1,0 +1,26 @@
+(ns vip.data-processor.validation.v5.id-test
+  (:require  [clojure.test :refer :all]
+             [vip.data-processor.pipeline :as pipeline]
+             [vip.data-processor.db.postgres :as psql]
+             [vip.data-processor.validation.xml :refer :all]
+             [vip.data-processor.test-helpers :refer :all]
+             [vip.data-processor.validation.v5.id :as v5.id]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres id-uniqueness-test
+  (let [ctx {:input (xml-input "v5-duplicate-ids.xml")
+             :pipeline [psql/start-run
+                        load-xml-ltree
+                        v5.id/validate-unique-ids]}
+        out-ctx (pipeline/run-pipeline ctx)]
+
+    (testing "duplicate IDs are flagged"
+      (is (= (set (get-in out-ctx [:fatal :id :duplicates "super-duper"]))
+             #{"VipObject.0.ElectionAuthority.0.id"
+               "VipObject.0.ElectionAuthority.1.id"})))
+
+    (testing "unique IDs are not flagged"
+      (is (not (get-in out-ctx [:fatal :id :duplicated "you-nique"])))
+      (is (not (get-in out-ctx [:fatal :id :duplicated "mo-nique"]))))))


### PR DESCRIPTION
Any duplicate IDs will be included under the key `:fatal` in the processing context. We also fixed a problem where Postgres tests in multiple namespaces would not run.

[Pivotal Card](https://www.pivotaltracker.com/story/show/112941181)