### PR TITLE
Import 5.0 validations

### DIFF
--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -9,7 +9,8 @@
             [vip.data-processor.db.statistics :as stats]
             [vip.data-processor.db.util :as db.util]
             [vip.data-processor.util :as util]
-            [vip.data-processor.validation.data-spec :as data-spec]))
+            [vip.data-processor.validation.data-spec :as data-spec])
+  (:import [org.postgresql.util PGobject]))
 
 (defn url []
   (let [{:keys [host port user password database]} (config :postgres)]
@@ -48,6 +49,11 @@
     (korma/database results-db))
   (def v3-0-import-entities
     (db.util/make-entities "3.0" results-db db.util/import-entity-names)))
+
+(defn path->ltree [path]
+  (doto (PGobject.)
+    (.setType "ltree")
+    (.setValue path)))
 
 (defn ltree-match
   "Helper function for generating WHERE clases using ~. Accepts a keyword as a

--- a/src/vip/data_processor/validation/v5/email.clj
+++ b/src/vip/data_processor/validation/v5/email.clj
@@ -14,7 +14,7 @@
               (if (re-find (:check value-format/email)
                            (:value row))
                 ctx
-                (assoc-in ctx
-                          [:errors :email :format (-> row :path .getValue)]
-                          (:value row))))
+                (update-in ctx
+                          [:errors :email (-> row :path .getValue) :format]
+                          conj (:value row))))
             ctx emails)))

--- a/src/vip/data_processor/validation/v5/id.clj
+++ b/src/vip/data_processor/validation/v5/id.clj
@@ -19,5 +19,5 @@
     (reduce (fn [ctx row]
               (let [id (:value row)
                     path (-> row :path .getValue)]
-                (assoc-in ctx [:fatal :id :duplicates path] id)))
+                (update-in ctx [:fatal :id path :duplicates] conj id)))
             ctx duplicate-ids)))

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -7,8 +7,7 @@
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.util :as util]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.v5 :as v5-validations])
-  (:import [org.postgresql.util PGobject]))
+            [vip.data-processor.validation.v5 :as v5-validations]))
 
 (def address-elements
   #{"address"
@@ -209,11 +208,6 @@
                         (:content node))]
      (apply concat attribute-entries child-entries))))
 
-(defn path->ltree [path]
-  (doto (PGobject.)
-    (.setType "ltree")
-    (.setValue path)))
-
 (defn load-xml-ltree
   [ctx]
   (let [xml-file (first (:input ctx))
@@ -226,8 +220,8 @@
                        (map (fn [chunk]
                               (map (fn [path-map]
                                      (-> path-map
-                                         (update :path path->ltree)
-                                         (update :parent_with_id path->ltree)
+                                         (update :path postgres/path->ltree)
+                                         (update :parent_with_id postgres/path->ltree)
                                          (assoc :results_id import-id)))
                                    chunk))))]
         (korma/insert postgres/xml-tree-values

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -228,6 +228,14 @@
           (korma/values pvs))))
     ctx))
 
+(defn load-xml-tree-validations
+  [ctx]
+  (let [results-id (:import-id ctx)
+        errors (postgres/xml-tree-validation-values ctx)]
+    (korma/insert postgres/xml-tree-validations
+      (korma/values errors)))
+  ctx)
+
 (defn determine-spec-version [ctx]
   (let [xml-file (first (:input ctx))]
     (with-open [reader (util/bom-safe-reader xml-file)]
@@ -242,7 +250,8 @@
   {"3.0" [sqlite/attach-sqlite-db
           load-xml]
    "5.0" (concat [load-xml-ltree]
-                 v5-validations/validations)})
+                 v5-validations/validations
+                 [load-xml-tree-validations])})
 
 (defn branch-on-spec-version [{:keys [spec-version] :as ctx}]
   (if-let [pipeline (get version-pipelines spec-version)]

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -55,6 +55,25 @@
                     (filter #(= "bad-format" (:error_type %)))
                     count)))))))
 
+(deftest xml-tree-validation-values-test
+  (testing "generates validates values for 5.0 style errors"
+    (let [ctx {:import-id 25
+               :errors {}
+               :fatal {:id
+                       {"VipObject.0.Election.1.id"
+                        {:duplicate ["ele0001"]}
+                        "VipObject.0.Election.2.id"
+                        {:duplicate ["ele0001"]}}}
+               :warnings {:import
+                          {:global
+                           {:invalid-extensions [".exemell" ".seeesvee"]}}}}
+          values (xml-tree-validation-values ctx)]
+      (is (= 4 (count values)))
+      (is (= 2
+             (->> values
+                  (filter #(= "duplicate" (:error_type %)))
+                  count))))))
+
 (deftest election-id-test
   (testing "election-id generation"
    (is (= "2015-10-10-LOUISIANA-GENERAL"

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -17,11 +17,11 @@
         out-ctx (pipeline/run-pipeline ctx)]
 
     (testing "duplicate IDs are flagged"
-      (is (= (get-in out-ctx [:fatal :id :duplicates "VipObject.0.ElectionAuthority.0.id"])
-             "super-duper"))
-      (is (= (get-in out-ctx [:fatal :id :duplicates "VipObject.0.ElectionAuthority.1.id"])
-             "super-duper")))
+      (is (= (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.0.id" :duplicates])
+             ["super-duper"]))
+      (is (= (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.1.id" :duplicates])
+             ["super-duper"])))
 
     (testing "unique IDs are not flagged"
-      (is (not (get-in out-ctx [:fatal :id :duplicated "VipObject.0.ElectionAuthority.2.id"])))
-      (is (not (get-in out-ctx [:fatal :id :duplicated "VipObject.0.ElectionAuthority.3.id"]))))))
+      (is (not (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.2.id" :duplicates])))
+      (is (not (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.3.id" :duplicates]))))))

--- a/test/vip/data_processor/validation/xml_test_with_postgres.clj
+++ b/test/vip/data_processor/validation/xml_test_with_postgres.clj
@@ -62,7 +62,7 @@
                           load-xml-ltree
                           v5.email/validate-emails]}
           out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:errors :email :format "VipObject.0.Person.0.ContactInformation.0.Email.0"]))
-      (is (get-in out-ctx [:errors :email :format "VipObject.0.Person.1.ContactInformation.0.Email.0"]))
+      (is (get-in out-ctx [:errors :email "VipObject.0.Person.0.ContactInformation.0.Email.0" :format]))
+      (is (get-in out-ctx [:errors :email "VipObject.0.Person.1.ContactInformation.0.Email.0" :format]))
       (testing "but not for good emails"
-        (is (nil? (get-in out-ctx [:errors :email :format "VipObject.0.Person.2.ContactInformation.0.Email.0"])))))))
+        (is (nil? (get-in out-ctx [:errors :email "VipObject.0.Person.2.ContactInformation.0.Email.0" :format])))))))


### PR DESCRIPTION
When there are errors processing a 5.0 feed, save them to the database in a table named `xml_tree_validations`. The form of our error maps has changed, so we've updated existing validations to use the new form.

[Pivotal Card](https://www.pivotaltracker.com/story/show/113391199)