### PR TITLE
Load errors only when errors exist

### DIFF
--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -232,8 +232,9 @@
   [ctx]
   (let [results-id (:import-id ctx)
         errors (postgres/xml-tree-validation-values ctx)]
-    (korma/insert postgres/xml-tree-validations
-      (korma/values errors)))
+    (when-not (empty? errors)
+      (korma/insert postgres/xml-tree-validations
+        (korma/values errors))))
   ctx)
 
 (defn determine-spec-version [ctx]

--- a/test/vip/data_processor/validation/xml_with_postgres_test.clj
+++ b/test/vip/data_processor/validation/xml_with_postgres_test.clj
@@ -55,6 +55,18 @@
                   set)
              #{"\".exemell\"" "\".seeesvee\""}))))
 
+  (testing "when there are no errors, the errors table doesn't grow"
+    (let [ctx {:fatal {}
+               :warnings {:import
+                          {:global
+                           {:invalid-extensions []}}}
+               :errors {}
+               :pipeline [psql/start-run
+                          load-xml-tree-validations]}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (is (= 0 (count (korma/select psql/xml-tree-validations
+                        (korma/where {:results_id (:import-id out-ctx)}))))))))
+
 (deftest ^:postgres validate-emails-test
   (testing "adds errors to the context for badly formatted emails"
     (let [ctx {:input (xml-input "v5-bad-emails.xml")

--- a/test/vip/data_processor/validation/xml_with_postgres_test.clj
+++ b/test/vip/data_processor/validation/xml_with_postgres_test.clj
@@ -18,10 +18,10 @@
                           load-xml-ltree]}
           out-ctx (pipeline/run-pipeline ctx)]
       (is (= (-> (korma/select psql/xml-tree-values
-                     (korma/where {:results_id (:import-id out-ctx)})
-                     (korma/where (psql/ltree-match psql/xml-tree-values
-                                                    :path
-                                                    "VipObject.0.Source.*{1}.VipId.*{1}")))
+                   (korma/where {:results_id (:import-id out-ctx)})
+                   (korma/where (psql/ltree-match psql/xml-tree-values
+                                                  :path
+                                                  "VipObject.0.Source.*{1}.VipId.*{1}")))
                  first
                  :value)
              "51")))))
@@ -49,11 +49,11 @@
                  :error_data)
              "\"ele0001\""))
       (is (= (->> (korma/select psql/xml-tree-validations
-                   (korma/where {:results_id (:import-id out-ctx)
-                                 :path nil}))
-                 (map :error_data)
-                 set)
-             #{"\".exemell\"" "\".seeesvee\""})))))
+                    (korma/where {:results_id (:import-id out-ctx)
+                                  :path nil}))
+                  (map :error_data)
+                  set)
+             #{"\".exemell\"" "\".seeesvee\""}))))
 
 (deftest ^:postgres validate-emails-test
   (testing "adds errors to the context for badly formatted emails"

--- a/test/vip/data_processor/validation/xml_with_postgres_test.clj
+++ b/test/vip/data_processor/validation/xml_with_postgres_test.clj
@@ -57,6 +57,7 @@
 
   (testing "when there are no errors, the errors table doesn't grow"
     (let [ctx {:fatal {}
+               :critical {}
                :warnings {:import
                           {:global
                            {:invalid-extensions []}}}


### PR DESCRIPTION
If there are no errors, we'll generate bad SQL and the import process will fail.