### PR TITLE
Validate precincts

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -1,7 +1,8 @@
 (ns vip.data-processor.validation.v5
   (:require [vip.data-processor.validation.v5.candidate :as candidate]
             [vip.data-processor.validation.v5.email :as email]
-            [vip.data-processor.validation.v5.id :as id]))
+            [vip.data-processor.validation.v5.id :as id]
+            [vip.data-processor.validation.v5.precinct :as precinct]))
 
 (def validations
   [candidate/validate-no-missing-ballot-names
@@ -9,4 +10,6 @@
    candidate/validate-post-election-statuses
    email/validate-emails
    id/validate-unique-ids
-   id/validate-no-missing-ids])
+   id/validate-no-missing-ids
+   precinct/validate-no-missing-names
+   precinct/validate-no-missing-locality-ids])

--- a/src/vip/data_processor/validation/v5/candidate.clj
+++ b/src/vip/data_processor/validation/v5/candidate.clj
@@ -1,7 +1,7 @@
 (ns vip.data-processor.validation.v5.candidate
   (:require [korma.core :as korma]
             [vip.data-processor.db.postgres :as postgres]
-            [vip.data-processor.validation.data-spec.value-format :as value-format]))
+            [vip.data-processor.validation.v5.util :as util]))
 
 (defn valid-pre-election-status? [status]
   (#{"filed" "qualified" "withdrawn" "write-in"} (:value status)))
@@ -38,32 +38,14 @@
                          conj (:value row)))
             ctx invalid-statuses)))
 
-(def missing-ballot-name-query-string
-  "SELECT xtv.path
+(def validate-no-missing-ballot-names
+  (util/build-xml-tree-value-query-validator
+   :errors :candidates :missing :missing-ballot-name
+   "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'BallotName' AS path
           FROM xml_tree_values WHERE results_id = ?
           AND subltree(path, 0, 4) ~ 'VipObject.0.Candidate.*{1}') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
-    WHERE xtv2.path IS NULL")
-
-(defn missing-ballot-name-query
-  "Generates a query vector for korma's exec-raw to find missing BallotNames."
-  [import-id]
-  [missing-ballot-name-query-string [import-id import-id]])
-
-(defn missing-ballot-names
-  "For an import, find all the BallotName paths that should exist but don't."
-  [import-id]
-  (korma/exec-raw
-   (:conn postgres/xml-tree-values)
-   (missing-ballot-name-query import-id)
-   :results))
-
-(defn validate-no-missing-ballot-names [{:keys [import-id] :as ctx}]
-  (->> (missing-ballot-names import-id)
-       (map :path)
-       (reduce (fn [ctx path]
-                 (update-in ctx [:errors :candidates (.getValue path) :missing]
-                            conj :missing-ballot-name))
-               ctx)))
+    WHERE xtv2.path IS NULL"
+   util/two-import-ids))

--- a/src/vip/data_processor/validation/v5/id.clj
+++ b/src/vip/data_processor/validation/v5/id.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.v5.id
   (:require [korma.core :as korma]
-            [vip.data-processor.db.postgres :as postgres]))
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.validation.v5.util :as util]))
 
 (defn duplicate-ids [import-id]
   (korma/select [postgres/xml-tree-values :first]
@@ -22,39 +23,14 @@
                 (update-in ctx [:fatal :id path :duplicates] conj id)))
             ctx duplicate-ids)))
 
-(def missing-id-query-string
-  "A close reading of the 5.0 and 5.1 spec reveals that only direct
-  children of the VipObject element require an id attribute and that
-  *every* direct child of the VipObject requires an id
-  attribute. Thus, this query generates every id path that should
-  exist (in the first subquery), and then left joins against paths
-  that do exist to find the ones that are missing."
-  "SELECT xtv.path
+(def validate-no-missing-ids
+  (util/build-xml-tree-value-query-validator
+   :fatal :id :missing :missing-id
+   "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'id' AS path
           FROM xml_tree_values WHERE results_id = ?
           AND nlevel(subltree(path, 0, 4)) = 4) xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = xtv2.path
-    WHERE xtv2.path IS NULL")
-
-(defn missing-id-query
-  "Generates a query vector for korma's exec-raw to find missing ids."
-  [import-id]
-  [missing-id-query-string [import-id import-id]])
-
-(defn missing-ids
-  "For an import, find all the id paths that should exist but don't."
-  [import-id]
-  (korma/exec-raw
-   (:conn postgres/xml-tree-values)
-   (missing-id-query import-id)
-   :results))
-
-(defn validate-no-missing-ids
-  [{:keys [import-id] :as ctx}]
-  (->> (missing-ids import-id)
-       (map :path)
-       (reduce (fn [ctx path]
-                 (update-in ctx [:fatal :id (.getValue path) :missing]
-                            conj :missing-id))
-               ctx)))
+    WHERE xtv2.path IS NULL"
+   util/two-import-ids))

--- a/src/vip/data_processor/validation/v5/precinct.clj
+++ b/src/vip/data_processor/validation/v5/precinct.clj
@@ -1,0 +1,26 @@
+(ns vip.data-processor.validation.v5.precinct
+  (:require [vip.data-processor.validation.v5.util :as util]))
+
+(def validate-no-missing-names
+  (util/build-xml-tree-value-query-validator
+   :errors :precincts :missing :missing-name
+   "SELECT xtv.path
+    FROM (SELECT DISTINCT subltree(path, 0, 4) || 'Name' AS path
+          FROM xml_tree_values WHERE results_id = ?
+          AND subltree(path, 0, 4) ~ 'VipObject.0.Precinct.*{1}') xtv
+    LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
+    ON xtv.path = subltree(xtv2.path, 0, 5)
+    WHERE xtv2.path IS NULL"
+   util/two-import-ids))
+
+(def validate-no-missing-locality-ids
+  (util/build-xml-tree-value-query-validator
+   :errors :precincts :missing :missing-locality-id
+   "SELECT xtv.path
+    FROM (SELECT DISTINCT subltree(path, 0, 4) || 'LocalityId' AS path
+          FROM xml_tree_values WHERE results_id = ?
+          AND subltree(path, 0, 4) ~ 'VipObject.0.Precinct.*{1}') xtv
+    LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
+    ON xtv.path = subltree(xtv2.path, 0, 5)
+    WHERE xtv2.path IS NULL"
+   util/two-import-ids))

--- a/src/vip/data_processor/validation/v5/util.clj
+++ b/src/vip/data_processor/validation/v5/util.clj
@@ -11,7 +11,7 @@
 (defn build-xml-tree-value-query-validator
   "Generate a validator that adds a validation error for every path in
   the results of the query. The params-fn must be a fn of one argument (the
-  context), which reutrns a vector of params for the query."
+  context) which returns a vector of params for the query."
   [severity scope error-type error-data query params-fn]
   (fn [{:keys [import-id] :as ctx}]
     (let [missing-paths (korma/exec-raw

--- a/src/vip/data_processor/validation/v5/util.clj
+++ b/src/vip/data_processor/validation/v5/util.clj
@@ -1,0 +1,26 @@
+(ns vip.data-processor.validation.v5.util
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]))
+
+(defn two-import-ids
+  "A common params-fn for build-xml-tree-value-query-validator that
+  returns a 2-element vector of the import-id of the context twice."
+  [{:keys [import-id]}]
+  [import-id import-id])
+
+(defn build-xml-tree-value-query-validator
+  "Generate a validator that adds a validation error for every path in
+  the results of the query. The params-fn must be a fn of one argument (the
+  context), which reutrns a vector of params for the query."
+  [severity scope error-type error-data query params-fn]
+  (fn [{:keys [import-id] :as ctx}]
+    (let [missing-paths (korma/exec-raw
+                         (:conn postgres/xml-tree-values)
+                         [query (params-fn ctx)]
+                         :results)]
+      (->> missing-paths
+           (map :path)
+           (reduce (fn [ctx path]
+                     (update-in ctx [severity scope (.getValue path) error-type]
+                                conj error-data))
+                   ctx)))))

--- a/test-resources/xml/v5-precincts.xml
+++ b/test-resources/xml/v5-precincts.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<VipObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.0" xsi:noNamespaceSchemaLocation="http://votinginfoproject.github.com/vip-specification/vip_spec.xsd">
+  <Precinct id="p1"></Precinct>
+  <Precinct id="p2">
+    <Name></Name>
+    <LocalityId>loc01</LocalityId>
+  </Precinct>
+  <Precinct id="p3">
+    <Name>District 2</Name>
+  </Precinct>
+  <Precinct id="p4">
+    <Name>A Fully Good Precinct</Name>
+    <LocalityId>loc02</LocalityId>
+  </Precinct>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/precinct_test.clj
+++ b/test/vip/data_processor/validation/v5/precinct_test.clj
@@ -1,0 +1,36 @@
+(ns vip.data-processor.validation.v5.precinct-test
+  (:require  [clojure.test :refer :all]
+             [vip.data-processor.pipeline :as pipeline]
+             [vip.data-processor.db.postgres :as psql]
+             [vip.data-processor.validation.xml :as xml]
+             [vip.data-processor.test-helpers :refer :all]
+             [vip.data-processor.validation.v5.precinct :as precinct]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-no-missing-names-test
+  (let [ctx {:input (xml-input "v5-precincts.xml")
+             :pipeline [psql/start-run
+                        xml/load-xml-ltree
+                        precinct/validate-no-missing-names]}
+        out-ctx (pipeline/run-pipeline ctx)]
+    (testing "missing Names are flagged"
+      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.0.Name" :missing]))
+      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.1.Name" :missing])))
+    (testing "doesn't for those that aren't"
+      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.2.Name" :missing])))
+      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.3.Name" :missing]))))))
+
+(deftest ^:postgres validate-no-missing-locality-ids-test
+  (let [ctx {:input (xml-input "v5-precincts.xml")
+             :pipeline [psql/start-run
+                        xml/load-xml-ltree
+                        precinct/validate-no-missing-locality-ids]}
+        out-ctx (pipeline/run-pipeline ctx)]
+    (testing "missing LocalityIds are flagged"
+      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.0.LocalityId" :missing]))
+      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.2.LocalityId" :missing])))
+    (testing "doesn't for those that aren't"
+      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.1.LocalityId" :missing])))
+      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.3.LocalityId" :missing]))))))


### PR DESCRIPTION
Validate that `Precinct` elements have `Name` and `LocalityId` children.

Pivotal story: [113421735](https://www.pivotaltracker.com/story/show/113421735)

Additionally, now that "run a query and add an error for every path returned" is a pattern, pull it out and reduce the amount of repeated structure that we started littering these namespaces with.