### PR TITLE
Faster xml type queries

### DIFF
--- a/resources/migrations/20160318-add-simple-path-to-xml-tree-values.down.sql
+++ b/resources/migrations/20160318-add-simple-path-to-xml-tree-values.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX xml_tree_values_result_simple_path_idx;
+
+ALTER TABLE xml_tree_values DROP COLUMN simple_path;

--- a/resources/migrations/20160318-add-simple-path-to-xml-tree-values.up.sql
+++ b/resources/migrations/20160318-add-simple-path-to-xml-tree-values.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE xml_tree_values ADD COLUMN simple_path ltree;
+
+CREATE INDEX xml_tree_values_result_simple_path_idx ON xml_tree_values (results_id, simple_path);

--- a/src/vip/data_processor/validation/v5/election.clj
+++ b/src/vip/data_processor/validation/v5/election.clj
@@ -25,7 +25,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'Date' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.Election.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.Election') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"
@@ -37,7 +37,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'StateId' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.Election.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.Election') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"

--- a/src/vip/data_processor/validation/v5/precinct.clj
+++ b/src/vip/data_processor/validation/v5/precinct.clj
@@ -7,7 +7,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'Name' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.Precinct.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.Precinct') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"
@@ -19,7 +19,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'LocalityId' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.Precinct.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.Precinct') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"

--- a/src/vip/data_processor/validation/v5/retention_contest.clj
+++ b/src/vip/data_processor/validation/v5/retention_contest.clj
@@ -7,7 +7,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'CandidateId' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.RetentionContest.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.RetentionContest') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"

--- a/src/vip/data_processor/validation/v5/source.clj
+++ b/src/vip/data_processor/validation/v5/source.clj
@@ -26,7 +26,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'Name' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.Source.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.Source') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"
@@ -38,7 +38,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'DateTime' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.Source.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.Source') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"
@@ -50,19 +50,17 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'VipId' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.Source.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.Source') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"
    util/two-import-ids))
 
 (defn validate-vip-id-valid-fips [{:keys [import-id] :as ctx}]
-  (let [path "VipObject.0.Source.*{1}.VipId.*{1}"
+  (let [simple-path (postgres/path->ltree "VipObject.Source.VipId")
         vip-ids (korma/select postgres/xml-tree-values
-                              (korma/where {:results_id import-id})
-                              (korma/where
-                               (postgres/ltree-match
-                                postgres/xml-tree-values :path path)))
+                  (korma/where {:results_id import-id
+                                :simple_path simple-path}))
         invalid-vip-ids (remove (comp fips/valid-fips? :value) vip-ids)]
     (reduce (fn [ctx row]
               (update-in ctx

--- a/src/vip/data_processor/validation/v5/state.clj
+++ b/src/vip/data_processor/validation/v5/state.clj
@@ -7,7 +7,7 @@
    "SELECT xtv.path
     FROM (SELECT DISTINCT subltree(path, 0, 4) || 'Name' AS path
           FROM xml_tree_values WHERE results_id = ?
-          AND subltree(path, 0, 4) ~ 'VipObject.0.State.*{1}') xtv
+          AND subltree(simple_path, 0, 2) = 'VipObject.State') xtv
     LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
     ON xtv.path = subltree(xtv2.path, 0, 5)
     WHERE xtv2.path IS NULL"

--- a/src/vip/data_processor/validation/xml/spec.clj
+++ b/src/vip/data_processor/validation/xml/spec.clj
@@ -1,7 +1,8 @@
 (ns vip.data-processor.validation.xml.spec
   (:import [javax.xml.parsers DocumentBuilder DocumentBuilderFactory]
            [javax.xml.xpath XPathFactory XPathConstants])
-  (:require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 (defn spec-resource [version]
   (let [path (str "specs/vip_spec_v" version ".xsd")]
@@ -89,18 +90,16 @@
               (recur (map #(concat lqueries %) forked-paths)
                      xs)))))
 
-(defn path->lquery [path]
+(defn path->simple-path [path]
   (->> path
-       (interleave (repeat "*{1}"))
-       (interpose ".")
        reverse
-       (apply str)))
+       (str/join ".")))
 
-(defn type->lqueries
-  "Generates a list of lqueries to find all elements of type in the
-  version of the specification."
+(defn type->simple-paths
+  "Generates a list of simple-paths to find all elements of type in
+  the version of the specification."
   [type version]
   {:pre [(contains? spec-docs version)]}
   (->> (paths-for-type type version)
        (mapcat explode-paths)
-       (map path->lquery)))
+       (map path->simple-path)))

--- a/test/vip/data_processor/validation/xml/spec_test.clj
+++ b/test/vip/data_processor/validation/xml/spec_test.clj
@@ -2,46 +2,46 @@
   (:require [vip.data-processor.validation.xml.spec :refer :all]
             [clojure.test :refer :all]))
 
-(deftest type->lqueries-test
-  (testing "generates lists of lqueries from a type for a spec"
-    (are [type version expected] (= (set (type->lqueries type version)) expected)
-      "Locality"     "5.0" #{"VipObject.*{1}.Locality.*{1}"}
-      "DistrictType" "5.0" #{"VipObject.*{1}.ElectoralDistrict.*{1}.Type.*{1}"
-                             "VipObject.*{1}.Locality.*{1}.Type.*{1}"}
-      "xs:date"      "3.0" #{"vip_object.*{1}.contest.*{1}.filing_closed_date.*{1}"
-                             "vip_object.*{1}.early_vote_site.*{1}.end_date.*{1}"
-                             "vip_object.*{1}.early_vote_site.*{1}.start_date.*{1}"
-                             "vip_object.*{1}.election.*{1}.absentee_request_deadline.*{1}"
-                             "vip_object.*{1}.election.*{1}.date.*{1}"
-                             "vip_object.*{1}.election.*{1}.registration_deadline.*{1}"}
+(deftest type->simple-paths-test
+  (testing "generates lists of simple paths for a type for a spec"
+    (are [type version expected] (= (set (type->simple-paths type version)) expected)
+      "Locality"     "5.0" #{"VipObject.Locality"}
+      "DistrictType" "5.0" #{"VipObject.ElectoralDistrict.Type"
+                             "VipObject.Locality.Type"}
+      "xs:date"      "3.0" #{"vip_object.contest.filing_closed_date"
+                             "vip_object.early_vote_site.end_date"
+                             "vip_object.early_vote_site.start_date"
+                             "vip_object.election.absentee_request_deadline"
+                             "vip_object.election.date"
+                             "vip_object.election.registration_deadline"}
       ;; The big one
-      "InternationalizedText" "5.0" #{"VipObject.*{1}.BallotMeasureContest.*{1}.ConStatement.*{1}"
-                                      "VipObject.*{1}.BallotMeasureContest.*{1}.EffectOfAbstain.*{1}"
-                                      "VipObject.*{1}.BallotMeasureContest.*{1}.FullText.*{1}"
-                                      "VipObject.*{1}.BallotMeasureContest.*{1}.PassageThreshold.*{1}"
-                                      "VipObject.*{1}.BallotMeasureContest.*{1}.ProStatement.*{1}"
-                                      "VipObject.*{1}.BallotMeasureContest.*{1}.SummaryText.*{1}"
-                                      "VipObject.*{1}.BallotMeasureSelection.*{1}.Selection.*{1}"
-                                      "VipObject.*{1}.Candidate.*{1}.BallotName.*{1}"
-                                      "VipObject.*{1}.Contest.*{1}.BallotSubTitle.*{1}"
-                                      "VipObject.*{1}.Contest.*{1}.BallotTitle.*{1}"
-                                      "VipObject.*{1}.Contest.*{1}.ElectorateSpecification.*{1}"
-                                      "VipObject.*{1}.Election.*{1}.AbsenteeBallotInfo.*{1}"
-                                      "VipObject.*{1}.Election.*{1}.ElectionType.*{1}"
-                                      "VipObject.*{1}.Election.*{1}.Name.*{1}"
-                                      "VipObject.*{1}.Election.*{1}.PollingHours.*{1}"
-                                      "VipObject.*{1}.Election.*{1}.RegistrationInfo.*{1}"
-                                      "VipObject.*{1}.ElectionAdministration.*{1}.Department.*{1}.ContactInformation.*{1}.Hours.*{1}"
-                                      "VipObject.*{1}.ElectionAdministration.*{1}.Department.*{1}.VoterService.*{1}.ContactInformation.*{1}.Hours.*{1}"
-                                      "VipObject.*{1}.ElectionAdministration.*{1}.Department.*{1}.VoterService.*{1}.Description.*{1}"
-                                      "VipObject.*{1}.Office.*{1}.ContactInformation.*{1}.Hours.*{1}"
-                                      "VipObject.*{1}.Office.*{1}.Name.*{1}"
-                                      "VipObject.*{1}.Party.*{1}.Name.*{1}"
-                                      "VipObject.*{1}.Person.*{1}.ContactInformation.*{1}.Hours.*{1}"
-                                      "VipObject.*{1}.Person.*{1}.FullName.*{1}"
-                                      "VipObject.*{1}.Person.*{1}.Profession.*{1}"
-                                      "VipObject.*{1}.Person.*{1}.Title.*{1}"
-                                      "VipObject.*{1}.PollingLocation.*{1}.Directions.*{1}"
-                                      "VipObject.*{1}.PollingLocation.*{1}.Hours.*{1}"
-                                      "VipObject.*{1}.Source.*{1}.Description.*{1}"
-                                      "VipObject.*{1}.Source.*{1}.FeedContactInformation.*{1}.Hours.*{1}"})))
+      "InternationalizedText" "5.0" #{"VipObject.BallotMeasureContest.ConStatement"
+                                      "VipObject.BallotMeasureContest.EffectOfAbstain"
+                                      "VipObject.BallotMeasureContest.FullText"
+                                      "VipObject.BallotMeasureContest.PassageThreshold"
+                                      "VipObject.BallotMeasureContest.ProStatement"
+                                      "VipObject.BallotMeasureContest.SummaryText"
+                                      "VipObject.BallotMeasureSelection.Selection"
+                                      "VipObject.Candidate.BallotName"
+                                      "VipObject.Contest.BallotSubTitle"
+                                      "VipObject.Contest.BallotTitle"
+                                      "VipObject.Contest.ElectorateSpecification"
+                                      "VipObject.Election.AbsenteeBallotInfo"
+                                      "VipObject.Election.ElectionType"
+                                      "VipObject.Election.Name"
+                                      "VipObject.Election.PollingHours"
+                                      "VipObject.Election.RegistrationInfo"
+                                      "VipObject.ElectionAdministration.Department.ContactInformation.Hours"
+                                      "VipObject.ElectionAdministration.Department.VoterService.ContactInformation.Hours"
+                                      "VipObject.ElectionAdministration.Department.VoterService.Description"
+                                      "VipObject.Office.ContactInformation.Hours"
+                                      "VipObject.Office.Name"
+                                      "VipObject.Party.Name"
+                                      "VipObject.Person.ContactInformation.Hours"
+                                      "VipObject.Person.FullName"
+                                      "VipObject.Person.Profession"
+                                      "VipObject.Person.Title"
+                                      "VipObject.PollingLocation.Directions"
+                                      "VipObject.PollingLocation.Hours"
+                                      "VipObject.Source.Description"
+                                      "VipObject.Source.FeedContactInformation.Hours"})))


### PR DESCRIPTION
* Adds a column to `xml_tree_values` called `simple_path`, which is like `path`, but without the indexes (and thus is not good for _identifying_ data, but good for _querying_ data in ways we want to).
* Replaces `type->lqueries` with `type->simple-paths`, because equality checks are faster than `~`.
* Updates current validations that could trivially use `simple_path` to do so.