### PR TITLE
Validate Locality elements

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -9,7 +9,8 @@
             [vip.data-processor.validation.v5.state :as state]
             [vip.data-processor.validation.v5.hours-open :as hours-open]
             [vip.data-processor.validation.v5.election-administration :as election-admin]
-            [vip.data-processor.validation.v5.election :as election]))
+            [vip.data-processor.validation.v5.election :as election]
+            [vip.data-processor.validation.v5.locality :as locality]))
 
 (def validations
   [candidate/validate-no-missing-ballot-names
@@ -35,4 +36,7 @@
    election-admin/validate-voter-service-type-format
    election/validate-one-election
    election/validate-date
-   election/validate-state-id])
+   election/validate-state-id
+   locality/validate-no-missing-names
+   locality/validate-no-missing-state-ids
+   locality/validate-types])

--- a/src/vip/data_processor/validation/v5/locality.clj
+++ b/src/vip/data_processor/validation/v5/locality.clj
@@ -1,0 +1,33 @@
+(ns vip.data-processor.validation.v5.locality
+  (:require [vip.data-processor.validation.v5.util :as util]
+            [vip.data-processor.validation.xml.spec :as spec]
+            [clojure.string :as str]))
+
+(def locality-paths
+  (spec/type->simple-paths "Locality" "5.0"))
+
+(defn clojure-type->xml-type [type]
+  (let [components (-> type name (str/split #"-"))]
+    (str/join (map str/capitalize components))))
+
+(defn build-validators [type import-id]
+  (let [path-element (clojure-type->xml-type type)]
+    (for [p locality-paths]
+      (util/build-xml-tree-value-query-validator
+       :errors :locality :missing (->> type name (str "missing-") keyword)
+       "SELECT xtv.path
+        FROM (SELECT DISTINCT subltree(path, 0, 4) || ? AS path
+              FROM xml_tree_values WHERE results_id = ?
+              AND subltree(simple_path, 0, 2) = text2ltree(?)) xtv
+        LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
+        ON xtv.path = subltree(xtv2.path, 0, 5)
+        WHERE xtv2.path IS NULL"
+       (constantly [path-element import-id p import-id])))))
+
+(defn validate-no-missing-names [{:keys [import-id] :as ctx}]
+  (let [validators (build-validators :name import-id)]
+    (reduce (fn [ctx validator] (validator ctx)) ctx validators)))
+
+(defn validate-no-missing-state-ids [{:keys [import-id] :as ctx}]
+  (let [validators (build-validators :state-id import-id)]
+    (reduce (fn [ctx validator] (validator ctx)) ctx validators)))

--- a/test-resources/xml/v5-localities.xml
+++ b/test-resources/xml/v5-localities.xml
@@ -5,5 +5,11 @@
   <Locality id="l002">
     <Name>I'm a locality!</Name>
     <StateId>state001</StateId>
+    <Type>city</Type>
+  </Locality>
+  <Locality id="l003">
+    <Name>I'm a locality too!</Name>
+    <StateId>state001</StateId>
+    <Type>planet</Type>
   </Locality>
 </VipObject>

--- a/test-resources/xml/v5-localities.xml
+++ b/test-resources/xml/v5-localities.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.0">
+  <Locality id="l001">
+  </Locality>
+  <Locality id="l002">
+    <Name>I'm a locality!</Name>
+    <StateId>state001</StateId>
+  </Locality>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/locality_test.clj
+++ b/test/vip/data_processor/validation/v5/locality_test.clj
@@ -33,3 +33,19 @@
     (testing "state-id present is OK"
       (is (not (get-in out-ctx [:errors :locality
                                 "VipObject.0.Locality.1.StateId" :missing]))))))
+
+(deftest ^:postgres validate-types-test
+  (let [ctx {:input (xml-input "v5-localities.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.locality/validate-types)]
+    (testing "type missing is OK"
+      (is (not (get-in out-ctx [:errors :locality
+                                "VipObject.0.Locality.0.Type" :missing]))))
+    (testing "type present and valid is OK"
+      (is (not (get-in out-ctx [:errors :locality
+                                "VipObject.0.Locality.1.Type.2" :format]))))
+    (testing "type present and invalid is an error"
+      (is (get-in out-ctx [:errors :locality
+                           "VipObject.0.Locality.2.Type.2" :format])))))

--- a/test/vip/data_processor/validation/v5/locality_test.clj
+++ b/test/vip/data_processor/validation/v5/locality_test.clj
@@ -1,0 +1,35 @@
+(ns vip.data-processor.validation.v5.locality-test
+  (:require [vip.data-processor.validation.v5.locality :as v5.locality]
+            [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-no-missing-names-test
+  (let [ctx {:input (xml-input "v5-localities.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.locality/validate-no-missing-names)]
+    (testing "name missing is an error"
+      (is (get-in out-ctx [:errors :locality "VipObject.0.Locality.0.Name"
+                           :missing])))
+    (testing "name present is OK"
+      (is (not (get-in out-ctx [:errors :locality "VipObject.0.Locality.1.Name"
+                                :missing]))))))
+
+(deftest ^:postgres validate-no-missing-state-ids-test
+  (let [ctx {:input (xml-input "v5-localities.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.locality/validate-no-missing-state-ids)]
+    (testing "state-id missing is an error"
+      (is (get-in out-ctx [:errors :locality
+                           "VipObject.0.Locality.0.StateId" :missing])))
+    (testing "state-id present is OK"
+      (is (not (get-in out-ctx [:errors :locality
+                                "VipObject.0.Locality.1.StateId" :missing]))))))


### PR DESCRIPTION
This isn't quite done yet, but I wanted to get it up for review of my general approach to integrating the new type-lookup code and simple paths.

Instead of assuming one element named `Locality` that is a child of `VipObject`, this looks up all elements of the type `Locality` from the schema and runs its validations on them.

[Pivotal card](https://www.pivotaltracker.com/story/show/114351679)