### PR TITLE
let election_type be longer than 20 characters

### DIFF
--- a/resources/migrations/20160325-lengthen-election_type.down.sql
+++ b/resources/migrations/20160325-lengthen-election_type.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE v3_0_elections ALTER COLUMN election_type TYPE VARCHAR(20);

--- a/resources/migrations/20160325-lengthen-election_type.up.sql
+++ b/resources/migrations/20160325-lengthen-election_type.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE v3_0_elections ALTER COLUMN election_type TYPE TEXT;


### PR DESCRIPTION
Some recent feeds have had longer `election_type`s than could be stored. So let's remove the very constricting type with a more liberating one.

There are no other limited `VARCHAR` types in the tables. I checked.