### PR TITLE
Validate Office element

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -12,6 +12,7 @@
             [vip.data-processor.validation.v5.election :as election]
             [vip.data-processor.validation.v5.locality :as locality]
             [vip.data-processor.validation.v5.internationalized-text :as intl-text]
+            [vip.data-processor.validation.v5.district-type :as district-type]
             [vip.data-processor.validation.v5.office :as office]))
 
 (def validations
@@ -41,8 +42,8 @@
    election/validate-state-id
    locality/validate-no-missing-names
    locality/validate-no-missing-state-ids
-   locality/validate-types
    intl-text/validate-no-missing-texts
+   district-type/validate
    office/validate-no-missing-names
    office/validate-no-missing-term-types
    office/validate-term-types])

--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -11,7 +11,8 @@
             [vip.data-processor.validation.v5.election-administration :as election-admin]
             [vip.data-processor.validation.v5.election :as election]
             [vip.data-processor.validation.v5.locality :as locality]
-            [vip.data-processor.validation.v5.internationalized-text :as intl-text]))
+            [vip.data-processor.validation.v5.internationalized-text :as intl-text]
+            [vip.data-processor.validation.v5.office :as office]))
 
 (def validations
   [candidate/validate-no-missing-ballot-names
@@ -41,4 +42,7 @@
    locality/validate-no-missing-names
    locality/validate-no-missing-state-ids
    locality/validate-types
-   intl-text/validate-no-missing-texts])
+   intl-text/validate-no-missing-texts
+   office/validate-no-missing-names
+   office/validate-no-missing-term-types
+   office/validate-term-types])

--- a/src/vip/data_processor/validation/v5/district_type.clj
+++ b/src/vip/data_processor/validation/v5/district_type.clj
@@ -3,4 +3,4 @@
 
 (def validate
   "Validates all DistrictType elements' formats."
-  (util/validate-enum-elements :district-type))
+  (util/validate-enum-elements :district-type :errors))

--- a/src/vip/data_processor/validation/v5/district_type.clj
+++ b/src/vip/data_processor/validation/v5/district_type.clj
@@ -1,0 +1,6 @@
+(ns vip.data-processor.validation.v5.district-type
+  (:require [vip.data-processor.validation.v5.util :as util]))
+
+(def validate
+  "Validates all DistrictType elements' formats."
+  (util/validate-enum-elements :district-type))

--- a/src/vip/data_processor/validation/v5/internationalized_text.clj
+++ b/src/vip/data_processor/validation/v5/internationalized_text.clj
@@ -2,4 +2,4 @@
   (:require [vip.data-processor.validation.v5.util :as util]))
 
 (def validate-no-missing-texts
-  (util/validate-no-missing-elements :internationalized-text :text))
+  (util/validate-no-missing-elements :internationalized-text [:text]))

--- a/src/vip/data_processor/validation/v5/locality.clj
+++ b/src/vip/data_processor/validation/v5/locality.clj
@@ -1,39 +1,10 @@
 (ns vip.data-processor.validation.v5.locality
-  (:require [vip.data-processor.validation.v5.util :as util]
-            [korma.core :as korma]
-            [vip.data-processor.db.postgres :as postgres]
-            [vip.data-processor.validation.xml.spec :as spec]))
-
-(def valid-types
-  #{"city" "city-council" "congressional" "county" "county-concil" "judicial"
-    "municipality" "national" "school" "special" "state" "state-house"
-    "state-senate" "town" "township" "utility" "village" "ward" "water"
-    "other"})
+  (:require [vip.data-processor.validation.v5.util :as util]))
 
 (def validate-no-missing-names
   (util/validate-no-missing-elements :locality [:name]))
 
 (def validate-no-missing-state-ids
-
-(defn valid-type? [type] (valid-types type))
   (util/validate-no-missing-elements :locality [:state-id]))
 
-(defn validate-types [ctx]
-  (let [validators (for [p (spec/type->simple-paths "Locality" "5.0")]
-                     (fn [{:keys [import-id] :as ctx}]
-                       (let [type-path (str p ".Type")
-                             types (korma/select postgres/xml-tree-values
-                                     (korma/where
-                                      {:results_id import-id
-                                       :simple_path (postgres/path->ltree
-                                                     type-path)}))
-                             invalid-types (remove (comp valid-type? :value)
-                                                   types)]
-                         (reduce (fn [ctx row]
-                                   (update-in
-                                    ctx
-                                    [:errors :locality (-> row :path .getValue)
-                                     :format]
-                                    conj (:value row)))
-                                 ctx invalid-types))))]
-    (reduce (fn [ctx validator] (validator ctx)) ctx validators)))
+;; type validation is done in vip.data-processor.validation.v5.district-type

--- a/src/vip/data_processor/validation/v5/locality.clj
+++ b/src/vip/data_processor/validation/v5/locality.clj
@@ -11,12 +11,12 @@
     "other"})
 
 (def validate-no-missing-names
-  (util/validate-no-missing-elements :locality :name))
+  (util/validate-no-missing-elements :locality [:name]))
 
 (def validate-no-missing-state-ids
-  (util/validate-no-missing-elements :locality :state-id))
 
 (defn valid-type? [type] (valid-types type))
+  (util/validate-no-missing-elements :locality [:state-id]))
 
 (defn validate-types [ctx]
   (let [validators (for [p (spec/type->simple-paths "Locality" "5.0")]

--- a/src/vip/data_processor/validation/v5/office.clj
+++ b/src/vip/data_processor/validation/v5/office.clj
@@ -8,4 +8,4 @@
   (util/validate-no-missing-elements :office [:term :type]))
 
 (def validate-term-types
-  (util/validate-enum-elements :office-term-type))
+  (util/validate-enum-elements :office-term-type :errors))

--- a/src/vip/data_processor/validation/v5/office.clj
+++ b/src/vip/data_processor/validation/v5/office.clj
@@ -1,0 +1,11 @@
+(ns vip.data-processor.validation.v5.office
+  (:require [vip.data-processor.validation.v5.util :as util]))
+
+(def validate-no-missing-names
+  (util/validate-no-missing-elements :office [:name]))
+
+(def validate-no-missing-term-types
+  (util/validate-no-missing-elements :office [:term :type]))
+
+(def validate-term-types
+  (util/validate-enum-elements :office-term-type))

--- a/src/vip/data_processor/validation/xml/spec.clj
+++ b/src/vip/data_processor/validation/xml/spec.clj
@@ -119,3 +119,9 @@
   {:pre [(contains? spec-docs version)]}
   (->> (paths-for-type type version)
        (map (partial str/join "."))))
+
+(defn enumeration-values [type version]
+  (let [query (str "//xs:simpleType[@name='" type "']//xs:enumeration")]
+    (->> (query->elements query version)
+         (map #(.getAttribute % "value"))
+         set)))

--- a/test-resources/xml/v5-offices.xml
+++ b/test-resources/xml/v5-offices.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.0">
+  <Office id="o001">
+  </Office>
+  <Office id="o002">
+    <Name>The Office</Name>
+  </Office>
+  <Office id="o003">
+    <Name>The Corner Office</Name>
+    <Term>
+      <Type>full-term</Type>
+    </Term>
+  </Office>
+  <Office id="o004">
+    <Name>The Window Office</Name>
+    <Term>What am I?</Term>
+  </Office>
+  <Office id="o003">
+    <Name>The Corner Office</Name>
+    <Term>
+      <Type>Not a type</Type>
+    </Term>
+  </Office>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/district_type_test.clj
+++ b/test/vip/data_processor/validation/v5/district_type_test.clj
@@ -1,0 +1,28 @@
+(ns vip.data-processor.validation.v5.district-type-test
+  (:require [vip.data-processor.validation.v5.district-type :as v5.district-type]
+            [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-test
+  (testing "Locality elements"
+    (let [ctx {:input (xml-input "v5-localities.xml")}
+          out-ctx (-> ctx
+                      psql/start-run
+                      xml/load-xml-ltree
+                      v5.district-type/validate)]
+      (testing "type missing is OK"
+        (is (not (get-in out-ctx [:errors :locality
+                                  "VipObject.0.Locality.0.Type" :missing]))))
+      (testing "type present and valid is OK"
+        (is (not (get-in out-ctx [:errors :locality
+                                  "VipObject.0.Locality.1.Type.2" :format]))))
+      (testing "type present and invalid is an error"
+        (is (get-in out-ctx [:errors :locality
+                             "VipObject.0.Locality.2.Type.2" :format])))))
+  (testing "ElectoralDistrict elements" ; TODO
+    ))

--- a/test/vip/data_processor/validation/v5/locality_test.clj
+++ b/test/vip/data_processor/validation/v5/locality_test.clj
@@ -33,19 +33,3 @@
     (testing "state-id present is OK"
       (is (not (get-in out-ctx [:errors :locality
                                 "VipObject.0.Locality.1.StateId" :missing]))))))
-
-(deftest ^:postgres validate-types-test
-  (let [ctx {:input (xml-input "v5-localities.xml")}
-        out-ctx (-> ctx
-                    psql/start-run
-                    xml/load-xml-ltree
-                    v5.locality/validate-types)]
-    (testing "type missing is OK"
-      (is (not (get-in out-ctx [:errors :locality
-                                "VipObject.0.Locality.0.Type" :missing]))))
-    (testing "type present and valid is OK"
-      (is (not (get-in out-ctx [:errors :locality
-                                "VipObject.0.Locality.1.Type.2" :format]))))
-    (testing "type present and invalid is an error"
-      (is (get-in out-ctx [:errors :locality
-                           "VipObject.0.Locality.2.Type.2" :format])))))

--- a/test/vip/data_processor/validation/v5/office_test.clj
+++ b/test/vip/data_processor/validation/v5/office_test.clj
@@ -1,0 +1,53 @@
+(ns vip.data-processor.validation.v5.office-test
+  (:require [vip.data-processor.validation.v5.office :as v5.office]
+            [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-no-missing-names-test
+  (let [ctx {:input (xml-input "v5-offices.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.office/validate-no-missing-names)]
+    (testing "name missing is an error"
+      (is (get-in out-ctx [:errors :office "VipObject.0.Office.0.Name"
+                           :missing])))
+    (testing "name present is OK"
+      (is (not (get-in out-ctx [:errors :office "VipObject.0.Office.1.Name"
+                                :missing]))))))
+
+(deftest ^:postgres validate-no-missing-term-types-test
+  (let [ctx {:input (xml-input "v5-offices.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.office/validate-no-missing-term-types)]
+    (testing "term missing is OK"
+      (is (not (get-in out-ctx [:errors :office "VipObject.0.Office.0.Term"
+                                :missing])))
+      (is (not (get-in out-ctx [:errors :office "VipObject.0.Office.1.Term"
+                                :missing]))))
+    (testing "term present w/ type is OK"
+      (is (not (get-in out-ctx [:errors :office "VipObject.0.Office.2.Term.0.Type"
+                                :missing]))))
+    (testing "term present w/o type is an error"
+      (is (get-in out-ctx [:errors :office "VipObject.0.Office.3.Term.1.Type"
+                           :missing])))))
+
+(deftest ^:postgres validate-term-types-test
+  (let [ctx {:input (xml-input "v5-offices.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.office/validate-term-types)]
+    (testing "valid term type is OK"
+      (is (not (get-in out-ctx [:errors :term "VipObject.0.Office.2.Term.1.Type.0"
+                                :format]))))
+    (testing "invalid term type is an error"
+      (is (get-in out-ctx [:errors :term "VipObject.0.Office.4.Term.1.Type.0"
+                           :format])))))


### PR DESCRIPTION
[Pivotal card](https://www.pivotaltracker.com/story/show/114352615)

While writing this I noticed another opportunity for some code centralization, which drove out the `vip.data-processor.validation.v5.util/validate-enum-elements` fn.

After making the Office -> Term -> Type validation use it, I also adapted the other validations already in the target branch to use it too.