### PR TITLE
Validate Party -> Color

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -13,7 +13,8 @@
             [vip.data-processor.validation.v5.locality :as locality]
             [vip.data-processor.validation.v5.internationalized-text :as intl-text]
             [vip.data-processor.validation.v5.district-type :as district-type]
-            [vip.data-processor.validation.v5.office :as office]))
+            [vip.data-processor.validation.v5.office :as office]
+            [vip.data-processor.validation.v5.party :as party]))
 
 (def validations
   [candidate/validate-no-missing-ballot-names
@@ -46,4 +47,5 @@
    district-type/validate
    office/validate-no-missing-names
    office/validate-no-missing-term-types
-   office/validate-term-types])
+   office/validate-term-types
+   party/validate-colors])

--- a/src/vip/data_processor/validation/v5/party.clj
+++ b/src/vip/data_processor/validation/v5/party.clj
@@ -1,0 +1,7 @@
+(ns vip.data-processor.validation.v5.party
+  (:require [vip.data-processor.validation.v5.util :as util]))
+
+(def validate-colors
+  (util/validate-elements :html-color-string
+                          #(re-matches #"\A[0-9a-f]{6}\z" %)
+                          :errors :format))

--- a/test-resources/xml/v5-parties.xml
+++ b/test-resources/xml/v5-parties.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.0">
+  <Party id="p001">
+    <Color>not a color even though ffeedd is one</Color>
+  </Party>
+  <Party id="p002">
+    <Color>33eedd</Color>
+  </Party>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/party_test.clj
+++ b/test/vip/data_processor/validation/v5/party_test.clj
@@ -1,0 +1,22 @@
+(ns vip.data-processor.validation.v5.party-test
+  (:require [vip.data-processor.validation.v5.party :as v5.party]
+            [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-colors-test
+  (let [ctx {:input (xml-input "v5-parties.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.party/validate-colors)]
+    (testing "color invalid is an error"
+      (is (get-in out-ctx [:errors :party "VipObject.0.Party.0.Color.0"
+                           :format])))
+    (testing "color valid is OK"
+      (is (not (get-in out-ctx [:errors :party "VipObject.0.Party.1.Color.0"
+                                :format]))))))


### PR DESCRIPTION
[Pivotal card](https://www.pivotaltracker.com/story/show/114353319)

This is based on the same branch as #146 so I could use the `util/validate-elements` fn from there. But only commit d91587cce4ecd2477eea365944ee0f8221d1e938 and forward are relevant to this PR.