### PR TITLE
The simple street segment validations

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -16,7 +16,8 @@
             [vip.data-processor.validation.v5.district-type :as district-type]
             [vip.data-processor.validation.v5.office :as office]
             [vip.data-processor.validation.v5.party-selection :as party-selection]
-            [vip.data-processor.validation.v5.ordered-contest :as ordered-contest]))
+            [vip.data-processor.validation.v5.ordered-contest :as ordered-contest]
+            [vip.data-processor.validation.v5.street-segment :as street-segment]))
 
 (def validations
   [candidate/validate-no-missing-ballot-names
@@ -53,4 +54,9 @@
    office/validate-no-missing-term-types
    office/validate-term-types
    party-selection/validate-no-missing-party-ids
-   ordered-contest/validate-no-missing-contest-ids])
+   ordered-contest/validate-no-missing-contest-ids
+   street-segment/validate-no-missing-odd-even-both
+   street-segment/validate-odd-even-both-value
+   street-segment/validate-no-missing-city
+   street-segment/validate-no-missing-state
+   street-segment/validate-no-missing-zip])

--- a/src/vip/data_processor/validation/v5/street_segment.clj
+++ b/src/vip/data_processor/validation/v5/street_segment.clj
@@ -1,0 +1,15 @@
+(ns vip.data-processor.validation.v5.street-segment
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.validation.v5.util :as util]
+            [clojure.string :as str]))
+
+(util/validate-no-missing-values :street-segment
+                                 [:odd-even-both]
+                                 [:city]
+                                 [:state]
+                                 [:street-name]
+                                 [:zip])
+
+(def validate-odd-even-both-value
+  (util/validate-enum-elements :oeb-enum :errors))

--- a/src/vip/data_processor/validation/v5/util.clj
+++ b/src/vip/data_processor/validation/v5/util.clj
@@ -100,6 +100,26 @@
                                                   import-id)]
       (reduce (fn [ctx validator] (validator ctx)) ctx validators))))
 
+(defmacro validate-no-missing-values
+  "Create a bunch of validate-no-missing validators at once.
+
+   `(validate-no-missing-values :street-segments [:city] [:state])`
+  defs both validate-no-missing-city and validate-no-missing-state."
+  [element & element-paths]
+  (let [defs (map
+              (fn [element-path]
+                (let [validation-name
+                      (symbol (str
+                               "validate-no-missing-"
+                               (str/join "-" (map name element-path))))]
+                  `(def ~validation-name
+                     (validate-no-missing-elements ~element
+                                                   ~element-path))))
+              element-paths)]
+    `(do ~@defs)))
+
+
+
 (defn elements-for-simple-path
   "Returns all elements in `import-id` whose `simple-path` matches the given
   arg."

--- a/test-resources/xml/v5-street-segment.xml
+++ b/test-resources/xml/v5-street-segment.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.0">
+  <StreetSegment id="ss001">
+  </StreetSegment>
+  <StreetSegment id="ss002">
+    <OddEvenBoth>odd</OddEvenBoth>
+    <StreetName>Bath</StreetName>
+    <City>Santa Barbara</City>
+    <State>CA</State>
+    <Zip>93101</Zip>
+  </StreetSegment>
+  <StreetSegment id="ss003">
+    <OddEvenBoth>even</OddEvenBoth>
+    <StreetName>Bath</StreetName>
+    <City>Santa Barbara</City>
+    <State>CA</State>
+    <Zip>93101</Zip>
+  </StreetSegment>
+  <StreetSegment id="ss004">
+    <OddEvenBoth>both</OddEvenBoth>
+    <StreetName>Bath</StreetName>
+    <City>Santa Barbara</City>
+    <State>CA</State>
+    <Zip>93101</Zip>
+  </StreetSegment>
+  <StreetSegment id="ss005">
+    <OddEvenBoth>non-prime odd numbers</OddEvenBoth>
+    <NameOfStreet>Bath</NameOfStreet>
+    <Township>Santa Barbara</Township>
+    <StateOrTerritory>CA</StateOrTerritory>
+    <ZipPlus4>93101-8816</ZipPlus4>
+  </StreetSegment>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/street_segment_test.clj
+++ b/test/vip/data_processor/validation/v5/street_segment_test.clj
@@ -1,0 +1,123 @@
+(ns vip.data-processor.validation.v5.street-segment-test
+  (:require [vip.data-processor.validation.v5.street-segment :as v5.ss]
+            [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-no-missing-odd-even-both
+  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.ss/validate-no-missing-odd-even-both)]
+    (testing "odd-even-both missing is an error"
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.0.OddEvenBoth" :missing])))
+    (testing "odd-even-both present is OK"
+      (is (not (get-in out-ctx [:errors :street-segment
+                                "VipObject.0.StreetSegment.1.OddEvenBoth"
+                                :missing]))))))
+
+(deftest ^:postgres validate-odd-even-both-value
+  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.ss/validate-odd-even-both-value)]
+    (testing "odd/even/both are good values"
+      (doseq [path ["VipObject.0.StreetSegment.1.OddEvenBoth.0"
+                    "VipObject.0.StreetSegment.2.OddEvenBoth.0"
+                    "VipObject.0.StreetSegment.3.OddEvenBoth.0"]]
+        (assert-no-problems out-ctx
+                            [:street-segment
+                             path
+                             :format])))
+    (testing "anything else is not"
+      (is (get-in out-ctx [:errors
+                           :street-segment
+                           "VipObject.0.StreetSegment.4.OddEvenBoth.0"
+                           :format])))))
+
+(deftest ^:postgres validate-no-missing-city
+  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.ss/validate-no-missing-city)]
+    (testing "city missing is an error"
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.0.City" :missing]))
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.4.City" :missing])))
+    (testing "city present is OK"
+      (doseq [path ["VipObject.0.StreetSegment.1.City"
+                    "VipObject.0.StreetSegment.2.City"
+                    "VipObject.0.StreetSegment.3.City"]]
+        (assert-no-problems out-ctx
+                            [:street-segment
+                             path
+                             :missing])))))
+
+(deftest ^:postgres validate-no-missing-state
+  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.ss/validate-no-missing-state)]
+    (testing "state missing is an error"
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.0.State" :missing]))
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.4.State" :missing])))
+    (testing "state present is OK"
+      (doseq [path ["VipObject.0.StreetSegment.1.State"
+                    "VipObject.0.StreetSegment.2.State"
+                    "VipObject.0.StreetSegment.3.State"]]
+        (assert-no-problems out-ctx
+                            [:street-segment
+                             path
+                             :missing])))))
+
+(deftest ^:postgres validate-no-missing-zip
+  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.ss/validate-no-missing-zip)]
+    (testing "zip missing is an error"
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.0.Zip" :missing]))
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.4.Zip" :missing])))
+    (testing "zip present is OK"
+      (doseq [path ["VipObject.0.StreetSegment.1.Zip"
+                    "VipObject.0.StreetSegment.2.Zip"
+                    "VipObject.0.StreetSegment.3.Zip"]]
+        (assert-no-problems out-ctx
+                            [:street-segment
+                             path
+                             :missing])))))
+
+(deftest ^:postgres validate-no-missing-street-name
+  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.ss/validate-no-missing-street-name)]
+    (testing "street-name missing is an error"
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.0.StreetName" :missing]))
+      (is (get-in out-ctx [:errors :street-segment
+                           "VipObject.0.StreetSegment.4.StreetName" :missing])))
+    (testing "street-name present is OK"
+      (doseq [path ["VipObject.0.StreetSegment.1.StreetName"
+                    "VipObject.0.StreetSegment.2.StreetName"
+                    "VipObject.0.StreetSegment.3.StreetName"]]
+        (assert-no-problems out-ctx
+                            [:street-segment
+                             path
+                             :missing])))))


### PR DESCRIPTION
Pivotal story: [114358811](https://www.pivotaltracker.com/story/show/114358811)

Validate the presence of OddEvenBoth, StreetName, City, State, Zip and the format of OddEvenBoth.

And one macro.