### PR TITLE
Validate PollingLocation elements

### DIFF
--- a/resources/specs/vip_spec_v5.0.xsd
+++ b/resources/specs/vip_spec_v5.0.xsd
@@ -498,6 +498,15 @@
     <xs:attribute name="id" type="xs:ID" use="required" />
   </xs:complexType>
 
+  <xs:complexType name="LatLng">
+    <xs:sequence>
+      <xs:element name="Latitude" type="xs:float" minOccurs="1" maxOccurs="1" />
+      <xs:element name="Longitude" type="xs:float" minOccurs="1" maxOccurs="1" />
+      <xs:element name="Source" type="xs:string" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute name="label" type="xs:string" />
+  </xs:complexType>
+
   <xs:complexType name="PollingLocation">
     <xs:sequence>
       <!-- It is intentional that an address is required. -->
@@ -511,16 +520,7 @@
       <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
       <xs:element name="IsDropBox" type="xs:boolean" minOccurs="0" maxOccurs="1" />
       <xs:element name="IsEarlyVoting" type="xs:boolean" minOccurs="0" maxOccurs="1" />
-      <xs:element name="LatLng" minOccurs="0" maxOccurs="1">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="Latitude" type="xs:float" minOccurs="1" maxOccurs="1" />
-            <xs:element name="Longitude" type="xs:float" minOccurs="1" maxOccurs="1" />
-            <xs:element name="Source" type="xs:string" minOccurs="0" maxOccurs="1" />
-          </xs:sequence>
-          <xs:attribute name="label" type="xs:string" />
-        </xs:complexType>
-      </xs:element>
+      <xs:element name="LatLng" type="LatLng" minOccurs="0" maxOccurs="1" />
       <xs:element name="PhotoUri" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />

--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -18,7 +18,8 @@
             [vip.data-processor.validation.v5.party :as party]
             [vip.data-processor.validation.v5.party-selection :as party-selection]
             [vip.data-processor.validation.v5.ordered-contest :as ordered-contest]
-            [vip.data-processor.validation.v5.street-segment :as street-segment]))
+            [vip.data-processor.validation.v5.street-segment :as street-segment]
+            [vip.data-processor.validation.v5.polling-location :as polling-location]))
 
 (def validations
   [candidate/validate-no-missing-ballot-names
@@ -61,4 +62,9 @@
    street-segment/validate-odd-even-both-value
    street-segment/validate-no-missing-city
    street-segment/validate-no-missing-state
-   street-segment/validate-no-missing-zip])
+   street-segment/validate-no-missing-zip
+   polling-location/validate-no-missing-address-lines
+   polling-location/validate-no-missing-latitudes
+   polling-location/validate-no-missing-longitudes
+   polling-location/validate-latitude
+   polling-location/validate-longitude])

--- a/src/vip/data_processor/validation/v5/party.clj
+++ b/src/vip/data_processor/validation/v5/party.clj
@@ -2,6 +2,6 @@
   (:require [vip.data-processor.validation.v5.util :as util]))
 
 (def validate-colors
-  (util/validate-elements :html-color-string
+  (util/validate-elements :html-color-string []
                           #(re-matches #"\A[0-9a-f]{6}\z" %)
                           :errors :format))

--- a/src/vip/data_processor/validation/v5/polling_location.clj
+++ b/src/vip/data_processor/validation/v5/polling_location.clj
@@ -1,5 +1,24 @@
 (ns vip.data-processor.validation.v5.polling-location
-  (:require [vip.data-processor.validation.v5.util :as util]))
+  (:require [vip.data-processor.validation.v5.util :as util]
+            [clojure.edn :as edn]))
 
 (def validate-no-missing-address-lines
   (util/validate-no-missing-elements :polling-location [:address-line]))
+
+(def validate-no-missing-latitudes
+  (util/validate-no-missing-elements :lat-lng [:latitude]))
+
+(def validate-no-missing-longitudes
+  (util/validate-no-missing-elements :lat-lng [:longitude]))
+
+(def validate-latitude
+  (util/validate-elements :lat-lng
+                          [:latitude]
+                          (comp float? edn/read-string)
+                          :errors :format))
+
+(def validate-longitude
+  (util/validate-elements :lat-lng
+                          [:longitude]
+                          (comp float? edn/read-string)
+                          :errors :format))

--- a/src/vip/data_processor/validation/v5/polling_location.clj
+++ b/src/vip/data_processor/validation/v5/polling_location.clj
@@ -1,0 +1,5 @@
+(ns vip.data-processor.validation.v5.polling-location
+  (:require [vip.data-processor.validation.v5.util :as util]))
+
+(def validate-no-missing-address-lines
+  (util/validate-no-missing-elements :polling-location [:address-line]))

--- a/test-resources/xml/v5-polling-locations.xml
+++ b/test-resources/xml/v5-polling-locations.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.0">
+  <PollingLocation id="pl001">
+  </PollingLocation>
+  <PollingLocation id="pl002">
+    <AddressLine>I'm an address line</AddressLine>
+  </PollingLocation>
+</VipObject>

--- a/test-resources/xml/v5-polling-locations.xml
+++ b/test-resources/xml/v5-polling-locations.xml
@@ -5,4 +5,34 @@
   <PollingLocation id="pl002">
     <AddressLine>I'm an address line</AddressLine>
   </PollingLocation>
+  <PollingLocation id="pl003">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Latitude>39.750016</Latitude>
+      <Longitude>-105.000361</Longitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
+  <PollingLocation id="pl004">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Longitude>-105.000361</Longitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
+  <PollingLocation id="pl005">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Latitude>39.750016</Latitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
+  <PollingLocation id="pl006">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Latitude>invalid latitude</Latitude>
+      <Longitude></Longitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
 </VipObject>

--- a/test/vip/data_processor/validation/v5/polling_location_test.clj
+++ b/test/vip/data_processor/validation/v5/polling_location_test.clj
@@ -22,3 +22,42 @@
       (is (not (get-in out-ctx [:errors :polling-location
                                 "VipObject.0.PollingLocation.1.AddressLine"
                                 :missing]))))))
+
+(deftest ^:postgres validate-latitude-longitude-test
+  (let [ctx {:input (xml-input "v5-polling-locations.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.polling-location/validate-no-missing-latitudes
+                    v5.polling-location/validate-no-missing-longitudes
+                    v5.polling-location/validate-latitude
+                    v5.polling-location/validate-longitude)]
+    (testing "lat-lng missing is OK"
+      (is (not (get-in out-ctx [:errors :lat-lng
+                                "VipObject.0.PollingLocation.0.LatLng"
+                                :missing])))
+      (is (not (get-in out-ctx [:errors :lat-lng
+                                "VipObject.0.PollingLocation.1.LatLng"
+                                :missing]))))
+    (testing "valid lat-lng is OK"
+      (is (not (get-in out-ctx [:errors :lat-lng
+                                "VipObject.0.PollingLocation.2.LatLng.1.Latitude.0"
+                                :format])))
+      (is (not (get-in out-ctx [:errors :lat-lng
+                                "VipObject.0.PollingLocation.2.LatLng.1.Longitude.1"
+                                :format]))))
+    (testing "missing latitude is an error"
+      (is (get-in out-ctx [:errors :lat-lng
+                           "VipObject.0.PollingLocation.3.LatLng.1.Latitude"
+                           :missing])))
+    (testing "missing longitude is an error"
+      (is (get-in out-ctx [:errors :lat-lng
+                           "VipObject.0.PollingLocation.4.LatLng.1.Longitude"
+                           :missing]))
+      (is (get-in out-ctx [:errors :lat-lng
+                           "VipObject.0.PollingLocation.5.LatLng.1.Longitude"
+                           :missing])))
+    (testing "invalid latitude is an error"
+      (is (get-in out-ctx [:errors :lat-lng
+                           "VipObject.0.PollingLocation.5.LatLng.1.Latitude.0"
+                           :format])))))

--- a/test/vip/data_processor/validation/v5/polling_location_test.clj
+++ b/test/vip/data_processor/validation/v5/polling_location_test.clj
@@ -1,0 +1,24 @@
+(ns vip.data-processor.validation.v5.polling-location-test
+  (:require [vip.data-processor.validation.v5.polling-location :as v5.polling-location]
+            [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-no-missing-address-lines-test
+  (let [ctx {:input (xml-input "v5-polling-locations.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.polling-location/validate-no-missing-address-lines)]
+    (testing "address-line missing is an error"
+      (is (get-in out-ctx [:errors :polling-location
+                           "VipObject.0.PollingLocation.0.AddressLine"
+                           :missing])))
+    (testing "address-line present is OK"
+      (is (not (get-in out-ctx [:errors :polling-location
+                                "VipObject.0.PollingLocation.1.AddressLine"
+                                :missing]))))))


### PR DESCRIPTION
[Pivotal card](https://www.pivotaltracker.com/story/show/114353949)

Note that this PR modifies the 5.0 schema! It's equivalent as far as valid XML files go, but it gives the `LatLng` type a name (also `LatLng`) because our schema-based validation generators currently rely on named types.