### PR TITLE
Validate ballot measure contests

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -1,5 +1,6 @@
 (ns vip.data-processor.validation.v5
-  (:require [vip.data-processor.validation.v5.candidate :as candidate]
+  (:require [vip.data-processor.validation.v5.ballot-measure-contest :as ballot-measure-contest]
+            [vip.data-processor.validation.v5.candidate :as candidate]
             [vip.data-processor.validation.v5.email :as email]
             [vip.data-processor.validation.v5.external-identifiers :as external-identifiers]
             [vip.data-processor.validation.v5.id :as id]
@@ -21,7 +22,9 @@
             [vip.data-processor.validation.v5.street-segment :as street-segment]))
 
 (def validations
-  [candidate/validate-no-missing-ballot-names
+  [ballot-measure-contest/validate-ballot-measure-types
+   ballot-measure-contest/validate-no-missing-types
+   candidate/validate-no-missing-ballot-names
    candidate/validate-pre-election-statuses
    candidate/validate-post-election-statuses
    email/validate-emails

--- a/src/vip/data_processor/validation/v5/ballot_measure_contest.clj
+++ b/src/vip/data_processor/validation/v5/ballot_measure_contest.clj
@@ -1,7 +1,5 @@
 (ns vip.data-processor.validation.v5.ballot-measure-contest
-  (:require [vip.data-processor.validation.v5.util :as util]
-            [korma.core :as korma]
-            [vip.data-processor.db.postgres :as postgres]))
+  (:require [vip.data-processor.validation.v5.util :as util]))
 
 (def validate-ballot-measure-types
   (util/validate-enum-elements :ballot-measure-type :errors))

--- a/src/vip/data_processor/validation/v5/ballot_measure_contest.clj
+++ b/src/vip/data_processor/validation/v5/ballot_measure_contest.clj
@@ -1,0 +1,10 @@
+(ns vip.data-processor.validation.v5.ballot-measure-contest
+  (:require [vip.data-processor.validation.v5.util :as util]
+            [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]))
+
+(def validate-ballot-measure-types
+  (util/validate-enum-elements :ballot-measure-type :errors))
+
+(def validate-no-missing-types
+  (util/validate-no-missing-elements :ballot-measure-contest [:type]))

--- a/test-resources/xml/v5-ballot-measure-contests.xml
+++ b/test-resources/xml/v5-ballot-measure-contests.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.0">
+  <BallotMeasureContest id="bmc000">
+  </BallotMeasureContest>
+  <BallotMeasureContest id="bmc001">
+    <Type>Not a real type</Type>
+  </BallotMeasureContest>
+  <BallotMeasureContest id="bmc002">
+    <Type>ballot-measure</Type>
+  </BallotMeasureContest>
+  <BallotMeasureContest id="bmc003">
+    <Type>initiative</Type>
+  </BallotMeasureContest>
+  <BallotMeasureContest id="bmc004">
+    <Type>referendum</Type>
+  </BallotMeasureContest>
+  <BallotMeasureContest id="bmc005">
+    <Type>other</Type>
+  </BallotMeasureContest>
+</VipObject>

--- a/test-resources/xml/v5_sample_feed.xml
+++ b/test-resources/xml/v5_sample_feed.xml
@@ -683,6 +683,7 @@
     <Name>Judicial Retention, Supreme Court</Name>
     <CandidateId>can14444</CandidateId>
     <OfficeId>off20006</OfficeId>
+    <Type>other</Type>
   </RetentionContest>
 
   <!-- The various ballot styles in use by the different precincts. -->
@@ -2192,6 +2193,7 @@
   <!-- Retention Contests -->
   <RetentionContest id="rc0001">
     <CandidateId>can10214</CandidateId>
+    <Type>other</Type>
   </RetentionContest>
   <!-- End of additions for tests -->
 

--- a/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
@@ -1,0 +1,47 @@
+(ns vip.data-processor.validation.v5.ballot-measure-contest-test
+  (:require [vip.data-processor.validation.v5.ballot-measure-contest :as v5.bmc]
+            [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]))
+
+(use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
+
+(deftest ^:postgres validate-no-missing-types-test
+  (let [ctx {:input (xml-input "v5-ballot-measure-contests.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.bmc/validate-no-missing-types)]
+    (testing "type missing is an error"
+      (is (get-in out-ctx [:errors :ballot-measure-contest
+                           "VipObject.0.BallotMeasureContest.0.Type" :missing])))
+    (testing "type present is OK"
+      (doseq [path ["VipObject.0.BallotMeasureContest.1.Type"
+                    "VipObject.0.BallotMeasureContest.2.Type"
+                    "VipObject.0.BallotMeasureContest.3.Type"
+                    "VipObject.0.BallotMeasureContest.4.Type"
+                    "VipObject.0.BallotMeasureContest.5.Type"]]
+        (assert-no-problems out-ctx [:ballot-measure-contest
+                                     path
+                                     :missing])))))
+
+(deftest ^:postgres validate-ballot-measure-types-test
+  (let [ctx {:input (xml-input "v5-ballot-measure-contests.xml")}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.bmc/validate-ballot-measure-types)]
+    (testing "a bad type is an error"
+      (is (get-in out-ctx [:errors :ballot-measure-contest
+                           "VipObject.0.BallotMeasureContest.1.Type.0"
+                           :format])))
+    (testing "a good type is okay"
+      (doseq [path ["VipObject.0.BallotMeasureContest.2.Type.0"
+                    "VipObject.0.BallotMeasureContest.3.Type.0"
+                    "VipObject.0.BallotMeasureContest.4.Type.0"
+                    "VipObject.0.BallotMeasureContest.5.Type.0"]]
+        (assert-no-problems out-ctx [:ballot-measure-contest
+                                     path
+                                     :format])))))


### PR DESCRIPTION
BallotMeasureContests need a Type and it needs to be a valid Type.

And it turns out the sample feed had a problem in this regard. That is fixed.

Pivotal story: [114348619](https://www.pivotaltracker.com/story/show/114348619)