### PR TITLE
Create zip file in a temp directory

### DIFF
--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -53,8 +53,10 @@
   "Uploads the generated xml file to the specified S3 bucket."
   [ctx]
   (let [zip-name (str (zip-filename ctx) ".zip")
-        zip-file (File. zip-name)
-        zip (ZipFile. zip-name)
+        zip-dir (Files/createTempDirectory tmp-path-prefix
+                                           (into-array FileAttribute []))
+        zip-file (File. (.toFile zip-dir) zip-name)
+        zip (ZipFile. zip-file)
         zip-params (doto (ZipParameters.)
                      (.setCompressionLevel
                       Zip4jConstants/DEFLATE_LEVEL_NORMAL))

--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -65,4 +65,4 @@
     (put-object zip-name zip-file)
     (-> ctx
         (assoc :generated-xml-filename zip-name)
-        (update :to-be-cleaned conj zip-file))))
+        (update :to-be-cleaned concat [zip-file zip-dir]))))


### PR DESCRIPTION
Fixes the problem where a zip file can carry over between processing runs of feeds for the same election and causing problems when trying to recreate the zip file.