### PR TITLE
Fix v5 full good run test

### DIFF
--- a/test/vip/data_processor/test_helpers.clj
+++ b/test/vip/data_processor/test_helpers.clj
@@ -22,6 +22,8 @@
   That will check there is nothing
   at [:warnings :missing :ballot], [:errors :missing :ballot], etc."
   [ctx key-path]
+  (is (nil? (:stop ctx)))
+  (is (nil? (:exception ctx)))
   (doseq [problem-type problem-types]
     (is (empty? (get-in ctx (cons problem-type key-path))))))
 

--- a/test/vip/data_processor/validation/v5_test.clj
+++ b/test/vip/data_processor/validation/v5_test.clj
@@ -12,6 +12,7 @@
 (deftest ^:postgres full-good-v5-test
   (let [ctx {:input (xml-input "v5_sample_feed.xml")
              :pipeline (concat [psql/start-run
+                                xml/determine-spec-version
                                 xml/load-xml-ltree]
                                v5/validations)}
         out-ctx (pipeline/run-pipeline ctx)]


### PR DESCRIPTION
There is an assertion that happens somewhere in the validating of xml files that the spec version of the loaded xml is in the known set of versions. We were not setting that in the test. Now we are.

Additionally, since this threw an exception that is caught by the pipeline, the test passed, despite not completing the pipeline. I've updated `assert-no-problems` to also check that the `:stop` and `:exception` keys on the context are nil. That would have caused the test to fail.