### PR TITLE
Update existing tables to match the 5.1 spec

### DIFF
--- a/resources/migrations/20160523-update-to-5-1.down.sql
+++ b/resources/migrations/20160523-update-to-5-1.down.sql
@@ -1,0 +1,57 @@
+ALTER TABLE v5_1_candidates ADD COLUMN sequence_order TEXT;
+
+ALTER TABLE v5_1_ballot_selections DROP COLUMN sequence_order;
+
+ALTER TABLE v5_1_contact_information
+  DROP COLUMN directions,
+  DROP COLUMN lat,
+  DROP COLUMN lng;
+
+ALTER TABLE v5_1_people DROP COLUMN gender;
+
+ALTER TABLE v5_1_offices RENAME COLUMN office_holder_person_ids TO office_holder_person_id;
+ALTER TABLE v5_1_ballot_styles RENAME COLUMN ordered_contest_ids TO ordered_contest_id;
+
+-- IDREFS -> Join table
+ALTER TABLE v5_1_localities DROP COLUMN polling_location_ids;
+ALTER TABLE v5_1_states DROP COLUMN polling_location_ids;
+
+ALTER TABLE v5_1_precincts
+  DROP COLUMN polling_location_ids,
+  DROP COLUMN electoral_district_ids;
+ALTER TABLE v5_1_states DROP COLUMN polling_location_ids;
+
+ALTER TABLE v5_1_candidate_contests
+  DROP COLUMN ballot_selection_ids,
+  RENAME COLUMN office_ids TO office_id,
+  RENAME COLUMN primary_party_ids TO primary_party_id;
+
+CREATE TABLE v5_1_candidate_contest_ballot_selections
+(candidate_contest_id TEXT NOT NULL,
+ ballot_selection_id TEXT NOT NULL,
+ results_id BIGINT REFERENCES results (id) NOT NULL,
+ PRIMARY KEY (results_id, candidate_contest_id, ballot_selection_id));
+
+CREATE TABLE v5_1_precinct_electoral_districts
+(precinct_id TEXT NOT NULL,
+ electoral_district_id TEXT NOT NULL,
+ results_id BIGINT REFERENCES results (id) NOT NULL,
+ PRIMARY KEY (results_id, precinct_id, electoral_district_id));
+
+CREATE TABLE v5_1_precinct_polling_locations
+(precinct_id TEXT NOT NULL,
+ polling_location_id TEXT NOT NULL,
+ results_id BIGINT REFERENCES results (id) NOT NULL,
+ PRIMARY KEY (results_id, precinct_id, polling_location_id));
+
+CREATE TABLE v5_1_locality_polling_locations
+(locality_id TEXT NOT NULL,
+ polling_location_id TEXT NOT NULL,
+ results_id BIGINT REFERENCES results (id) NOT NULL,
+ PRIMARY KEY (results_id, locality_id, polling_location_id));
+
+CREATE TABLE v5_1_state_polling_locations
+(state_id TEXT NOT NULL,
+ polling_location_id TEXT NOT NULL,
+ results_id BIGINT REFERENCES results (id) NOT NULL,
+ PRIMARY KEY (results_id, state_id, polling_location_id));

--- a/resources/migrations/20160523-update-to-5-1.up.sql
+++ b/resources/migrations/20160523-update-to-5-1.up.sql
@@ -1,0 +1,29 @@
+ALTER TABLE v5_1_candidates DROP COLUMN sequence_order;
+
+ALTER TABLE v5_1_ballot_selections ADD COLUMN sequence_order TEXT;
+
+ALTER TABLE v5_1_contact_information
+  ADD COLUMN directions TEXT,
+  ADD COLUMN lat TEXT,
+  ADD COLUMN lng TEXT;
+
+ALTER TABLE v5_1_people ADD COLUMN gender TEXT;
+
+ALTER TABLE v5_1_ballot_styles RENAME COLUMN ordered_contest_id TO ordered_contest_ids;
+ALTER TABLE v5_1_candidate_contests RENAME COLUMN office_id TO office_ids;
+ALTER TABLE v5_1_candidate_contests RENAME COLUMN primary_party_id TO primary_party_ids;
+ALTER TABLE v5_1_offices RENAME COLUMN office_holder_person_id TO office_holder_person_ids;
+
+-- IDREF becomes IDREFS, and we can drop some join tables
+ALTER TABLE v5_1_localities ADD COLUMN polling_location_ids TEXT;
+ALTER TABLE v5_1_states ADD COLUMN polling_location_ids TEXT;
+ALTER TABLE v5_1_candidate_contests ADD COLUMN ballot_selection_ids TEXT;
+ALTER TABLE v5_1_precincts
+  ADD COLUMN electoral_district_ids TEXT,
+  ADD COLUMN polling_location_ids TEXT;
+
+DROP TABLE v5_1_candidate_contest_ballot_selections;
+DROP TABLE v5_1_precinct_electoral_districts;
+DROP TABLE v5_1_precinct_polling_locations;
+DROP TABLE v5_1_locality_polling_locations;
+DROP TABLE v5_1_state_polling_locations;

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -63,16 +63,12 @@
                                              :electoral-districts
                                              :hours-open
                                              :localities
-                                             :locality-polling-locations
                                              :parties
                                              :people
                                              :polling-locations
                                              :precincts
-                                             :precinct-electoral-districts
-                                             :precinct-polling-locations
                                              :sources
                                              :states
-                                             :state-polling-locations
                                              :street-segments]))
   (def v3-0-import-entities
     (db.util/make-entities "3.0" results-db db.util/import-entity-names)))

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -76,17 +76,18 @@
    {:filename "ballot_selection.txt"
     :table :ballot-selections
     :columns [{:name "id"}
-              {:name "ballot_measure_contest_id"}
-              {:name "ballot_measure_contest_selection_id"}
+              {:name "ballot_measure_contest_ids"}
+              {:name "ballot_measure_contest_selection_ids"}
               {:name "text"}
               {:name "candidate_id"}
               {:name "endorsement_party_id"}
-              {:name "is_write_in"}]}
+              {:name "is_write_in"}
+              {:name "sequence_order"}]}
    {:filename "ballot_style.txt"
     :table :ballot-styles
     :columns [{:name "id"}
               {:name "image_uri"}
-              {:name "ordered_contest_id"}
+              {:name "ordered_contest_ids"}
               {:name "party_id"}]}
    {:filename "candidate.txt"
     :table :candidates
@@ -110,6 +111,7 @@
               {:name "abbreviation"}
               {:name "ballot_sub_title"}
               {:name "ballot_title"}
+              ;; {:name "ballot_selection_ids" ;; this is in a join-table named 'candidate-contest-ballot-selections'
               {:name "electoral_district_id"}
               {:name "electorate_specification"}
               {:name "external_identifier_type"}
@@ -121,9 +123,9 @@
               {:name "vote_variation"}
               {:name "other_vote_variation"}
               {:name "number_elected"}
-              {:name "primary_party_id"}
+              {:name "primary_party_ids"}
               {:name "votes_allowed"}
-              {:name "office_id"}]}
+              {:name "office_ids"}]}
    {:filename "department.txt"
     :table :departments
     :columns [{:name "id"}

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -34,7 +34,7 @@
               {:name "filing_deadline"}
               {:name "is_partisan"}
               {:name "name"}
-              {:name "office_holder_person_id"}
+              {:name "office_holder_person_ids"}
               {:name "term_type"}
               {:name "term_start_date"}
               {:name "term_end_date"}]}
@@ -103,7 +103,6 @@
               {:name "person_id"}
               {:name "post_election_status"}
               {:name "pre_election_status"}
-              {:name "sequence_order"}
               {:name "contest_id"}]}
    {:filename "candidate_contest.txt"
     :table :candidate-contests
@@ -111,7 +110,7 @@
               {:name "abbreviation"}
               {:name "ballot_sub_title"}
               {:name "ballot_title"}
-              ;; {:name "ballot_selection_ids" ;; this is in a join-table named 'candidate-contest-ballot-selections'
+              {:name "ballot_selection_ids"}
               {:name "electoral_district_id"}
               {:name "electorate_specification"}
               {:name "external_identifier_type"}
@@ -195,11 +194,8 @@
               {:name "election_administration_id"}
               {:name "external_identifier_type"}
               {:name "external_identifier_othertype"}
-              {:name "external_identifier_value"}]}
-   {:filename "locality_polling_location.txt"
-    :table :locality-polling-locations
-    :columns [{:name "locality_id"}
-              {:name "polling_location_id"}]}
+              {:name "external_identifier_value"}
+              {:name "polling_location_ids"}]}
    {:filename "party.txt"
     :table :parties
     :columns [{:name "id"}
@@ -224,7 +220,8 @@
               {:name "suffix"}
               {:name "title"}
               {:name "profession"}
-              {:name "party_id"}]}
+              {:name "party_id"}
+              {:name "gender"}]}
    {:filename "polling_location.txt"
     :table :polling-locations
     :columns [{:name "id"}
@@ -250,15 +247,9 @@
               {:name "external_identifier_othertype"}
               {:name "external_identifier_value"}
               {:name "precinct_split_name"}
-              {:name "ballot_style_id"}]}
-   {:filename "precinct_electoral_district.txt"
-    :table :precinct-electoral-districts
-    :columns [{:name "precinct_id"}
-              {:name "electoral_district_id"}]}
-   {:filename "precinct_polling_location.txt"
-    :table :precinct-polling-locations
-    :columns [{:name "precinct_id"}
-              {:name "polling_location_id"}]}
+              {:name "ballot_style_id"}
+              {:name "electoral_district_ids"}
+              {:name "polling_location_ids"}]}
    {:filename "source.txt"
     :table :sources
     :columns [{:name "id"}
@@ -277,11 +268,8 @@
               {:name "election_administration_id"}
               {:name "external_identifier_type"}
               {:name "external_identifier_othertype"}
-              {:name "external_identifier_value"}]}
-   {:filename "state_polling_location.txt"
-    :table :state-polling-locations
-    :columns [{:name "polling_location_id"}
-              {:name "state_id"}]}
+              {:name "external_identifier_value"}
+              {:name "polling_location_ids"}]}
    {:filename "street_segment.txt"
     :table :street-segments
     :columns [{:name "id"}

--- a/test-resources/xml/v5-bad-emails.xml
+++ b/test-resources/xml/v5-bad-emails.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-     Sample XML file for Voting Information Project (VIP) Spec Version 5.0
+     Sample XML file for Voting Information Project (VIP) Spec Version 5.1
      Date: 2014-03-21
      File would be named: vipFeed-51-2013-11-05.xml
 
@@ -9,7 +9,7 @@
      For the sake of file size, street segments are not included.
 
     NOTE: The primary goal of the ordering of elements within this sample feed is to aid the reader
-          in understanding how the data objects within VIP 5.0 relate to each other.
+          in understanding how the data objects within VIP 5.1 relate to each other.
 -->
 <VipObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.0" xsi:noNamespaceSchemaLocation="http://votinginfoproject.github.com/vip-specification/vip_spec.xsd">
   <Person id="per001">


### PR DESCRIPTION
The [5.1 XML spec](https://github.com/votinginfoproject/vip-specification/blob/vip511/vip_spec.xsd) has a set of changes described in a [Pivotal card](https://www.pivotaltracker.com/story/show/119862555).

This PR updates existing tables to match the spec where possible. Some tables are missing, some changes from the card aren't present - there are bugs filed to sort out this matter.