### PR TITLE
Create missing tables for loading 5.1 CSV files

### DIFF
--- a/resources/migrations/20160524-create-missing-tables.down.sql
+++ b/resources/migrations/20160524-create-missing-tables.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE v5_1_candidate_selections;
+DROP TABLE v5_1_contests;
+DROP TABLE v5_1_ordered_contests;
+DROP TABLE v5_1_party_selections;

--- a/resources/migrations/20160524-create-missing-tables.up.sql
+++ b/resources/migrations/20160524-create-missing-tables.up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE v5_1_candidate_selections (id TEXT NOT NULL,
+                                        results_id BIGINT REFERENCES results (id) NOT NULL,
+                                        PRIMARY KEY (results_id, id),
+                                        sequence_order TEXT,
+                                        candidate_ids TEXT,
+                                        endorsement_party_ids TEXT,
+                                        is_write_in TEXT);
+
+CREATE TABLE v5_1_contests (id TEXT NOT NULL,
+                            results_id BIGINT REFERENCES results (id) NOT NULL,
+                            abbreviation TEXT,
+                            ballot_selection_ids TEXT,
+                            ballot_sub_title TEXT,
+                            ballot_title TEXT,
+                            electoral_district_id TEXT,
+                            electorate_specification TEXT,
+                            external_identifier_type TEXT,
+                            external_identifier_othertype TEXT,
+                            external_identifier_value TEXT,
+                            has_rotation TEXT,
+                            name TEXT,
+                            sequence_order TEXT,
+                            vote_variation TEXT,
+                            other_vote_variation TEXT);
+
+CREATE TABLE v5_1_ordered_contests (id TEXT NOT NULL,
+                                    results_id BIGINT REFERENCES results (id) NOT NULL,
+                                    PRIMARY KEY (results_id, id),
+                                    contest_id TEXT,
+                                    ordered_ballot_selection_ids TEXT);
+
+CREATE TABLE v5_1_party_selections (id TEXT NOT NULL,
+                                    results_id BIGINT REFERENCES results (id) NOT NULL,
+                                    PRIMARY KEY (results_id, id),
+                                    sequence_order TEXT,
+                                    party_ids TEXT);

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -57,13 +57,17 @@
                                              :ballot-styles
                                              :candidates
                                              :candidate-contests
+                                             :candidate-selections
+                                             :contests
                                              :departments
                                              :elections
                                              :election-administrations
                                              :electoral-districts
                                              :hours-open
                                              :localities
+                                             :ordered-contests
                                              :parties
+                                             :party-selections
                                              :people
                                              :polling-locations
                                              :precincts

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -125,6 +125,30 @@
               {:name "primary_party_ids"}
               {:name "votes_allowed"}
               {:name "office_ids"}]}
+   {:filename "candidate_selection.txt"
+    :table :candidate-selections
+    :columns [{:name "id"}
+              {:name "sequence_order"}
+              {:name "candidate_ids"}
+              {:name "endorsement_party_ids"}
+              {:name "is_write_in"}]}
+   {:filename "contest.txt"
+    :table :contests
+    :columns [{:name "id"}
+              {:name "abbreviation"}
+              {:name "ballot_selection_ids"}
+              {:name "ballot_sub_title"}
+              {:name "ballot_title"}
+              {:name "electoral_district_id"}
+              {:name "electorate_specification"}
+              {:name "external_identifier_type"}
+              {:name "external_identifier_othertype"}
+              {:name "external_identifier_value"}
+              {:name "has_rotation"}
+              {:name "name"}
+              {:name "sequence_order"}
+              {:name "vote_variation"}
+              {:name "other_vote_variation"}]}
    {:filename "department.txt"
     :table :departments
     :columns [{:name "id"}
@@ -196,6 +220,10 @@
               {:name "external_identifier_othertype"}
               {:name "external_identifier_value"}
               {:name "polling_location_ids"}]}
+   {:filename "ordered_contest.txt"
+    :table :ordered-contest
+    :columns [{:name "id"}
+              {:name "ordered_ballot_selection_ids"}]}
    {:filename "party.txt"
     :table :parties
     :columns [{:name "id"}
@@ -207,6 +235,11 @@
               {:name "external_identifier_value"}
               {:name "logo_uri"}
               {:name "name"}]}
+   {:filename "party_selection.txt"
+    :table :party-selections
+    :columns [{:name "id"}
+              {:name "sequence_order"}
+              {:name "party_ids"}]}
    {:filename "person.txt"
     :table :people
     :columns [{:name "id"}

--- a/test-resources/csv/5-1/candidate_selection.txt
+++ b/test-resources/csv/5-1/candidate_selection.txt
@@ -1,0 +1,4 @@
+id,sequence_order,candidate_ids,endorsement_party_ids,is_write_in
+cs001,3,can032,par01,false
+cs002,2,can512,par02,false
+cs003,1,can124,par02,true

--- a/test-resources/csv/5-1/contest.txt
+++ b/test-resources/csv/5-1/contest.txt
@@ -1,0 +1,3 @@
+id,abbreviation,ballot_selection_ids,ballot_sub_title,ballot_title,electoral_district_id,electorate_specification,external_identifier_type,external_identifier_othertype,external_identifier_value,has_rotation,name,sequence_order,vote_variation,other_vote_variation
+con01,SE-1,bs01 bs02,With a Vengance,Die Hard Series,ed37,An electorate specification,fips,,23,false,Bruce Willis Movies,,,
+con02,SE-2,bs01 bs02,,Friends of Lee Van Cleef,ed37,An electorate specification,fips,,23,false,Spaghetti Westerns,,,

--- a/test-resources/csv/5-1/ordered-contest.txt
+++ b/test-resources/csv/5-1/ordered-contest.txt
@@ -1,0 +1,3 @@
+id,ordered_ballot_selection_ids
+oc01,"bs01 bs05 bs02 bs05 bs03"
+oc02,"bs08 bs06 bs07 bs05 bs03 bs00 bs09"

--- a/test-resources/csv/5-1/party_selection.txt
+++ b/test-resources/csv/5-1/party_selection.txt
@@ -1,0 +1,4 @@
+id,sequence_order,party_ids
+ps001,1,"p001 p004"
+ps002,2,"p001 p002"
+ps003,3,"p003"


### PR DESCRIPTION
These are a few tables that were found missing. I added a sample file for each table, since we didn't have one in the original set of 5.1 CSVs.

##### Pivotal cards
- [party_selections is missing](https://www.pivotaltracker.com/story/show/120202393)
- [ordered_contests is missing](https://www.pivotaltracker.com/story/show/120202491)
- [candidate_selections is missing](https://www.pivotaltracker.com/story/show/120129193)
- [contests is missing](https://www.pivotaltracker.com/story/show/120012625)
