### PR TITLE
Transform candidate contests

### DIFF
--- a/src/vip/data_processor/db/translations/v5_1/candidate_contests.clj
+++ b/src/vip/data_processor/db/translations/v5_1/candidate_contests.clj
@@ -1,0 +1,45 @@
+(ns vip.data-processor.db.translations.v5-1.candidate-contests
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.util :as util]))
+
+(defn candidate-contests
+  [import-id]
+  (korma/select (postgres/v5-1-tables :candidate-contests)
+    (korma/where {:results_id import-id})))
+
+(defn base-path [index]
+  (str "VipObject.0.CandidateContest." index))
+
+(defn candidate-contest->ltree-entries
+  [idx-fn row]
+  (let [path (base-path (idx-fn))
+        id-path (util/id-path path)
+        child-idx-fn (util/index-generator 0)]
+    (conj
+     (mapcat #(% child-idx-fn path row)
+             [(util/simple-value->ltree :abbreviation)
+              (util/simple-value->ltree :ballot_selection_ids)
+              (util/internationalized-text->ltree :ballot_sub_title)
+              (util/internationalized-text->ltree :ballot_title)
+              (util/simple-value->ltree :electoral_district_id)
+              (util/internationalized-text->ltree :electorate_specification)
+              util/external-identifiers->ltree
+              (util/simple-value->ltree :has_rotation)
+              (util/simple-value->ltree :name)
+              (util/simple-value->ltree :sequence_order)
+              (util/simple-value->ltree :vote_variation)
+              (util/simple-value->ltree :other_vote_variation)
+              (util/simple-value->ltree :number_elected)
+              (util/simple-value->ltree :office_ids)
+              (util/simple-value->ltree :primary_party_ids)
+              (util/simple-value->ltree :votes_allowed)])
+     {:path id-path
+      :simple_path "VipObject.CandidateContest.id"
+      :parent_with_id id-path
+      :value (:id row)})))
+
+(def transformer
+  (util/transformer
+   candidate-contests
+   candidate-contest->ltree-entries))

--- a/test-resources/csv/5-1/candidate_contest.txt
+++ b/test-resources/csv/5-1/candidate_contest.txt
@@ -1,0 +1,3 @@
+abbreviation,ballot_selection_ids,ballot_sub_title,ballot_title,electoral_district_id,electorate_specification,external_identifier_type,external_identifier_othertype,external_identifier_value,has_rotation,name,sequence_order,vote_variation,other_vote_variation,number_elected,office_ids,primary_party_ids,votes_allowed,id
+SE-1,"bs01 bs02",,Bad Guys,ed37,An electorate specification,fips,,23,true,Actors who wear black hats,,,,14,"office001 office002 office003","party001 party002 party003",4,cancon001
+SE-2,"bs01 bs02",,Good Guys,ed37,An electorate specification,fips,,23,true,Actors who wear white hats,,,,2,"office003","party003",1,cancon002

--- a/test/vip/data_processor/db/translations/v5_1/candidate_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/candidate_contests_postgres_test.clj
@@ -1,0 +1,29 @@
+(ns vip.data-processor.db.translations.v5-1.candidate-contests-postgres-test
+  (:require [clojure.test :refer :all]
+            [korma.core :as korma]
+            [vip.data-processor.db.translations.v5-1.candidate-contests
+             :as candidate-contests]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.test-helpers :refer :all]))
+
+(use-fixtures :once setup-postgres)
+
+(deftest ^:postgres contest->ltree-entries-test
+  (testing "tests run the important function"
+    (let [ctx {:input (csv-inputs ["5-1/candidate_contest.txt"])
+               :spec-version "5.1"
+               :ltree-index 0
+               :pipeline (concat
+                          [postgres/start-run]
+                          (get csv/version-pipelines "5.1")
+                          [candidate-contests/transformer])}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (assert-no-problems out-ctx [])
+      (are-xml-tree-values out-ctx
+                           "cancon001" "VipObject.0.CandidateContest.0.id"
+                           "Bad Guys" "VipObject.0.CandidateContest.0.BallotTitle.2.Text.0"
+                           "en" "VipObject.0.CandidateContest.0.BallotTitle.2.Text.0.language"
+                           "fips" "VipObject.0.CandidateContest.0.ExternalIdentifiers.5.ExternalIdentifier.0.Type.0"
+                           "23" "VipObject.0.CandidateContest.0.ExternalIdentifiers.5.ExternalIdentifier.0.Value.1"))))


### PR DESCRIPTION
More xml_tree_values can be generated. This time for CandidateContest elements.

[Pivotal story](https://www.pivotaltracker.com/story/show/119478475)