### PR TITLE
v5_1_polling_locations -> xml_tree_values

### DIFF
--- a/src/vip/data_processor/db/translations/util.clj
+++ b/src/vip/data_processor/db/translations/util.clj
@@ -94,8 +94,7 @@
 
 (defn latlng->ltree [idx-fn parent-path row]
   (when-not (and (str/blank? (:latitude row))
-                 (str/blank? (:longitude row))
-                 (str/blank? (:latlng_source row)))
+                 (str/blank? (:longitude row)))
     (let [index (idx-fn)
           base-path (str parent-path ".LatLng." index)
           parent-with-id (id-path parent-path)

--- a/src/vip/data_processor/db/translations/util.clj
+++ b/src/vip/data_processor/db/translations/util.clj
@@ -92,6 +92,19 @@
                (simple-value->ltree :external_identifier_othertype "OtherType" parent-with-id)
                (simple-value->ltree :external_identifier_value "Value" parent-with-id)]))))
 
+(defn latlng->ltree [idx-fn parent-path row]
+  (when-not (and (str/blank? (:latitude row))
+                 (str/blank? (:longitude row))
+                 (str/blank? (:latlng_source row)))
+    (let [index (idx-fn)
+          base-path (str parent-path ".LatLng." index)
+          parent-with-id (id-path parent-path)
+          sub-idx-fn (index-generator 0)]
+      (mapcat #(% sub-idx-fn base-path row)
+              [(simple-value->ltree :latitude "Latitude" parent-with-id)
+               (simple-value->ltree :longitude "Longitude" parent-with-id)
+               (simple-value->ltree :latlng_source "Source" parent-with-id)]))))
+
 (defn ltreeify [row]
   (-> row
       (update :path postgres/path->ltree)

--- a/src/vip/data_processor/db/translations/v5_1/polling_locations.clj
+++ b/src/vip/data_processor/db/translations/v5_1/polling_locations.clj
@@ -1,0 +1,34 @@
+(ns vip.data-processor.db.translations.v5-1.polling-locations
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.util :as util]))
+
+(defn row-fn [import-id]
+  (korma/select (postgres/v5-1-tables :polling-locations)
+    (korma/where {:results_id import-id})))
+
+(defn base-path [index]
+  (str "VipObject.0.PollingLocation." index))
+
+(defn transform-fn
+  [idx-fn row]
+  (let [path (base-path (idx-fn))
+        id-path (util/id-path path)
+        child-idx-fn (util/index-generator 0)]
+    (conj
+     (mapcat #(% child-idx-fn path row)
+             [(util/simple-value->ltree :address_line)
+              (util/internationalized-text->ltree :directions)
+              (util/internationalized-text->ltree :hours)
+              (util/simple-value->ltree :photo_uri)
+              (util/simple-value->ltree :hours_open_id)
+              (util/simple-value->ltree :is_drop_box)
+              (util/simple-value->ltree :is_early_voting)
+              util/latlng->ltree])
+     {:path id-path
+      :simple_path "VipObject.PollingLocation.id"
+      :parent_with_id id-path
+      :value (:id row)})))
+
+(def transformer
+ (util/transformer row-fn transform-fn))

--- a/test-resources/csv/5-1/polling_location.txt
+++ b/test-resources/csv/5-1/polling_location.txt
@@ -1,0 +1,2 @@
+address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source,id
+"ALBERMARLE HIGH SCHOOL 2775 Hydraulic Rd Charlottesville, VA 22901","Use back door",7am-8pm,www.picture.com,hours0001,false,true,38.0754627,78.5014875,Google Maps,pl81274

--- a/test/vip/data_processor/db/translations/util_test.clj
+++ b/test/vip/data_processor/db/translations/util_test.clj
@@ -95,3 +95,31 @@
                 :parent_with_id "VipObject.0.BallotMeasureContest.0.id"
                 :value "ThisOtherType's value"}}
              (set (transform-fn idx-fn "VipObject.0.BallotMeasureContest.0" row)))))))
+
+(deftest latlng->ltree-test
+  (testing "when all three identifiers are missing, nothing happens"
+    (let [row {:latitude ""
+               :longitude ""
+               :latlng_source ""}
+          idx-fn (util/index-generator 0)]
+      (is (nil? (util/latlng->ltree idx-fn "VipObject.0.PollingLocation.0" row)))))
+
+  (testing "LatLng elements have three components"
+    (let [row {:latitude "38.0754627"
+               :longitude "78.5014875"
+               :latlng_source "Google Maps"}
+          transform-fn util/latlng->ltree
+          idx-fn (util/index-generator 0)]
+      (is (= #{{:path "VipObject.0.PollingLocation.0.LatLng.0.Latitude.0"
+                :simple_path "VipObject.PollingLocation.LatLng.Latitude"
+                :parent_with_id "VipObject.0.PollingLocation.0.id"
+                :value "38.0754627"}
+               {:path "VipObject.0.PollingLocation.0.LatLng.0.Longitude.1"
+                :simple_path "VipObject.PollingLocation.LatLng.Longitude"
+                :parent_with_id "VipObject.0.PollingLocation.0.id"
+                :value "78.5014875"}
+               {:path "VipObject.0.PollingLocation.0.LatLng.0.Source.2"
+                :simple_path "VipObject.PollingLocation.LatLng.Source"
+                :parent_with_id "VipObject.0.PollingLocation.0.id"
+                :value "Google Maps"}}
+             (set (transform-fn idx-fn "VipObject.0.PollingLocation.0" row)))))))

--- a/test/vip/data_processor/db/translations/util_test.clj
+++ b/test/vip/data_processor/db/translations/util_test.clj
@@ -97,14 +97,30 @@
              (set (transform-fn idx-fn "VipObject.0.BallotMeasureContest.0" row)))))))
 
 (deftest latlng->ltree-test
-  (testing "when all three identifiers are missing, nothing happens"
+  (testing "when latitude and longitude are missing, nothing happens"
     (let [row {:latitude ""
                :longitude ""
-               :latlng_source ""}
+               :latlng_source "Optional source"}
           idx-fn (util/index-generator 0)]
       (is (nil? (util/latlng->ltree idx-fn "VipObject.0.PollingLocation.0" row)))))
 
-  (testing "LatLng elements have three components"
+  (testing "LatLng elements have two core components"
+    (let [row {:latitude "38.0754627"
+               :longitude "78.5014875"
+               :latlng_source ""}
+          transform-fn util/latlng->ltree
+          idx-fn (util/index-generator 0)]
+      (is (= #{{:path "VipObject.0.PollingLocation.0.LatLng.0.Latitude.0"
+                :simple_path "VipObject.PollingLocation.LatLng.Latitude"
+                :parent_with_id "VipObject.0.PollingLocation.0.id"
+                :value "38.0754627"}
+               {:path "VipObject.0.PollingLocation.0.LatLng.0.Longitude.1"
+                :simple_path "VipObject.PollingLocation.LatLng.Longitude"
+                :parent_with_id "VipObject.0.PollingLocation.0.id"
+                :value "78.5014875"}}
+             (set (transform-fn idx-fn "VipObject.0.PollingLocation.0" row))))))
+
+  (testing "Source is included when present"
     (let [row {:latitude "38.0754627"
                :longitude "78.5014875"
                :latlng_source "Google Maps"}

--- a/test/vip/data_processor/db/translations/v5_1/polling_locations_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/polling_locations_test.clj
@@ -1,0 +1,37 @@
+(ns vip.data-processor.db.translations.v5-1.polling-locations-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [korma.core :as korma]
+            [vip.data-processor.db.translations.v5-1.polling-locations :as ploc]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.validation.csv :as csv]))
+
+(use-fixtures :once setup-postgres)
+
+(deftest ^:postgres transformer-test
+  (testing "polling_location.txt is loaded and transformed"
+    (let [ctx {:input (csv-inputs ["5-1/polling_location.txt"])
+               :spec-version "5.1"
+               :ltree-index 77
+               :pipeline (concat
+                          [postgres/start-run]
+                          (get csv/version-pipelines "5.1")
+                          [ploc/transformer])}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (assert-no-problems out-ctx [])
+      (are-xml-tree-values
+       out-ctx
+       "pl81274" "VipObject.0.PollingLocation.77.id"
+       "ALBERMARLE HIGH SCHOOL 2775 Hydraulic Rd Charlottesville, VA 22901" "VipObject.0.PollingLocation.77.AddressLine.0"
+       "Use back door" "VipObject.0.PollingLocation.77.Directions.1.Text.0"
+       "en" "VipObject.0.PollingLocation.77.Directions.1.Text.0.language"
+       "7am-8pm" "VipObject.0.PollingLocation.77.Hours.2.Text.0"
+       "en" "VipObject.0.PollingLocation.77.Hours.2.Text.0.language"
+       "www.picture.com" "VipObject.0.PollingLocation.77.PhotoUri.3"
+       "hours0001" "VipObject.0.PollingLocation.77.HoursOpenId.4"
+       "false" "VipObject.0.PollingLocation.77.IsDropBox.5"
+       "true" "VipObject.0.PollingLocation.77.IsEarlyVoting.6"
+       "38.0754627" "VipObject.0.PollingLocation.77.LatLng.7.Latitude.0"
+       "78.5014875" "VipObject.0.PollingLocation.77.LatLng.7.Longitude.1"
+       "Google Maps" "VipObject.0.PollingLocation.77.LatLng.7.Source.2"))))


### PR DESCRIPTION
Here's a transformation of polling location to `xml_tree_values`. There's a new complex type for the `LatLng` element, which is similar to the `ExternalIdentifiers`, but with less nesting. [Pivotal card](https://www.pivotaltracker.com/story/show/119861935)