### PR TITLE
Transform street segments

### DIFF
--- a/resources/migrations/20160602-1-add-includes-all-streets-to-street-segments.down.sql
+++ b/resources/migrations/20160602-1-add-includes-all-streets-to-street-segments.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE v5_1_street_segments
+DROP COLUMN includes_all_streets;

--- a/resources/migrations/20160602-1-add-includes-all-streets-to-street-segments.up.sql
+++ b/resources/migrations/20160602-1-add-includes-all-streets-to-street-segments.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE v5_1_street_segments
+ ADD COLUMN includes_all_streets BOOLEAN;

--- a/src/vip/data_processor/db/translations/util.clj
+++ b/src/vip/data_processor/db/translations/util.clj
@@ -38,7 +38,7 @@
    (simple-value->ltree column-name (column->xml-elment column-name)))
   ([column-name xml-element]
    (fn [idx-fn base-path row]
-     (let [value (get row column-name)]
+     (let [value (str (get row column-name))]
        (when-not (str/blank? value)
          (let [path (str base-path "." xml-element "." (idx-fn))]
            (list

--- a/src/vip/data_processor/db/translations/v5_1/street_segments.clj
+++ b/src/vip/data_processor/db/translations/v5_1/street_segments.clj
@@ -1,0 +1,38 @@
+(ns vip.data-processor.db.translations.v5-1.street-segments
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.util :as util]))
+
+(defn row-fn [import-id]
+  (korma/select (postgres/v5-1-tables :street-segments)
+    (korma/where {:results_id import-id})))
+
+(defn base-path [index]
+  (str "VipObject.0.StreetSegment." index))
+
+(defn transform-fn [idx-fn row]
+  (let [path (base-path (idx-fn))
+        id-path (util/id-path path)
+        child-idx-fn (util/index-generator 0)]
+    (conj
+     (mapcat #(% child-idx-fn path row)
+             [(util/simple-value->ltree :address_direction)
+              (util/simple-value->ltree :city)
+              (util/simple-value->ltree :includes_all_addresses)
+              (util/simple-value->ltree :includes_all_streets)
+              (util/simple-value->ltree :odd_even_both)
+              (util/simple-value->ltree :precinct_id)
+              (util/simple-value->ltree :start_house_number)
+              (util/simple-value->ltree :end_house_number)
+              (util/simple-value->ltree :state)
+              (util/simple-value->ltree :street_direction)
+              (util/simple-value->ltree :street_name)
+              (util/simple-value->ltree :street_suffix)
+              (util/simple-value->ltree :unit_number)
+              (util/simple-value->ltree :zip)])
+     {:path id-path
+      :simple_path (util/path->simple-path id-path)
+      :parent_with_id id-path
+      :value (:id row)})))
+
+(def transformer (util/transformer row-fn transform-fn))

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -376,6 +376,8 @@
     :columns [{:name "id"}
               {:name "includes_all_addresses"
                :coerce coerce/postgres-boolean}
+              {:name "includes_all_streets"
+               :coerce coerce/postgres-boolean}
               {:name "address_direction"}
               {:name "city"}
               {:name "odd_even_both"}

--- a/test-resources/csv/5-1/street_segment.txt
+++ b/test-resources/csv/5-1/street_segment.txt
@@ -1,0 +1,3 @@
+address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,state,street_direction,street_name,street_suffix,unit_number,zip,id
+N,Washington,false,false,odd,p001,101,199,DC,NW,Delaware,St,,20001,ss000001
+S,Washington,true,false,,p002,,,DC,SE,Wisconsin,Ave,,20002,ss000002

--- a/test/vip/data_processor/db/translations/v5_1/street_segment_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/street_segment_postgres_test.clj
@@ -1,0 +1,48 @@
+(ns vip.data-processor.db.translations.v5-1.street-segment-postgres-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.translations.v5-1.street-segments :as ss]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.validation.csv :as csv]))
+
+(use-fixtures :once setup-postgres)
+
+(deftest ^:postgres transformer-test
+  (testing "street_segment.txt is loaded and transformed"
+    (let [ctx {:input (csv-inputs ["5-1/street_segment.txt"])
+               :spec-version "5.1"
+               :ltree-index 1001
+               :pipeline (concat
+                          [postgres/start-run]
+                          (get csv/version-pipelines "5.1")
+                          [ss/transformer])}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (assert-no-problems out-ctx [])
+      (are-xml-tree-values out-ctx
+        "ss000001" "VipObject.0.StreetSegment.1001.id"
+        "N" "VipObject.0.StreetSegment.1001.AddressDirection.0"
+        "Washington" "VipObject.0.StreetSegment.1001.City.1"
+        "false" "VipObject.0.StreetSegment.1001.IncludesAllAddresses.2"
+        "false" "VipObject.0.StreetSegment.1001.IncludesAllStreets.3"
+        "odd" "VipObject.0.StreetSegment.1001.OddEvenBoth.4"
+        "p001" "VipObject.0.StreetSegment.1001.PrecinctId.5"
+        "101" "VipObject.0.StreetSegment.1001.StartHouseNumber.6"
+        "199" "VipObject.0.StreetSegment.1001.EndHouseNumber.7"
+        "DC" "VipObject.0.StreetSegment.1001.State.8"
+        "NW" "VipObject.0.StreetSegment.1001.StreetDirection.9"
+        "Delaware" "VipObject.0.StreetSegment.1001.StreetName.10"
+        "St" "VipObject.0.StreetSegment.1001.StreetSuffix.11"
+        "20001" "VipObject.0.StreetSegment.1001.Zip.12"
+
+        "ss000002" "VipObject.0.StreetSegment.1002.id"
+        "S" "VipObject.0.StreetSegment.1002.AddressDirection.0"
+        "Washington" "VipObject.0.StreetSegment.1002.City.1"
+        "true" "VipObject.0.StreetSegment.1002.IncludesAllAddresses.2"
+        "false" "VipObject.0.StreetSegment.1002.IncludesAllStreets.3"
+        "p002" "VipObject.0.StreetSegment.1002.PrecinctId.4"
+        "DC" "VipObject.0.StreetSegment.1002.State.5"
+        "SE" "VipObject.0.StreetSegment.1002.StreetDirection.6"
+        "Wisconsin" "VipObject.0.StreetSegment.1002.StreetName.7"
+        "Ave" "VipObject.0.StreetSegment.1002.StreetSuffix.8"
+        "20002" "VipObject.0.StreetSegment.1002.Zip.9"))))


### PR DESCRIPTION
Transforming street_segment.txt!

Since some street segment values are coerced to non-text values in its table, `simple-value->ltree` needed a tiny update to stringify values it deals with.

And `includes_all_streets` needed to be added to the table.

Pivotal story: [119862431](https://www.pivotaltracker.com/story/show/119862431)