### PR TITLE
Use Leiningen 2.5.3 -> 2.6.1 with Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:lein-2.5.3
+FROM clojure:lein-2.6.1-alpine
 
 RUN mkdir -p /usr/src/data-processor
 WORKDIR /usr/src/data-processor


### PR DESCRIPTION
Change the base image from a larger, [Debian base image](https://github.com/Quantisan/docker-clojure/blob/0d4a0abe13497a6081ebd080e83d1be0abab3f59/Dockerfile), to a smaller, [Alpine base image](https://github.com/Quantisan/docker-clojure/blob/0d4a0abe13497a6081ebd080e83d1be0abab3f59/alpine/Dockerfile). At the same time, upgrade Leiningen. You can see the [changes](https://github.com/technomancy/leiningen/blob/master/NEWS.md) between `2.5.3` and `2.6.1`.

I've tested this with out [data suite](https://github.com/votinginfoproject/data-suite) and the oft-used file `va-clean.zip`.