### PR TITLE
Transform schedule.txt to HoursOpen(!) xml-tree-values

### DIFF
--- a/resources/migrations/20160607-update-schedules-and-hours-open.down.sql
+++ b/resources/migrations/20160607-update-schedules-and-hours-open.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE v5_1_schedules
+ADD COLUMN start_time2 TEXT,
+ADD COLUMN end_time2 TEXT,
+DROP COLUMN hours_open_id;
+
+CREATE TABLE v5_1_hours_open (id TEXT NOT NULL,
+                              results_id BIGINT REFERENCES results(id) NOT NULL,
+                              schedule_id TEXT NOT NULL,
+                              PRIMARY KEY (results_id, id, schedule_id));

--- a/resources/migrations/20160607-update-schedules-and-hours-open.up.sql
+++ b/resources/migrations/20160607-update-schedules-and-hours-open.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE v5_1_schedules
+DROP COLUMN start_time2,
+DROP COLUMN end_time2,
+ADD COLUMN hours_open_id TEXT;
+
+DROP TABLE IF EXISTS v5_1_hours_open;

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -65,7 +65,6 @@
                                              :elections
                                              :election-administrations
                                              :electoral-districts
-                                             :hours-open
                                              :localities
                                              :ordered-contests
                                              :parties
@@ -75,6 +74,7 @@
                                              :polling-locations
                                              :precincts
                                              :retention-contests
+                                             :schedules
                                              :sources
                                              :states
                                              :street-segments]))

--- a/src/vip/data_processor/db/translations/v5_1/hours_open.clj
+++ b/src/vip/data_processor/db/translations/v5_1/hours_open.clj
@@ -1,0 +1,27 @@
+(ns vip.data-processor.db.translations.v5-1.hours-open
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.util :as util]
+            [vip.data-processor.db.translations.v5-1.schedules :as schedules]))
+
+(defn row-fn [import-id]
+  (let [schedules (korma/select (postgres/v5-1-tables :schedules)
+                                (korma/where {:results_id import-id}))]
+    (group-by :hours_open_id schedules)))
+
+(defn base-path [index]
+  (str "VipObject.0.HoursOpen." index))
+
+(defn transform-fn [idx-fn [hours_open_id schedules]]
+  (let [path (base-path (idx-fn))
+        id-path (util/id-path path)
+        child-idx-fn (util/index-generator 0)]
+    (conj
+     (mapcat (partial schedules/schedule->ltree path child-idx-fn)
+             schedules)
+     {:path id-path
+      :simple_path (util/path->simple-path id-path)
+      :parent_with_id id-path
+      :value hours_open_id})))
+
+(def transformer (util/transformer row-fn transform-fn))

--- a/src/vip/data_processor/db/translations/v5_1/schedules.clj
+++ b/src/vip/data_processor/db/translations/v5_1/schedules.clj
@@ -1,0 +1,45 @@
+(ns vip.data-processor.db.translations.v5-1.schedules
+  (:require [vip.data-processor.db.translations.util :as util]
+            [clojure.string :as str]))
+
+(defn hours->ltree [parent-path parent-with-id idx-fn schedule]
+  (when-not (and (str/blank? (:start_time schedule))
+                 (str/blank? (:end_time schedule)))
+    (let [path (str parent-path ".Hours." (idx-fn))
+          child-idx-fn (util/index-generator 0)]
+      (mapcat #(% child-idx-fn path schedule)
+              [(util/simple-value->ltree :start_time
+                                         "StartTime"
+                                         parent-with-id)
+               (util/simple-value->ltree :end_time
+                                         "EndTime"
+                                         parent-with-id)]))))
+
+(defn schedule->ltree [parent-path idx-fn schedule]
+  (let [path (str parent-path ".Schedule." (idx-fn))
+        label-path (str path ".label")
+        parent-with-id (util/id-path parent-path)
+        child-idx-fn (util/index-generator 0)]
+    (concat
+     (list
+      {:path label-path
+       :simple_path (util/path->simple-path label-path)
+       :parent_with_id parent-with-id
+       :value (:id schedule)})
+     (hours->ltree path parent-with-id child-idx-fn schedule)
+     (mapcat #(% child-idx-fn path schedule)
+             [(util/simple-value->ltree :is_only_by_appointment
+                                        "IsOnlyByAppointment"
+                                        parent-with-id)
+              (util/simple-value->ltree :is_or_by_appointment
+                                        "IsOrByAppointment"
+                                        parent-with-id)
+              (util/simple-value->ltree :is_subject_to_change
+                                        "IsSubjectToChange"
+                                        parent-with-id)
+              (util/simple-value->ltree :start_date
+                                        "StartDate"
+                                        parent-with-id)
+              (util/simple-value->ltree :end_date
+                                        "EndDate"
+                                        parent-with-id)]))))

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -215,17 +215,12 @@
               {:name "external_identifier_othertype"}
               {:name "external_identifier_value"}
               {:name "other_type"}]}
-   {:filename "hours_open.txt"
-    :table :hours-open
-    :columns [{:name "id"}
-              {:name "schedule_id"}]}
    {:filename "schedule.txt"
     :table :schedules
     :columns [{:name "id"}
+              {:name "hours_open_id"}
               {:name "start_time"}
               {:name "end_time"}
-              {:name "start_time2"}
-              {:name "end_time2"}
               {:name "is_only_by_appointment"}
               {:name "is_or_by_appointment"}
               {:name "is_subject_to_change"}

--- a/test-resources/csv/5-1/schedule.txt
+++ b/test-resources/csv/5-1/schedule.txt
@@ -1,0 +1,4 @@
+start_time,end_time,is_only_by_appointment,is_or_by_appointment,is_subject_to_change,start_date,end_date,hours_open_id,id
+07:00:00-06:00,22:00:00-06:00,,true,,2016-10-10-06:00,2016-10-12-06:00,ho001,sch001
+09:00:00-06:00,20:00:00-06:00,true,,,2016-10-13-06:00,2016-10-15-06:00,ho001,sch002
+08:00:00-06:00,14:00:00-06:00,,,true,2016-10-10-06:00,2016-10-15-06:00,ho002,sch003

--- a/test/vip/data_processor/db/translations/v5_1/hours_open_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/hours_open_postgres_test.clj
@@ -1,0 +1,47 @@
+(ns vip.data-processor.db.translations.v5-1.hours-open-postgres-test
+  (:require [clojure.test :refer :all]
+            [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.v5-1.hours-open :as hours-open]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.validation.csv :as csv]))
+
+(use-fixtures :once setup-postgres)
+
+(deftest ^:postgres hours-open->ltree-entries-test
+  (testing "schedule.txt is loaded and transformed into HoursOpen entities"
+    (let [ctx {:input (csv-inputs ["5-1/schedule.txt"])
+               :spec-version "5.1"
+               :ltree-index 2
+               :pipeline (concat
+                          [postgres/start-run]
+                          (get csv/version-pipelines "5.1")
+                          [hours-open/transformer])}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (assert-no-problems out-ctx [])
+      (testing "multiple Schedules for one HoursOpen"
+        (are-xml-tree-values out-ctx
+         "ho001" "VipObject.0.HoursOpen.2.id"
+         "sch001" "VipObject.0.HoursOpen.2.Schedule.0.label"
+         "07:00:00-06:00" "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.StartTime.0"
+         "22:00:00-06:00" "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.EndTime.1"
+         "true" "VipObject.0.HoursOpen.2.Schedule.0.IsOrByAppointment.1"
+         "2016-10-10-06:00" "VipObject.0.HoursOpen.2.Schedule.0.StartDate.2"
+         "2016-10-12-06:00" "VipObject.0.HoursOpen.2.Schedule.0.EndDate.3"
+
+         "sch002" "VipObject.0.HoursOpen.2.Schedule.1.label"
+         "09:00:00-06:00" "VipObject.0.HoursOpen.2.Schedule.1.Hours.0.StartTime.0"
+         "20:00:00-06:00" "VipObject.0.HoursOpen.2.Schedule.1.Hours.0.EndTime.1"
+         "true" "VipObject.0.HoursOpen.2.Schedule.1.IsOnlyByAppointment.1"
+         "2016-10-13-06:00" "VipObject.0.HoursOpen.2.Schedule.1.StartDate.2"
+         "2016-10-15-06:00" "VipObject.0.HoursOpen.2.Schedule.1.EndDate.3"))
+      (testing "another HoursOpen from a third row"
+        (are-xml-tree-values out-ctx
+         "ho002" "VipObject.0.HoursOpen.3.id"
+         "sch003" "VipObject.0.HoursOpen.3.Schedule.0.label"
+         "08:00:00-06:00" "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.StartTime.0"
+         "14:00:00-06:00" "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.EndTime.1"
+         "true" "VipObject.0.HoursOpen.3.Schedule.0.IsSubjectToChange.1"
+         "2016-10-10-06:00" "VipObject.0.HoursOpen.3.Schedule.0.StartDate.2"
+         "2016-10-15-06:00" "VipObject.0.HoursOpen.3.Schedule.0.EndDate.3")))))


### PR DESCRIPTION
HoursOpen is essentially just a container of Schedules, so it's possible to support them without hours_open.txt file. We can use schedule.txt and group by their `hours_open_id`....

Pivotal story: [119859211](https://www.pivotaltracker.com/story/show/119859211)