### PR TITLE
Transform election administration

### DIFF
--- a/resources/migrations/20160607-01-add-parent-id-to-departments.down.sql
+++ b/resources/migrations/20160607-01-add-parent-id-to-departments.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE v5_1_departments DROP COLUMN parent_id;

--- a/resources/migrations/20160607-01-add-parent-id-to-departments.up.sql
+++ b/resources/migrations/20160607-01-add-parent-id-to-departments.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE v5_1_departments ADD COLUMN parent_id TEXT;

--- a/resources/migrations/20160608-drop-extraneous-columns.down.sql
+++ b/resources/migrations/20160608-drop-extraneous-columns.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE v5_1_voter_services
+      ADD COLUMN department_id TEXT,
+      ADD COLUMN contact_information_id TEXT;
+
+ALTER TABLE v5_1_departments
+      ADD COLUMN department_name TEXT,
+      ADD COLUMN election_administration_id TEXT,
+      ADD COLUMN contact_information_id TEXT;

--- a/resources/migrations/20160608-drop-extraneous-columns.up.sql
+++ b/resources/migrations/20160608-drop-extraneous-columns.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE v5_1_voter_services
+      DROP COLUMN department_id,
+      DROP COLUMN contact_information_id;
+
+ALTER TABLE v5_1_departments
+      DROP COLUMN department_name,
+      DROP COLUMN election_administration_id,
+      DROP COLUMN contact_information_id;

--- a/resources/migrations/20160608-update-voter-services.down.sql
+++ b/resources/migrations/20160608-update-voter-services.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE v5_1_voter_services DROP COLUMN parent_id;
+ALTER TABLE v5_1_voter_services RENAME COLUMN type TO voter_service_type;

--- a/resources/migrations/20160608-update-voter-services.up.sql
+++ b/resources/migrations/20160608-update-voter-services.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE v5_1_voter_services ADD COLUMN parent_id TEXT;
+ALTER TABLE v5_1_voter_services RENAME COLUMN voter_service_type TO type;

--- a/src/vip/data_processor/db/translations/v5_1/contact_information.clj
+++ b/src/vip/data_processor/db/translations/v5_1/contact_information.clj
@@ -6,6 +6,10 @@
   ([] (contact-information->ltree "ContactInformation"))
   ([xml-element]
    (fn [idx-fn parent-path row]
+     (let [ci-fn (contact-information->ltree xml-element (util/id-path parent-path))]
+       (ci-fn idx-fn parent-path row))))
+  ([xml-element parent-with-id]
+   (fn [idx-fn parent-path row]
      (when-not (every? #(str/blank? (get row %))
                        [:ci_address_line_1
                         :ci_address_line_2
@@ -24,7 +28,6 @@
        (let [index (idx-fn)
              base-path (str parent-path "." xml-element "." index)
              label-path (str base-path ".label")
-             parent-with-id (util/id-path parent-path)
              sub-idx-fn (util/index-generator 0)]
          (conj
           (mapcat #(% sub-idx-fn base-path row)

--- a/src/vip/data_processor/db/translations/v5_1/departments.clj
+++ b/src/vip/data_processor/db/translations/v5_1/departments.clj
@@ -1,0 +1,47 @@
+(ns vip.data-processor.db.translations.v5-1.departments
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.util :as util]
+            [vip.data-processor.db.translations.v5-1.contact-information :as ci]
+            [vip.data-processor.db.translations.v5-1.voter-services :as vs]))
+
+(defn row-fn
+  [import-id]
+   (korma/select (postgres/v5-1-tables :departments)
+     (korma/fields :*
+                   [:contact_information.id :ci_id]
+                   [:contact_information.email :ci_email]
+                   [:contact_information.fax :ci_fax]
+                   [:contact_information.hours :ci_hours]
+                   [:contact_information.hours_open_id :ci_hours_open_id]
+                   [:contact_information.name :ci_name]
+                   [:contact_information.uri :ci_uri]
+                   [:contact_information.directions :ci_directions]
+                   [:contact_information.address_line_1 :ci_address_line_1]
+                   [:contact_information.address_line_2 :ci_address_line_2]
+                   [:contact_information.address_line_3 :ci_address_line_3]
+                   [:contact_information.latitude :ci_latitude]
+                   [:contact_information.longitude :ci_longitude]
+                   [:contact_information.latlng_source :ci_latlng_source]
+                   [:contact_information.phone :ci_phone]
+                   [:contact_information.parent_id :ci_parent_id])
+     (korma/join :left (postgres/v5-1-tables :contact-information)
+                 (and (= :contact_information.parent_id :id)
+                      (= :contact_information.results_id :results_id)))
+     (korma/where {:results_id import-id})))
+
+(defn departments->ltree [departments voter-services parent-with-id]
+  (fn [idx-fn parent-path _]
+    (mapcat
+     (fn [department]
+       (let [path (str parent-path ".Department." (idx-fn))
+             child-idx-fn (util/index-generator 0)
+             vss (get voter-services (:id department))]
+         (mapcat
+          #(% child-idx-fn path department)
+          [(ci/contact-information->ltree "ContactInformation" parent-with-id)
+           (util/simple-value->ltree :election_official_person_id
+                                     "ElectionOfficialPersonId"
+                                     parent-with-id)
+           (vs/voter-service->ltree vss parent-with-id)])))
+     departments)))

--- a/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
+++ b/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
@@ -1,0 +1,48 @@
+(ns vip.data-processor.db.translations.v5-1.election-administrations
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.util :as util]
+            [vip.data-processor.db.translations.v5-1.contact-information :as ci]
+            [vip.data-processor.db.translations.v5-1.departments :as ds]
+            [vip.data-processor.db.translations.v5-1.voter-services :as vs]))
+
+(defn row-fn [import-id]
+  (korma/select (postgres/v5-1-tables :election-administrations)
+    (korma/where {:results_id import-id})))
+
+(defn base-path [index]
+  (str "VipObject.0.ElectionAdministration." index))
+
+(defn election-administrations->ltree [import-id ltree-index]
+  (let [election-administrations (row-fn import-id)
+        departments (group-by :parent_id (ds/row-fn import-id))
+        voter-services (group-by :parent_id (vs/row-fn import-id))
+        idx-fn (util/index-generator ltree-index)]
+    (mapcat (fn [ea]
+              (let [ds (get departments (:id ea))
+                    path (base-path (idx-fn))
+                    id-path (util/id-path path)
+                    child-idx-fn (util/index-generator 0)]
+                (conj
+                 (mapcat #(% child-idx-fn path ea)
+                         [(util/simple-value->ltree :absentee_uri)
+                          (util/simple-value->ltree :am_i_registered_uri)
+                          (ds/departments->ltree ds voter-services id-path)
+                          (util/simple-value->ltree :elections_uri)
+                          (util/simple-value->ltree :registration_uri)
+                          (util/simple-value->ltree :rules_uri)
+                          (util/simple-value->ltree :what_is_on_my_ballot_uri)
+                          (util/simple-value->ltree :where_do_i_vote_uri)])
+                 {:path id-path
+                  :simple_path (util/path->simple-path id-path)
+                  :parent_with_id id-path
+                  :value (:id ea)})))
+            election-administrations)))
+
+(defn transformer [{:keys [import-id ltree-index] :as ctx}]
+  (let [ltree-entries (util/prep-for-insertion
+                       import-id
+                       (election-administrations->ltree import-id ltree-index))]
+    (korma/insert postgres/xml-tree-values
+      (korma/values ltree-entries))
+    ctx))

--- a/src/vip/data_processor/db/translations/v5_1/voter_services.clj
+++ b/src/vip/data_processor/db/translations/v5_1/voter_services.clj
@@ -1,0 +1,63 @@
+(ns vip.data-processor.db.translations.v5-1.voter-services
+  (:require [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.translations.v5-1.contact-information :as ci]
+            [vip.data-processor.db.translations.util :as util]))
+
+(defn row-fn [import-id]
+  (korma/select (postgres/v5-1-tables :voter-services)
+    (korma/fields :*
+                  [:contact_information.id :ci_id]
+                  [:contact_information.address_line_1 :ci_address_line_1]
+                  [:contact_information.address_line_2 :ci_address_line_2]
+                  [:contact_information.address_line_3 :ci_address_line_3]
+                  [:contact_information.directions :ci_directions]
+                  [:contact_information.email :ci_email]
+                  [:contact_information.fax :ci_fax]
+                  [:contact_information.hours :ci_hours]
+                  [:contact_information.hours_open_id :ci_hours_open_id]
+                  [:contact_information.latitude :ci_latitude]
+                  [:contact_information.longitude :ci_longitude]
+                  [:contact_information.latlng_source :ci_latlng_source]
+                  [:contact_information.name :ci_name]
+                  [:contact_information.parent_id :ci_parent_id]
+                  [:contact_information.phone :ci_phone]
+                  [:contact_information.uri :ci_uri])
+    (korma/join :left (postgres/v5-1-tables :contact-information)
+                (and (= :contact_information.parent_id :id)
+                     (= :contact_information.results_id :results_id)))
+    (korma/where {:results_id import-id})))
+
+(defn voter-service->ltree [vss parent-with-id]
+  (fn [idx-fn parent-path _]
+    (mapcat (fn [vs]
+              (when-not (every? #(clojure.string/blank? (get vs %))
+                                [:ci_address_line_1
+                                 :ci_address_line_2
+                                 :ci_address_line_3
+                                 :ci_directions
+                                 :ci_email
+                                 :ci_fax
+                                 :ci_hours
+                                 :ci_hours_open_id
+                                 :ci_latitude
+                                 :ci_longitude
+                                 :ci_latlng_source
+                                 :ci_name
+                                 :ci_phone
+                                 :ci_uri])
+                (let [path (str parent-path ".VoterService." (idx-fn))
+                      label-path (str path ".label")
+                      sub-idx-fn (util/index-generator 0)]
+                  (conj
+                   (mapcat #(% sub-idx-fn path vs)
+                           [(ci/contact-information->ltree)
+                            (util/internationalized-text->ltree :description)
+                            (util/simple-value->ltree :election_official_person_id)
+                            (util/simple-value->ltree :type)
+                            (util/simple-value->ltree :other_type)])
+                   {:path label-path
+                    :simple_path (util/path->simple-path label-path)
+                    :value (:id vs)
+                    :parent_with_id parent-with-id}))))
+            vss)))

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -41,11 +41,10 @@
    {:filename "voter_service.txt"
     :table :voter-services
     :columns [{:name "id"}
-              {:name "department_id"}
-              {:name "contact_information_id"}
               {:name "description"}
               {:name "election_official_person_id"}
-              {:name "voter_service_type"}
+              {:name "parent_id"}
+              {:name "type"}
               {:name "other_type"}]}
    {:filename "ballot_measure_contest.txt"
     :table :ballot-measure-contests
@@ -175,10 +174,8 @@
    {:filename "department.txt"
     :table :departments
     :columns [{:name "id"}
-              {:name "department_name"}
-              {:name "election_administration_id"}
-              {:name "contact_information_id"}
-              {:name "election_official_person_id"}]}
+              {:name "election_official_person_id"}
+              {:name "parent_id"}]}
    {:filename "election.txt"
     :table :elections
     :columns [{:name "id"}

--- a/test-resources/csv/5-1/contact_information.txt
+++ b/test-resources/csv/5-1/contact_information.txt
@@ -4,3 +4,9 @@ The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,
 1600 Pennsylvania Ave NW,Washington,DC 20006 USA,Head Southeast of the General Rochambeau statue,president@whitehouse.gov,202-456-1131,9am-6pm,h3005,38.899,-77.036,Google Maps,"White House",202-456-1111,"http://www.whitehouse.gov",per50001,ci10861a
 DemocracyWorks,1507 Blake Street,Denver CO 80201,Take the mall-ride,democracy@example.com,555-555-1212,8am-4pm,ho123,39.7500162,-105.0025499,Google maps,Uncubed,,,source01,ci1024
 Argyle Annex,Argyle Pl,Denver CO,Alley behind Tony P's,argyle@example.com,555-555-1000,sunup to sundown,,,, ,Back porch coworking,,,dep01,ci2048
+Suite Omega,,Brooklyn,,omega@example.com,,,,,, ,Curated Voting Consortium,,,dep03,ci4096
+Suite Omega,,Brooklyn,,omega@example.com,,,,,, ,Curated Voting Consortium,,,vs02,ci4097
+Suite Omega,,Brooklyn,,omega@example.com,,,,,, ,Curated Voting Consortium,,,vs03,ci4098
+Suite Omega,,Brooklyn,,omega@example.com,,,,,, ,Curated Voting Consortium,,,vs04,ci4099
+Suite 44, 44th St,Miami,,duplicity@example.com,,sunup to sundown,,,, ,Voter Fraud Foundation,,,dep04,ci16384
+Suite 44, 44th St,Miami,,duplicity@example.com,,sunup to sundown,,,, ,Voter Fraud Foundation,,,vs05,ci16385

--- a/test-resources/csv/5-1/contact_information.txt
+++ b/test-resources/csv/5-1/contact_information.txt
@@ -1,4 +1,6 @@
 address_line_1,address_line_2,address_line_3,directions,email,fax,hours,hours_open_id,latitude,longitude,latlng_source,name,phone,uri,parent_id,id
 The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,off001,ci0827
+The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01,ci0828
 1600 Pennsylvania Ave NW,Washington,DC 20006 USA,Head Southeast of the General Rochambeau statue,president@whitehouse.gov,202-456-1131,9am-6pm,h3005,38.899,-77.036,Google Maps,"White House",202-456-1111,"http://www.whitehouse.gov",per50001,ci10861a
 DemocracyWorks,1507 Blake Street,Denver CO 80201,Take the mall-ride,democracy@example.com,555-555-1212,8am-4pm,ho123,39.7500162,-105.0025499,Google maps,Uncubed,,,source01,ci1024
+Argyle Annex,Argyle Pl,Denver CO,Alley behind Tony P's,argyle@example.com,555-555-1000,sunup to sundown,,,, ,Back porch coworking,,,dep01,ci2048

--- a/test-resources/csv/5-1/department.txt
+++ b/test-resources/csv/5-1/department.txt
@@ -1,0 +1,3 @@
+election_official_person_id,parent_id,id
+eloff01,ea40133,dep01
+eloff02,ea345,dep02

--- a/test-resources/csv/5-1/department.txt
+++ b/test-resources/csv/5-1/department.txt
@@ -1,3 +1,5 @@
 election_official_person_id,parent_id,id
-eloff01,ea40133,dep01
+eloff01,ea123,dep01
 eloff02,ea345,dep02
+eloff03,ea625,dep03
+eloff05,ea625,dep04

--- a/test-resources/csv/5-1/election_administration.txt
+++ b/test-resources/csv/5-1/election_administration.txt
@@ -1,2 +1,4 @@
 absentee_uri,am_i_registered_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri,id
-https://example.com/absentee,https://example.com/am-i-registered,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote,ea40133
+https://example.com/absentee,https://example.com/am-i-registered,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote,ea123
+https://example.com/absentee2,https://example.com/am-i-registered2,https://example.com/elections2,https://example.com/registration2,https://example.com/rules2,https://example.com/what-is-on-my-ballot2,https://example.com/where-do-i-vote2,ea345
+https://example.com/absentee3,https://example.com/am-i-registered3,https://example.com/elections3,https://example.com/registration3,https://example.com/rules3,https://example.com/what-is-on-my-ballot3,https://example.com/where-do-i-vote3,ea625

--- a/test-resources/csv/5-1/election_administration.txt
+++ b/test-resources/csv/5-1/election_administration.txt
@@ -1,0 +1,2 @@
+absentee_uri,am_i_registered_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri,id
+https://example.com/absentee,https://example.com/am-i-registered,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote,ea40133

--- a/test-resources/csv/5-1/voter_service.txt
+++ b/test-resources/csv/5-1/voter_service.txt
@@ -1,0 +1,2 @@
+description,election_official_person_id,type,other_type,parent_id,id
+A service we provide,eloff02,overseas-voting,,dep01,vs01

--- a/test-resources/csv/5-1/voter_service.txt
+++ b/test-resources/csv/5-1/voter_service.txt
@@ -1,2 +1,7 @@
 description,election_official_person_id,type,other_type,parent_id,id
 A service we provide,eloff02,overseas-voting,,dep01,vs01
+Abstainance-only voting,eloff01,voter-registration,,dep02,vs00
+Pencil sharpening,eloff03,other,office-help,dep03,vs02
+Guided hike to polling place,eloff04,polling-places,,dep03,vs03
+Bike messenger ballot delivery,eloff05,absentee-ballots,,dep03,vs04
+Carbon-copy ballots,eloff06,other,voter-replication,dep04,vs05

--- a/test/vip/data_processor/db/translations/v5_1/departments_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/departments_test.clj
@@ -1,0 +1,81 @@
+(ns vip.data-processor.db.translations.v5-1.departments-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.translations.v5-1.departments :as departments]
+            [vip.data-processor.db.translations.util :as util]))
+
+(deftest department->ltree-test
+  (let [idx-fn (util/index-generator 0)
+        parent-path "VipObject.0.ElectionAdministration.0"
+        departments [{:id "dep01"
+                      :election_official_person_id "eloff01"
+                      :ci_address_line_1 "Suite 824"
+                      :ci_address_line_2 "20 Jay St"
+                      :ci_address_line_3 "Brooklyn, NY 11201"
+                      :ci_directions "Take the F to York St."
+                      :ci_email "democracy@example.com"
+                      :ci_fax "555-555-1FAX"
+                      :ci_hours "10am to 6pm"
+                      :ci_hours_open_id "ho002"
+                      :ci_latitude "40.704"
+                      :ci_longitude "-73.989"
+                      :ci_latlng_source "Sean"
+                      :ci_name "Democracy Works"
+                      :ci_phone "555-555-5555"
+                      :ci_uri "http://democracy.works"}]
+        voter-services {"dep01" [{:id "vs01"
+                                  :type "overseas-voting"
+                                  :other_type nil
+                                  :ci_address_line_1 "Suite 824"
+                                  :ci_address_line_2 "20 Jay St"
+                                  :ci_address_line_3 "Brooklyn, NY 11201"
+                                  :ci_directions "Take the F to York St."
+                                  :ci_email "democracy@example.com"
+                                  :ci_fax "555-555-1FAX"
+                                  :ci_hours "10am to 6pm"
+                                  :ci_hours_open_id "ho002"
+                                  :ci_latitude "40.704"
+                                  :ci_longitude "-73.989"
+                                  :ci_latlng_source "Sean"
+                                  :ci_name "Democracy Works"
+                                  :ci_phone "555-555-5555"
+                                  :ci_uri "http://democracy.works"}]}
+        transform-fn (departments/departments->ltree
+                      departments voter-services
+                      "VipObject.0.ElectionAdministration.0.id")
+        ltree-entries (set (transform-fn idx-fn parent-path nil))]
+    (testing "AddressLines come from address_line_{1,2,3}"
+      (is (contains? ltree-entries
+                     {:path "VipObject.0.ElectionAdministration.0.Department.0.ContactInformation.0.AddressLine.0"
+                      :value "Suite 824"
+                      :simple_path "VipObject.ElectionAdministration.Department.ContactInformation.AddressLine"
+                      :parent_with_id "VipObject.0.ElectionAdministration.0.id"}))
+      (is (contains? ltree-entries
+                     {:path "VipObject.0.ElectionAdministration.0.Department.0.ContactInformation.0.AddressLine.1"
+                      :value "20 Jay St"
+                      :simple_path "VipObject.ElectionAdministration.Department.ContactInformation.AddressLine"
+                      :parent_with_id "VipObject.0.ElectionAdministration.0.id"}))
+      (is (contains? ltree-entries
+                     {:path "VipObject.0.ElectionAdministration.0.Department.0.ContactInformation.0.AddressLine.2"
+                      :value "Brooklyn, NY 11201"
+                      :simple_path "VipObject.ElectionAdministration.Department.ContactInformation.AddressLine"
+                      :parent_with_id "VipObject.0.ElectionAdministration.0.id"})))
+    (testing "Directions has the ElectionAdministration as the parent_with_id"
+      (is (contains? ltree-entries
+                     {:path "VipObject.0.ElectionAdministration.0.Department.0.ContactInformation.0.Directions.3.Text.0"
+                      :value "Take the F to York St."
+                      :simple_path "VipObject.ElectionAdministration.Department.ContactInformation.Directions.Text"
+                      :parent_with_id "VipObject.0.ElectionAdministration.0.id"})))
+    (testing "LatLng has the ElectionAdministration as the parent_with_id"
+      (is (contains? ltree-entries
+                     {:path "VipObject.0.ElectionAdministration.0.Department.0.ContactInformation.0.LatLng.8.Latitude.0"
+                      :value "40.704"
+                      :simple_path "VipObject.ElectionAdministration.Department.ContactInformation.LatLng.Latitude"
+                      :parent_with_id "VipObject.0.ElectionAdministration.0.id"})))
+
+    (testing "Departments include Voter Services"
+      (is (contains? ltree-entries
+                     {:path "VipObject.0.ElectionAdministration.0.Department.0.VoterService.2.label"
+                      :value "vs01"
+                      :simple_path "VipObject.ElectionAdministration.Department.VoterService.label"
+                      :parent_with_id "VipObject.0.ElectionAdministration.0.id"})))))

--- a/test/vip/data_processor/db/translations/v5_1/election_administrations_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/election_administrations_postgres_test.clj
@@ -1,0 +1,64 @@
+(ns vip.data-processor.db.translations.v5-1.election-administrations-postgres-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.test-helpers :refer :all]
+            [vip.data-processor.db.translations.v5-1.election-administrations :as eas]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.validation.csv :as csv]))
+
+(use-fixtures :once setup-postgres)
+
+(deftest ^:postgres transformer-test
+  (testing "election_administration.txt is loaded and transformed"
+    (let [ctx {:input (csv-inputs ["5-1/contact_information.txt"
+                                   "5-1/department.txt"
+                                   "5-1/voter_service.txt"
+                                   "5-1/election_administration.txt"])
+               :spec-version "5.1"
+               :ltree-index 0
+               :pipeline (concat
+                          [postgres/start-run]
+                          (get csv/version-pipelines "5.1")
+                          [eas/transformer])}
+          out-ctx (pipeline/run-pipeline ctx)]
+      (assert-no-problems out-ctx [])
+      (are-xml-tree-values
+       out-ctx
+       "ea40133" "VipObject.0.ElectionAdministration.0.id"
+       "https://example.com/absentee" "VipObject.0.ElectionAdministration.0.AbsenteeUri.0"
+       "https://example.com/am-i-registered" "VipObject.0.ElectionAdministration.0.AmIRegisteredUri.1"
+
+       ;; Department starts with a ContactInformation block
+       "ci2048" "VipObject.0.ElectionAdministration.0.Department.2.ContactInformation.0.label"
+       "Argyle Annex" "VipObject.0.ElectionAdministration.0.Department.2.ContactInformation.0.AddressLine.0"
+       "Argyle Pl" "VipObject.0.ElectionAdministration.0.Department.2.ContactInformation.0.AddressLine.1"
+       "argyle@example.com" "VipObject.0.ElectionAdministration.0.Department.2.ContactInformation.0.Email.4"
+       "sunup to sundown" "VipObject.0.ElectionAdministration.0.Department.2.ContactInformation.0.Hours.6.Text.0"
+       "en" "VipObject.0.ElectionAdministration.0.Department.2.ContactInformation.0.Hours.6.Text.0.language"
+       "Back porch coworking" "VipObject.0.ElectionAdministration.0.Department.2.ContactInformation.0.Name.7"
+
+       ;; One more part of the root Department type...
+       "eloff01" "VipObject.0.ElectionAdministration.0.Department.2.ElectionOfficialPersonId.1"
+
+       ;; ...and now into the VoterService block
+       ;; with another ContactInformation block
+       "ci0828" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ContactInformation.0.label"
+       "The White House" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ContactInformation.0.AddressLine.0"
+       "1600 Pennsylvania Ave" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ContactInformation.0.AddressLine.1"
+       "josh@example.com" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ContactInformation.0.Email.2"
+       "Early to very late" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ContactInformation.0.Hours.3.Text.0"
+       "en" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ContactInformation.0.Hours.3.Text.0.language"
+       "Josh Lyman" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ContactInformation.0.Name.4"
+
+       ;; ...and now we're back to the other parts of the voter service block
+       "A service we provide" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.Description.1.Text.0"
+       "en"  "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.Description.1.Text.0.language"
+       "eloff02" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.ElectionOfficialPersonId.2"
+       "overseas-voting" "VipObject.0.ElectionAdministration.0.Department.2.VoterService.2.Type.3"
+
+       ;; ...and now we're back to the ElectionAdministration block
+       "https://example.com/elections" "VipObject.0.ElectionAdministration.0.ElectionsUri.3"
+       "https://example.com/registration" "VipObject.0.ElectionAdministration.0.RegistrationUri.4"
+       "https://example.com/rules" "VipObject.0.ElectionAdministration.0.RulesUri.5"
+       "https://example.com/what-is-on-my-ballot" "VipObject.0.ElectionAdministration.0.WhatIsOnMyBallotUri.6"
+       "https://example.com/where-do-i-vote" "VipObject.0.ElectionAdministration.0.WhereDoIVoteUri.7"))))


### PR DESCRIPTION
In a sweeping finale, we have a _slightly more complex than usual_ ElectionAdministration element built from `department`, `contact_information`, and `voter_services` CSV files. This element has an unbounded number of departments, each of which has contact information and an unbounded number of voter services; it's safe to say that this could be a pretty broad tree.

[Pivotal card](https://www.pivotaltracker.com/story/show/119851529)