### PR TITLE
Validate that `xs:IDREFS` elements have referents

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -33,7 +33,8 @@
    external-identifiers/validate-no-missing-values
    id/validate-unique-ids
    id/validate-no-missing-ids
-   id/validate-idrefs-refer
+   id/validate-idref-references
+   id/validate-idrefs-references
    precinct/validate-no-missing-names
    precinct/validate-no-missing-locality-ids
    source/validate-one-source

--- a/src/vip/data_processor/validation/v5/id.clj
+++ b/src/vip/data_processor/validation/v5/id.clj
@@ -36,27 +36,61 @@
     WHERE xtv2.path IS NULL"
    util/two-import-ids))
 
-(defn validate-idref-type-refers
-  [{:keys [import-id] :as ctx} simple-path]
+(defn validate-ids-with
+  [{:keys [import-id] :as ctx} simple-path query]
   (let [bad-ids (korma/exec-raw
                  (:conn postgres/xml-tree-values)
-                 ["SELECT xtv.path, xtv.value FROM xml_tree_values xtv
-                   LEFT JOIN (SELECT value FROM xml_tree_values
-                              WHERE results_id = ? AND simple_path ~ '*{2}.id') xtv2
-                          ON xtv.value = xtv2.value
-                   WHERE xtv.results_id = ?
-                   AND xtv.simple_path = ?
-                   AND xtv2.value IS NULL"
-                  [import-id import-id simple-path]]
+                 query
                  :results)]
     (reduce (fn [ctx bad-id]
               (update-in ctx [:errors :id (.getValue (:path bad-id)) :no-referent]
                          conj (str (:value bad-id))))
             ctx bad-ids)))
 
-(defn validate-idrefs-refer
+(defn validate-idref-type-refers
+  [{:keys [import-id] :as ctx} simple-path]
+  (validate-ids-with ctx simple-path
+   ["SELECT xtv.path, xtv.value FROM xml_tree_values xtv
+     LEFT JOIN (SELECT value FROM xml_tree_values
+                 WHERE results_id = ? AND simple_path ~ '*{2}.id') xtv2
+            ON xtv.value = xtv2.value
+         WHERE xtv.results_id = ?
+           AND xtv.simple_path = ?
+           AND xtv2.value IS NULL"
+    [import-id import-id simple-path]]))
+
+(defn validate-idrefs-type-refers
+  "Look at `xs:IDREFS` types and find those that do not have a referent"
+  [{:keys [import-id] :as ctx} simple-path]
+  (validate-ids-with ctx simple-path
+   ["WITH referer
+       AS (SELECT results_id, path,
+                  UNNEST(string_to_array(value, ' ')) AS value,
+                  parent_with_id, simple_path
+             FROM xml_tree_values
+            WHERE simple_path = ?)
+     SELECT referer.path, referer.value
+       FROM referer
+       LEFT JOIN (SELECT value
+                    FROM xml_tree_values
+                   WHERE results_id = ?
+                     AND simple_path ~ '*{2}.id') referent
+              ON referer.value = referent.value
+           WHERE referer.results_id = ?
+             AND referer.simple_path = ?
+             AND referent.value IS NULL;"
+    [simple-path import-id import-id simple-path]]))
+
+(defn validate-idref-references
   [{:keys [import-id spec-version] :as ctx}]
   (let [idref-simple-paths (->> (spec/type->simple-paths "xs:IDREF" spec-version)
                                 (map postgres/path->ltree))]
     (reduce validate-idref-type-refers
             ctx idref-simple-paths)))
+
+(defn validate-idrefs-references
+  [{:keys [import-id spec-version] :as ctx}]
+  (let [idrefs-simple-paths (->> (spec/type->simple-paths "xs:IDREFS" spec-version)
+                                 (map postgres/path->ltree))]
+    (reduce validate-idrefs-type-refers
+            ctx idrefs-simple-paths)))

--- a/test-resources/xml/v5-idrefs.xml
+++ b/test-resources/xml/v5-idrefs.xml
@@ -16,10 +16,27 @@
     <FirstName>Dave</FirstName>
     <PartyId>par004</PartyId>
   </Person>
+
   <Party id="par001">
     <Name><Text language="en">Democratic</Text></Name>
   </Party>
   <Party id="par002">
     <Name><Text language="en">Republican</Text></Name>
   </Party>
+
+  <PollingLocation id="poll01">
+    <AddressLine>123 Lonely Ln</AddressLine>
+  </PollingLocation>
+
+  <Locality id="l001">
+    <Name>I'm a locality!</Name>
+    <Type>city</Type>
+    <PollingLocationIds>poll01</PollingLocationIds>
+  </Locality>
+
+  <Locality id="l002">
+    <Name>I'm a locality too!</Name>
+    <Type>planet</Type>
+    <PollingLocationIds>poll01 poll02 poll03</PollingLocationIds>
+  </Locality>
 </VipObject>

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -43,11 +43,32 @@
              :spec-version "5.1"
              :pipeline [psql/start-run
                         load-xml-ltree
-                        v5.id/validate-idrefs-refer]}
+                        v5.id/validate-idref-references
+                        v5.id/validate-idrefs-references]}
         out-ctx (pipeline/run-pipeline ctx)]
+
     (testing "IDREF elements that don't have referents are flagged"
       (is (get-in out-ctx [:errors :id "VipObject.0.Person.1.PartyId.1" :no-referent]))
       (is (get-in out-ctx [:errors :id "VipObject.0.Person.3.PartyId.1" :no-referent])))
+
     (testing "IDREF elements that point to something are good"
       (assert-no-problems out-ctx [:errors :id "VipObject.0.Person.0.PartyId.1"])
       (assert-no-problems out-ctx [:errors :id "VipObject.0.Person.2.PartyId.1"]))))
+
+(deftest ^:postgres validate-idrefs-plural-refer-test
+  (let [ctx {:input (xml-input "v5-idrefs.xml")
+             :spec-version "5.1"
+             :pipeline [psql/start-run
+                        load-xml-ltree
+                        v5.id/validate-idrefs-references]}
+        out-ctx (pipeline/run-pipeline ctx)]
+
+    (testing "IDREFS elements that don't have any referents are flagged"
+      (is (get-in
+           out-ctx
+           [:errors :id "VipObject.0.Locality.8.PollingLocationIds.2" :no-referent])))
+
+    (testing "IDREFS elements that point to some things are good"
+      (assert-no-problems
+       out-ctx
+       [:errors :id "VipObject.0.Locality.11.PollingLocationIds.3"]))))


### PR DESCRIPTION
Some of the `xs:IDREF` elements changed to `xs:IDREFS` elements in the 5.1 spec, but not all of them. What was once a single element now is a space-delimited string. Links to specs, etc, are in the [Pivotal card](https://www.pivotaltracker.com/story/show/120708149)

This updates the validations to work with both types; the original query seemed useful, so I tried to find a way to turn a single row containing multiple IDs into multiple rows so I could use the same query.  I _think_ this is a pretty idiomatic way to use Postgres, but if not, let's discuss!

