### PR TITLE
Write 5.1 XML from CSV imports

### DIFF
--- a/resources/migrations/20160616-add-insert-counter-to-xml-tree-values.down.sql
+++ b/resources/migrations/20160616-add-insert-counter-to-xml-tree-values.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE xml_tree_values
+DROP COLUMN insert_counter;

--- a/resources/migrations/20160616-add-insert-counter-to-xml-tree-values.up.sql
+++ b/resources/migrations/20160616-add-insert-counter-to-xml-tree-values.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE xml_tree_values
+ADD COLUMN insert_counter BIGSERIAL;

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -312,7 +312,7 @@
               (bulk-import ctx
                            (ent v3-0-import-entities) ; TODO: choose import-entities based on import version
                            (->> table
-                                (db.util/select-*-lazily 5000)
+                                (db.util/lazy-select 5000)
                                 (map #(assoc % :results_id import-id))
                                 (data-spec/coerce-rows columns)))))
           ctx

--- a/src/vip/data_processor/db/translations/util.clj
+++ b/src/vip/data_processor/db/translations/util.clj
@@ -74,14 +74,14 @@
                text-path (str base-path "." xml-element "." index ".Text.0")
                lang-path (str text-path ".language")]
            (list
-            {:path text-path
-             :simple_path (path->simple-path text-path)
-             :parent_with_id parent-with-id
-             :value value}
             {:path lang-path
              :simple_path (path->simple-path lang-path)
              :parent_with_id parent-with-id
-             :value "en"})))))))
+             :value "en"}
+            {:path text-path
+             :simple_path (path->simple-path text-path)
+             :parent_with_id parent-with-id
+             :value value})))))))
 
 (defn external-identifiers->ltree
   [idx-fn parent-path row]

--- a/src/vip/data_processor/db/util.clj
+++ b/src/vip/data_processor/db/util.clj
@@ -143,17 +143,16 @@
                                   [message]))))))))
           ctx (chunk-rows rows statement-parameter-limit)))
 
-(defn select-*-lazily [chunk-size sql-table]
-  (let [total (-> sql-table
-                  (korma/select (korma/aggregate (count "*") :total))
-                  first
-                  :total)]
-    (letfn [(chunked-rows [page]
-              (let [offset (* page chunk-size)]
-                (when (< offset total)
-                  (lazy-cat
-                   (korma/select sql-table
-                                 (korma/offset offset)
-                                 (korma/limit chunk-size))
-                   (chunked-rows (inc page))))))]
-      (chunked-rows 0))))
+(defmacro lazy-select
+  [chunk-size sql-table & body]
+  `(letfn [(chunked-rows# [page#]
+             (let [offset# (* page# ~chunk-size)
+                   this-chunk# (korma/select ~sql-table
+                                             ~@body
+                                             (korma/offset offset#)
+                                             (korma/limit ~chunk-size))]
+               (when (seq this-chunk#)
+                 (lazy-cat
+                  this-chunk#
+                  (chunked-rows# (inc page#))))))]
+     (chunked-rows# 0)))

--- a/src/vip/data_processor/output/tree_xml.clj
+++ b/src/vip/data_processor/output/tree_xml.clj
@@ -1,0 +1,146 @@
+(ns vip.data-processor.output.tree-xml
+  (:require [clojure.data.xml :as xml]
+            [clojure.java.io :as io]
+            [korma.core :as korma]
+            [vip.data-processor.output.xml-helpers :refer [create-xml-file]]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.util :as db.util])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]
+           [org.apache.commons.lang StringEscapeUtils]))
+
+(defn attr
+  "Return the attribute of a path, if there is one."
+  [path]
+  (->> path
+       (re-find #"(?:\.)(\D+)\z")
+       second))
+
+(defn opening-tag
+  [tag]
+  (str "<" tag ">"))
+
+(defn closing-tag
+  [tag]
+  (str "</" tag ">"))
+
+(defn tags-with-indexes
+  "Returns a seq of the tags, with their indexes, of a path. Does not
+  include attributes.
+
+  (tags-with-indexes \"Root.0.Tag.10.id\") ;=> (\"Root.0\" \"Tag.10\")"
+  [path]
+  (when path
+    (re-seq #"\w+\.\d+" path)))
+
+(defn same-tag?
+  "Are the two paths about the same tag. Thus:
+
+  (same-tag? \"Root.0.Tag.10.id\" \"Root.0.Tag.10\") ;=> true"
+  [prev-path path]
+  (= (tags-with-indexes prev-path)
+     (tags-with-indexes path)))
+
+(defn shared-prefix
+  "Returns a seq of the shared initial elements of two sequences."
+  [a b]
+  (loop [a a
+         b b
+         result []]
+    (if (or (empty? a)
+            (empty? b))
+      result
+      (let [[a1 & a-rest] a
+            [b1 & b-rest] b]
+        (if (= a1 b1)
+          (recur a-rest
+                 b-rest
+                 (conj result a1))
+          result)))))
+
+(defn tag-without-index
+  "Given a tag with an index, return the tag without the index."
+  [tag-with-index]
+  (re-find #"\A[^.]*" tag-with-index))
+
+(defn to-close-and-to-open
+  "Given a previous path and a current path, return the tags needed to
+  be closed and the tags needed to be opened to transition from one to
+  the other."
+  [prev-path path]
+  (let [prev-parts (tags-with-indexes prev-path)
+        next-parts (tags-with-indexes path)
+        shared-prefix (shared-prefix prev-parts next-parts)]
+    {:to-close (->> prev-parts
+                    (drop (count shared-prefix))
+                    (map tag-without-index)
+                    reverse)
+     :to-open (->> next-parts
+                   (drop (count shared-prefix))
+                   (map tag-without-index))}))
+
+(defn map-str [f]
+  (fn [coll]
+    (->> coll
+         (map f)
+         (apply str))))
+
+(def opening-tags (map-str opening-tag))
+(def closing-tags (map-str closing-tag))
+
+(defn write-xml [file spec-version import-id]
+  (with-open [f (io/writer (.toFile file))]
+    (.write f (str "<?xml version=\"1.0\"?>\n<VipObject xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" schemaVersion=\"" spec-version "\" xsi:noNamespaceSchemaLocation=\"http://votinginfoproject.github.com/vip-specification/vip_spec.xsd\">\n"))
+    (let [last-seen-path (atom "VipObject.0")
+          inside-open-tag (atom false)]
+      (doseq [{:keys [path value simple_path] :as row}
+              (db.util/lazy-select 1000
+                                   postgres/xml-tree-values
+                                   (korma/where {:results_id import-id})
+                                   (korma/order :insert_counter :ASC))]
+        (let [path (.getValue path)
+              simple_path (.getValue simple_path)
+              escaped-value (StringEscapeUtils/escapeXml value)]
+          (if-let [attribute (attr path)]
+            (do
+              (if @inside-open-tag
+                (if (same-tag? @last-seen-path path)
+                  (.write f (str " " attribute "=\"" escaped-value "\""))
+                  (let [{:keys [to-close
+                                to-open]} (to-close-and-to-open @last-seen-path path)
+                        last-tag (last to-open)
+                        tags-to-open (butlast to-open)]
+                    (.write f ">")
+                    (.write f (closing-tags to-close))
+                    (.write f (opening-tags tags-to-open))
+                    (.write f (str "<" last-tag " " attribute "=\"" escaped-value "\""))))
+                (let [{:keys [to-close
+                              to-open]} (to-close-and-to-open @last-seen-path path)
+                      last-tag (last to-open)
+                      tags-to-open (butlast to-open)]
+                  (.write f (closing-tags to-close))
+                  (.write f (opening-tags tags-to-open))
+                  (.write f (str "<" last-tag " " attribute "=\"" escaped-value "\""))))
+              (reset! inside-open-tag true))
+            (do
+              (when @inside-open-tag
+                (.write f ">"))
+              (let [{:keys [to-close
+                            to-open]} (to-close-and-to-open @last-seen-path path)]
+                (.write f (closing-tags to-close))
+                (.write f (opening-tags to-open))
+                (.write f escaped-value))
+              (reset! inside-open-tag false)))
+          (reset! last-seen-path path)))
+      (let [{:keys [to-close]} (to-close-and-to-open @last-seen-path "")]
+        (when @inside-open-tag
+          (.write f ">"))
+        (.write f (closing-tags to-close))))))
+
+(defn generate-xml-file [{:keys [spec-version import-id xml-output-file] :as ctx}]
+  (write-xml xml-output-file spec-version import-id)
+  ctx)
+
+(def pipeline
+  [create-xml-file
+   generate-xml-file])

--- a/src/vip/data_processor/output/v3_0/street_segment.clj
+++ b/src/vip/data_processor/output/v3_0/street_segment.clj
@@ -26,5 +26,5 @@
 
 (defn xml-nodes [ctx]
   (let [sql-table (get-in ctx [:tables :street-segments])
-        street-segments (util/select-*-lazily chunk-size sql-table)]
+        street-segments (util/lazy-select chunk-size sql-table)]
     (map ->xml street-segments)))

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -19,20 +19,13 @@
             [clojure.java.io :as io]
             [clojure.walk :as walk]
             [com.climate.newrelic.trace :refer [defn-traced]]
-            [vip.data-processor.output.v3-0.xml :as v3-0])
-  (:import [java.nio.file Files]
-           [java.nio.file.attribute FileAttribute]
-           [javax.xml XMLConstants]
+            [vip.data-processor.output.v3-0.xml :as v3-0]
+            [vip.data-processor.output.xml-helpers :refer [create-xml-file]])
+  (:import [javax.xml XMLConstants]
            [javax.xml.transform.stream StreamSource]
            [javax.xml.validation SchemaFactory]
            [org.xml.sax SAXParseException]
            [org.apache.commons.lang StringEscapeUtils]))
-
-(defn create-xml-file [{:keys [filename] :as ctx}]
-  (let [xml-file (Files/createTempFile filename ".xml" (into-array FileAttribute []))]
-    (-> ctx
-        (assoc :xml-output-file xml-file)
-        (update :to-be-cleaned conj xml-file))))
 
 (def ^:const SPACE " ")
 (def ^:const OPEN-VALUE "=\"")

--- a/src/vip/data_processor/output/xml_helpers.clj
+++ b/src/vip/data_processor/output/xml_helpers.clj
@@ -1,5 +1,14 @@
 (ns vip.data-processor.output.xml-helpers
-  (:require [korma.core :as korma]))
+  (:require [korma.core :as korma])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn create-xml-file
+  [{:keys [filename] :as ctx}]
+  (let [xml-file (Files/createTempFile filename ".xml" (into-array FileAttribute []))]
+    (-> ctx
+        (assoc :xml-output-file xml-file)
+        (update :to-be-cleaned conj xml-file))))
 
 (defmacro xml-node [name]
   (let [tag (keyword name)]

--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -45,7 +45,9 @@
     :else fips))
 
 (defn zip-filename* [fips election-date]
-  (join "-" ["vipfeed" (format-fips fips) election-date]))
+  (let [fips (format-fips fips)
+        date (util/format-date election-date)]
+    (str (join "-" ["vipfeed" fips date]) ".zip")))
 
 (defn zip-filename
   [{:keys [spec-version tables import-id] :as ctx}]
@@ -60,8 +62,7 @@
                             :elections
                             korma/select
                             first
-                            :date
-                            util/format-date)]
+                            :date)]
       (zip-filename* fips election-date))
 
     "5.1"
@@ -74,7 +75,7 @@
 (defn upload-to-s3
   "Uploads the generated xml file to the specified S3 bucket."
   [{:keys [xml-output-file] :as ctx}]
-  (let [zip-name (str (zip-filename ctx) ".zip")
+  (let [zip-name (zip-filename ctx)
         zip-dir (Files/createTempDirectory tmp-path-prefix
                                            (into-array FileAttribute []))
         zip-file (File. (.toFile zip-dir) zip-name)

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -11,6 +11,7 @@
             [vip.data-processor.validation.csv.file-set :as csv-files]
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [vip.data-processor.output.tree-xml :as tree-xml]
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.db.translations.transformer :as v5-1-transformers]))
@@ -149,7 +150,8 @@
    "5.1" (concat [(fn [ctx] (assoc ctx :tables postgres/v5-1-tables))
                   (fn [ctx] (assoc ctx :ltree-index 0))
                   load-csvs]
-                 v5-1-transformers/transformers)})
+                 v5-1-transformers/transformers
+                 tree-xml/pipeline)})
 
 (defn branch-on-spec-version [{:keys [spec-version] :as ctx}]
   (if-let [pipeline (get version-pipelines spec-version)]

--- a/test/vip/data_processor/db/translations/util_test.clj
+++ b/test/vip/data_processor/db/translations/util_test.clj
@@ -59,14 +59,14 @@
           transform-fn (util/internationalized-text->ltree :instructions)
           idx-fn (util/index-generator 0)]
       (is (= (list
-              {:path "VipObject.0.BallotMeasureContest.0.Instructions.0.Text.0"
-               :simple_path "VipObject.BallotMeasureContest.Instructions.Text"
-               :parent_with_id "VipObject.0.BallotMeasureContest.0.id"
-               :value "Pat your head and rub your belly"}
               {:path "VipObject.0.BallotMeasureContest.0.Instructions.0.Text.0.language"
                :simple_path "VipObject.BallotMeasureContest.Instructions.Text.language"
                :parent_with_id "VipObject.0.BallotMeasureContest.0.id"
-               :value "en"})
+               :value "en"}
+              {:path "VipObject.0.BallotMeasureContest.0.Instructions.0.Text.0"
+               :simple_path "VipObject.BallotMeasureContest.Instructions.Text"
+               :parent_with_id "VipObject.0.BallotMeasureContest.0.id"
+               :value "Pat your head and rub your belly"})
              (transform-fn idx-fn "VipObject.0.BallotMeasureContest.0" row))))))
 
 (deftest external-identifiers->ltree-test

--- a/test/vip/data_processor/output/tree_xml_postgres_test.clj
+++ b/test/vip/data_processor/output/tree_xml_postgres_test.clj
@@ -1,0 +1,72 @@
+(ns vip.data-processor.output.tree-xml-postgres-test
+  (:require [clojure.test :refer :all]
+            [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.output.tree-xml :refer :all]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.test-helpers :refer :all]))
+
+(use-fixtures :once setup-postgres)
+
+(deftest ^:postgres pipeline-test
+  (let [import-id (-> postgres/results
+                      (korma/insert
+                       (korma/values {:public_id (name (gensym))}))
+                      :id)
+        _ (korma/insert postgres/xml-tree-values
+            (korma/values
+             [{:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.id")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "can001"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.Name.0")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.Name")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "Frank"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.Party.1")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.Party")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "Every day"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.Title.2.Text.0.language")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.Title.Text.language")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "en"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.Title.2.Text.0")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.Title.Text")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "President"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.Title.2.Text.1.language")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.Title.Text.language")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "es"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.Title.2.Text.1")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.Title.Text")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "\"El\" Presidente"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Candidate.0.Nickname.3")
+               :simple_path (postgres/path->ltree "VipObject.Candidate.Nickname")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Candidate.0.id")
+               :value "> Ezra"}
+              {:results_id import-id
+               :path (postgres/path->ltree "VipObject.0.Contest.1.id")
+               :simple_path (postgres/path->ltree "VipObject.Contest.id")
+               :parent_with_id (postgres/path->ltree "VipObject.0.Contest.1.id")
+               :value "con001"}]))
+        ctx {:spec-version "5.1.2"
+             :import-id import-id
+             :pipeline pipeline}
+        out-ctx (pipeline/run-pipeline ctx)]
+    (assert-no-problems out-ctx [])
+    (is (= (-> out-ctx
+               :xml-output-file
+               .toFile
+               slurp)
+           "<?xml version=\"1.0\"?>\n<VipObject xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" schemaVersion=\"5.1.2\" xsi:noNamespaceSchemaLocation=\"http://votinginfoproject.github.com/vip-specification/vip_spec.xsd\">\n<Candidate id=\"can001\"><Name>Frank</Name><Party>Every day</Party><Title><Text language=\"en\">President</Text><Text language=\"es\">&quot;El&quot; Presidente</Text></Title><Nickname>&gt; Ezra</Nickname></Candidate><Contest id=\"con001\"></Contest></VipObject>"))))

--- a/test/vip/data_processor/output/tree_xml_test.clj
+++ b/test/vip/data_processor/output/tree_xml_test.clj
@@ -1,0 +1,52 @@
+(ns vip.data-processor.output.tree-xml-test
+  (:require [vip.data-processor.output.tree-xml :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest attr-test
+  (testing "returns the attribute of a path when it is present"
+    (is (= "language"
+           (attr "Root.0.Tag.0.Text.0.language"))))
+  (testing "returns `nil` when the path doens't have an attribute"
+    (is (nil? (attr "Root.0.Tag.0.Thingy.1")))))
+
+(deftest tags-with-indexes-test
+  (testing "indexes are included"
+    (is (= '("Root.0" "Tag.0" "Thingy.1")
+           (tags-with-indexes "Root.0.Tag.0.Thingy.1"))))
+
+  (testing "attributes are not included"
+    (let [path "VipObject.0.Candidate.0.BallotName.0.Text.0.language"
+          result (set (tags-with-indexes path))]
+      (is (not (contains? result "language"))))))
+
+(deftest same-tag?-test
+  (testing "wasn't born yesterday"
+    (is (not (same-tag? "Root.0.Tag.0" "Toor.0.Gat.0"))))
+
+  (testing "looks at tags, ignores attributes"
+    (is (same-tag? "Root.0.Tag.0" "Root.0.Tag.0.language")))
+
+  (testing "doesn't care about indexes"
+    (is (not (same-tag? "Root.0.Tag.0" "Root.0.Tag.1")))))
+
+(deftest shared-prefix-test
+  (testing "finds the common set of tags, left to right"
+    (let [seq1 (tags-with-indexes "Root.0.Tag.0.Divergent.1")
+          seq2 (tags-with-indexes "Root.0.Tag.0.UniqueRabbit.2")]
+      (is (= ["Root.0" "Tag.0"]
+             (shared-prefix seq1 seq2))))))
+
+(deftest to-close-and-to-open-test
+  (testing "when paths change, tags must be closed"
+    (is (= {:to-close '("Thingy" "Tag")
+            :to-open '("Gat" "Whizbang")}
+           (to-close-and-to-open
+            "Root.0.Tag.0.Thingy.0"
+            "Root.0.Gat.1.Whizbang.0"))))
+
+  (testing "in a sequence of the same tag, we open and close the same type"
+    (is (= {:to-close '("Thingy")
+            :to-open '("Thingy")}
+           (to-close-and-to-open
+            "Root.0.Tag.0.Thingy.0"
+            "Root.0.Tag.0.Thingy.1")))))

--- a/test/vip/data_processor/output/xml_helpers_test.clj
+++ b/test/vip/data_processor/output/xml_helpers_test.clj
@@ -1,0 +1,9 @@
+(ns vip.data-processor.output.xml-helpers-test
+  (:require [vip.data-processor.output.xml-helpers :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest create-xml-file-test
+  (testing "adds an :xml-output-file key to a context"
+    (let [ctx {:filename "create-xml-test"}
+          out-ctx (create-xml-file ctx)]
+      (is (:xml-output-file out-ctx)))))

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -14,12 +14,6 @@
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]))
 
-(deftest create-xml-file-test
-  (testing "adds an :xml-output-file key to a context"
-    (let [ctx {:filename "create-xml-test"}
-          out-ctx (create-xml-file ctx)]
-      (is (:xml-output-file out-ctx)))))
-
 (deftest write-xml-test
   (testing "generates XML from an import"
     (let [db (sqlite/temp-db "xml-output" "3.0")

--- a/test/vip/data_processor/s3_test.clj
+++ b/test/vip/data_processor/s3_test.clj
@@ -1,0 +1,16 @@
+(ns vip.data-processor.s3-test
+  (:require [vip.data-processor.s3 :refer :all]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest zip-filename*-test
+  (testing "nicely formatted dates make nice filenames"
+    (is (= "vipfeed-51-2015-03-24.zip"
+           (zip-filename* "51" "2015-03-24"))))
+
+  (testing "workably formatted dates make nice filenames"
+    (is (= "vipfeed-52-2015-03-27.zip"
+           (zip-filename* "52" "2015/03/27"))))
+
+  (testing "poorly formatted dates use a workable filename"
+    (is (= "vipfeed-12345.zip"
+           (zip-filename* "12345" nil)))))

--- a/test/vip/data_processor/s3_test.clj
+++ b/test/vip/data_processor/s3_test.clj
@@ -12,5 +12,5 @@
            (zip-filename* "52" "2015/03/27"))))
 
   (testing "poorly formatted dates use a workable filename"
-    (is (= "vipfeed-12345.zip"
+    (is (= "vipfeed-12345-.zip"
            (zip-filename* "12345" nil)))))

--- a/test/vip/data_processor/util_test.clj
+++ b/test/vip/data_processor/util_test.clj
@@ -27,3 +27,11 @@
   (testing "but if it's a partial date, no dice!"
     (is (nil? (format-date "1983/01")))))
 
+(deftest flatten-keys-test
+  (testing "a nested map collapses into a single map"
+    (is (= {[:some :path :to :a] "value"}
+           (flatten-keys {:some {:path {:to {:a "value"}}}}))))
+
+  (testing "when we run into a vector, that becomes part of the value"
+    (is (= {[:to :flatten :or] [:not {:to "flatten"}]}
+           (flatten-keys {:to {:flatten {:or [:not {:to "flatten"}]}}})))))

--- a/test/vip/data_processor/util_test.clj
+++ b/test/vip/data_processor/util_test.clj
@@ -16,3 +16,14 @@
       (is (nil? (find-input-file ctx "DOES_NOT_EXIST.txt"))))
     (testing "finds files without regard to the file's case"
       (is (= upper-case-source (find-input-file ctx "source.txt"))))))
+
+(deftest format-date-test
+  (testing "date-strings with forward-slashes are normalized"
+    (is (= "1983-01-16" (format-date "1983/01/16"))))
+
+  (testing "date-strings without a forward-slash pass through"
+    (is (= "19830116" (format-date "19830116"))))
+
+  (testing "but if it's a partial date, no dice!"
+    (is (nil? (format-date "1983/01")))))
+


### PR DESCRIPTION
Now that 5.1 imports are translated into a tree that represents the resulting XML document, we can actually write that XML to a file.

The approach is essentially:

1. Pull the `xml_tree_values` rows out of the database in insert order.
2. Read through them, one by one, writing a fragment of XML for each row, closing and opening tags as necessary between rows.

By inserting the `xml_tree_values` rows in the order that the `write-xml` function needs them, we're able to avoid costly and complex ordering logic. A migration was added to include an auto-incrementing column (`SERIAL` Postgres type) which we `ORDER BY` when pulling the rows. To that end, rows for InternationalizedText elements needed their order swapped (attribute first, then data). Otherwise, we were already inserting in order!

The `write-xml` function is pretty stateful and procedural... but it's reading from a database and writing to a file. That's going to be stateful and procedural. Fortunately, it's not too long.

Pivotal stories: [120708367](https://www.pivotaltracker.com/story/show/120708367) and [121595323](https://www.pivotaltracker.com/story/show/121595323)