### PR TITLE
Update severity for invalid electoral district type

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -18,7 +18,7 @@
 (defn create-format-rule
   "Create a function that applies a format check for a specific
   element of an import."
-  [scope {:keys [name required format]}]
+  [scope {:keys [name required format severity] :or {severity :errors}}]
   (let [{:keys [check message]} format
         test-fn (cond
                  (sequential? check) (fn [val]
@@ -40,7 +40,7 @@
           (assoc-in ctx [:errors scope identifier name] ["Is not valid UTF-8."])
 
           (not (test-fn val))
-          (assoc-in ctx [:errors scope identifier name] [(str message ": " val)])
+          (assoc-in ctx [severity scope identifier name] [(str message ": " val)])
 
           :else ctx)))))
 

--- a/src/vip/data_processor/validation/data_spec/v3_0.clj
+++ b/src/vip/data_processor/validation/data_spec/v3_0.clj
@@ -192,7 +192,7 @@
     :stats true
     :columns [{:name "id" :required :critical :format format/all-digits :coerce coerce/coerce-integer}
               {:name "name" :required :critical}
-              {:name "type" :format format/electoral-district-type}
+              {:name "type" :format format/electoral-district-type :severity :warnings}
               {:name "number" :format format/all-digits :coerce coerce/coerce-integer}]}
    {:filename "locality.txt"
     :table :localities

--- a/test/vip/data_processor/validation/data_spec_test.clj
+++ b/test/vip/data_processor/validation/data_spec_test.clj
@@ -95,6 +95,16 @@
             (is (= (ffirst (get-in (format-rule ctx {column "abcdefg" "id" id} line-number) [:errors filename id]))
                    column))
             (is (= (ffirst (get-in (format-rule ctx {column "cleveland" "id" id} line-number) [:errors filename id]))
+                   column))))
+        (testing "with a severity key, uses that severity"
+          (let [format-rule (create-format-rule filename
+                                                {:name column
+                                                 :format format/yes-no
+                                                 :severity :warnings})]
+            (is (= (-> ctx
+                       (format-rule {column "nyet" "id" id} line-number)
+                       (get-in [:warnings filename id])
+                       ffirst)
                    column)))))
       (testing "if there's no check function, everything is okay"
         (let [format-rule (create-format-rule filename {:name column})]


### PR DESCRIPTION
Changes error severity for invalid electoral district type from "errors" to "warnings".

Pivotal story: [117504391](https://www.pivotaltracker.com/story/show/117504391)