### PR TITLE
XML validation errors are not fatal

### DIFF
--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -88,7 +88,7 @@
       (.validate validator (StreamSource. (.toFile xml-output-file)))
       ctx
       (catch SAXParseException e
-        (assoc-in ctx [:fatal :xml-generation :global :invalid-xml] [(.getMessage e)])))))
+        (assoc-in ctx [:error :xml-generation :global :invalid-xml] [(.getMessage e)])))))
 
 (def pipeline
   [create-xml-file

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -88,7 +88,7 @@
       (.validate validator (StreamSource. (.toFile xml-output-file)))
       ctx
       (catch SAXParseException e
-        (assoc-in ctx [:error :xml-generation :global :invalid-xml] [(.getMessage e)])))))
+        (assoc-in ctx [:errors :xml-generation :global :invalid-xml] [(.getMessage e)])))))
 
 (def pipeline
   [create-xml-file

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -82,3 +82,25 @@
       (is (= "certified" (:certification (xpath/$x:attrs "/vip_object/ballot_line_result" xml-doc))))
       (is (= "unofficial_complete" (:certification (xpath/$x:attrs "/vip_object/contest_result[@id=867001]" xml-doc))))
       (is (= "certified" (:certification (xpath/$x:attrs "/vip_object/contest_result[@id=867002]" xml-doc)))))))
+
+(deftest validate-xml-test
+  (testing "good data generates validatable XML"
+    (let [good-xml (-> "xml/full-good-run.xml"
+                      io/resource
+                      io/file
+                      .toPath)
+          ctx {:xml-output-file good-xml
+               :vip-version "3.0"}
+          results-ctx (validate-xml-output ctx)]
+      (assert-no-problems results-ctx [])))
+
+  (testing "bad XML won't validate, giving an `:error`"
+    (let [bad-xml (-> "xml/malformed.xml"
+                      io/resource
+                      io/file
+                      .toPath)
+          ctx {:xml-output-file bad-xml
+               :vip-version "3.0"}
+          results-ctx (validate-xml-output ctx)]
+      (is (= '(:invalid-xml)
+             (keys (get-in results-ctx [:error :xml-generation :global])))))))

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -94,7 +94,7 @@
           results-ctx (validate-xml-output ctx)]
       (assert-no-problems results-ctx [])))
 
-  (testing "bad XML won't validate, giving an `:error`"
+  (testing "bad XML won't validate, adding to `:errors`"
     (let [bad-xml (-> "xml/malformed.xml"
                       io/resource
                       io/file
@@ -103,4 +103,4 @@
                :vip-version "3.0"}
           results-ctx (validate-xml-output ctx)]
       (is (= '(:invalid-xml)
-             (keys (get-in results-ctx [:error :xml-generation :global])))))))
+             (keys (get-in results-ctx [:errors :xml-generation :global])))))))


### PR DESCRIPTION
Google is accepting XML that doesn't validate against the schema, so it
doesn't make sense to call it `:fatal`; let's call it an `:error`
instead.

[Pivotal Story](https://www.pivotaltracker.com/story/show/117504193)