### PR TITLE
Fix v5 public ids

### DIFF
--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -163,7 +163,7 @@
               "VipObject.0.Election.*{1}.Date.*{1}")
         election-type (find-single-xml-tree-value
                        import-id
-                       "VipObject.0.Election.*{1}.ElectionType.*{1}")]
+                       "VipObject.0.Election.*{1}.ElectionType.*{1}.Text.*{1}")]
     {:date date
      :election-type election-type
      :state state

--- a/test/vip/data_processor/validation/v5_test.clj
+++ b/test/vip/data_processor/validation/v5_test.clj
@@ -32,4 +32,12 @@
                                (csv/version-pipelines "5.1")
                                v5/validations)}
         out-ctx (pipeline/run-pipeline ctx)]
-    (assert-no-problems out-ctx [])))
+    (assert-no-problems out-ctx [])
+
+    (testing "the data for building a public_id is correctly fetched"
+      (is (= {:date "10/08/2016"
+              :election-type "Edible"
+              :state "Virginia"}
+             (dissoc
+              (psql/get-xml-tree-public-id-data out-ctx)
+              :import-id))))))


### PR DESCRIPTION
`ElectionType` is an internationalized text element, so we need to adjust the ltree path. This lets us build a `public_id` that will be what Metis expects. Related to https://github.com/votinginfoproject/Metis/pull/320