### PR TITLE
Handle csv errors in 5.1 feeds

### DIFF
--- a/src/vip/data_processor/db/tree_statistics.clj
+++ b/src/vip/data_processor/db/tree_statistics.clj
@@ -34,7 +34,8 @@
          coalesce(errors.error_count, 0) as error_count,
          coalesce(values.value_count, 0) as count
   FROM values
-  FULL OUTER JOIN errors ON errors.element_type = values.element_type;")))
+  FULL OUTER JOIN errors ON errors.element_type = values.element_type
+  WHERE values.element_type IS NOT NULL;")))
 
 (def camel-case-splitter #"(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")
 

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -38,6 +38,13 @@
             (assoc :input good-files)))
       ctx)))
 
+(defn csv-error-path [filename line-number]
+  (str "CSVError.0."
+       (-> filename
+           (str/split #"\.")
+           first)
+       "." line-number))
+
 (defn read-one-line
   "Reads one line at a time from a reader and parses it as a CSV
   string. Does not close the reader at the end, that's your job."
@@ -107,11 +114,7 @@
                                       (db.util/retry-chunk-without-dupe-ids ctx sql-table chunk-values)
                                       (let [identifier (if (= "3.0" (:spec-version ctx))
                                                          @line-number
-                                                         (str "CSVError.0."
-                                                              (-> filename
-                                                                  (str/split #"\.")
-                                                                  first)
-                                                              "." @line-number))]
+                                                         (csv-error-path filename @line-number))]
                                         (assoc-in ctx [:fatal (:name sql-table) identifier :unknown-sql-error]
                                                   [message])))))))
                             ctx))


### PR DESCRIPTION
CSV errors were trying to put the line number as the "path" for errors in 5.1 feeds. Postgres does not like numbers in the place of an ltree path. So let's create a path for these kinds of errors.

Additionally, fix a lingering bug in the statistics query which was still trying to insert values into non-existent columns if the "element" didn't match a "value".