### PR TITLE
Fix identifier for number of values validation

### DIFF
--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -95,9 +95,12 @@
                                                       ctx (data-spec/apply-format-rules format-rules ctx row-map @line-number)]
                                                   (if (= headers-count row-count)
                                                     ctx
-                                                    (assoc-in ctx [:critical table @line-number :number-of-values]
-                                                              [(str "Expected " headers-count
-                                                                    " values, found " row-count)]))))
+                                                    (let [identifier (if (= "3.0" (:spec-version ctx))
+                                                                       @line-number
+                                                                       (csv-error-path filename @line-number))]
+                                                      (assoc-in ctx [:critical table identifier :number-of-values]
+                                                                [(str "Expected " headers-count
+                                                                      " values, found " row-count)])))))
                                               ctx chunk)
                                   chunk-values (map (comp transforms #(select-keys % column-names) (partial zipmap headers)) chunk)
                                   chunk-values (if (= "postgresql" (get-in sql-table [:db :options :subprotocol]))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -67,6 +67,7 @@
 
 (deftest report-bad-rows-test
   (let [ctx (merge {:input (csv-inputs ["bad-number-of-values/contest.txt"])
+                    :spec-version "3.0"
                     :data-specs v3-0/data-specs}
                    (sqlite/temp-db "bad-number-of-values" "3.0"))
         out-ctx (load-csvs ctx)]


### PR DESCRIPTION
5.1 validations demand a path-like string for the identifier, not a number.