### PR TITLE
Count `ElectionAdministration` errors as 3 types

### DIFF
--- a/resources/migrations/20160829-create-element-type-function.down.sql
+++ b/resources/migrations/20160829-create-element-type-function.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS element_type(path ltree);

--- a/resources/migrations/20160829-create-element-type-function.up.sql
+++ b/resources/migrations/20160829-create-element-type-function.up.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION element_type(path ltree) RETURNS varchar AS $$
+
+DECLARE
+element_type varchar;
+
+BEGIN
+  element_type := CASE
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*{1}.VoterService.*'
+    THEN 'VoterService'
+
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*'
+    THEN 'Department'
+
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*'
+    THEN 'ElectionAdministration'
+
+    ELSE ltree2text(subltree(path, 2, 3))
+   END;
+
+   RETURN element_type;
+END;
+$$ LANGUAGE plpgsql;

--- a/resources/migrations/20160830-create-countable-path-function.down.sql
+++ b/resources/migrations/20160830-create-countable-path-function.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS countable_path(path ltree);

--- a/resources/migrations/20160830-create-countable-path-function.up.sql
+++ b/resources/migrations/20160830-create-countable-path-function.up.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION countable_path(path ltree) RETURNS ltree AS $$
+DECLARE
+  subtree ltree;
+BEGIN
+  subtree := CASE
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*{1}.VoterService.*'
+    THEN subltree(path, 0, 8)
+
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*'
+    THEN subltree(path, 0, 6)
+
+    ELSE subltree(path, 0, 4)
+   END;
+
+   RETURN subtree;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/vip/data_processor/db/translations/v5_1/voter_services.clj
+++ b/src/vip/data_processor/db/translations/v5_1/voter_services.clj
@@ -31,33 +31,18 @@
 (defn voter-service->ltree [vss parent-with-id]
   (fn [idx-fn parent-path _]
     (mapcat (fn [vs]
-              (when-not (every? #(clojure.string/blank? (get vs %))
-                                [:ci_address_line_1
-                                 :ci_address_line_2
-                                 :ci_address_line_3
-                                 :ci_directions
-                                 :ci_email
-                                 :ci_fax
-                                 :ci_hours
-                                 :ci_hours_open_id
-                                 :ci_latitude
-                                 :ci_longitude
-                                 :ci_latlng_source
-                                 :ci_name
-                                 :ci_phone
-                                 :ci_uri])
-                (let [path (str parent-path ".VoterService." (idx-fn))
-                      label-path (str path ".label")
-                      sub-idx-fn (util/index-generator 0)]
-                  (conj
-                   (mapcat #(% sub-idx-fn path vs)
-                           [(ci/contact-information->ltree)
-                            (util/internationalized-text->ltree :description)
-                            (util/simple-value->ltree :election_official_person_id)
-                            (util/simple-value->ltree :type)
-                            (util/simple-value->ltree :other_type)])
-                   {:path label-path
-                    :simple_path (util/path->simple-path label-path)
-                    :value (:id vs)
-                    :parent_with_id parent-with-id}))))
+              (let [path (str parent-path ".VoterService." (idx-fn))
+                    label-path (str path ".label")
+                    sub-idx-fn (util/index-generator 0)]
+                (conj
+                 (mapcat #(% sub-idx-fn path vs)
+                         [(ci/contact-information->ltree)
+                          (util/internationalized-text->ltree :description)
+                          (util/simple-value->ltree :election_official_person_id)
+                          (util/simple-value->ltree :type)
+                          (util/simple-value->ltree :other_type)])
+                 {:path label-path
+                  :simple_path (util/path->simple-path label-path)
+                  :value (:id vs)
+                  :parent_with_id parent-with-id})))
             vss)))

--- a/src/vip/data_processor/db/tree_statistics.clj
+++ b/src/vip/data_processor/db/tree_statistics.clj
@@ -23,7 +23,7 @@
                     AND errors.path IS NOT NULL
                   GROUP BY element_type),
        values AS (SELECT element_type(values.path) AS element_type,
-                         COUNT(values.path) as value_count
+                         COUNT(DISTINCT countable_path(values.path)) as value_count
                   FROM results r
                   LEFT JOIN xml_tree_values values ON r.id = values.results_id
                   WHERE r.id = ?

--- a/src/vip/data_processor/db/tree_statistics.clj
+++ b/src/vip/data_processor/db/tree_statistics.clj
@@ -15,14 +15,14 @@
 (defn error-query []
   (let [element-paths (str/join "|" (reported-elements))]
     (str
-     "WITH errors AS (SELECT subltree(errors.path, 2, 3) AS element_type,
+     "WITH errors AS (SELECT element_type(errors.path) AS element_type,
                          COUNT(errors.severity) AS error_count
                   FROM results r
                   LEFT JOIN xml_tree_validations errors ON r.id = errors.results_id
                   WHERE r.id = ?
                     AND errors.path IS NOT NULL
                   GROUP BY element_type),
-       values AS (SELECT subltree(values.path, 2, 3) AS element_type,
+       values AS (SELECT element_type(values.path) AS element_type,
                          COUNT(values.path) as value_count
                   FROM results r
                   LEFT JOIN xml_tree_values values ON r.id = values.results_id
@@ -30,7 +30,7 @@
                     AND values.path ~ 'VipObject.0." element-paths ".*'
                     AND values.path IS NOT NULL
                   GROUP BY element_type)
-  SELECT ltree2text(coalesce(errors.element_type, values.element_type)) AS element,
+  SELECT coalesce(errors.element_type, values.element_type) AS element,
          coalesce(errors.error_count, 0) as error_count,
          coalesce(values.value_count, 0) as count
   FROM values


### PR DESCRIPTION
Previously, errors with `Department` or `VoterService` elements were
included in the count of `ElectionAdministration` errors. This promotes
those errors so they show up in overview counts.

Fixes [this bug about grouping of elements](https://www.pivotaltracker.com/story/show/129071869) as well as [this bug about counts](https://www.pivotaltracker.com/story/show/129459125), where e.g., 1 `Source` element would be inflated to 5.

This blocks [a Metis PR](https://github.com/votinginfoproject/Metis/pull/330) that uses the database function.