### PR TITLE
Create indices on (results_id, severity)

### DIFF
--- a/resources/migrations/20160907-add-indices-to-validation-tables.down.sql
+++ b/resources/migrations/20160907-add-indices-to-validation-tables.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS validations_results_id_severity_idx;
+DROP INDEX IF EXISTS xml_tree_validations_results_id_severity_idx;

--- a/resources/migrations/20160907-add-indices-to-validation-tables.up.sql
+++ b/resources/migrations/20160907-add-indices-to-validation-tables.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX validations_results_id_severity_idx ON validations (results_id, severity);
+CREATE INDEX xml_tree_validations_results_id_severity_idx ON xml_tree_validations (results_id, severity);


### PR DESCRIPTION
This is what fixed yesterday's slow query (& gateway timeout) experience.
Since these were already applied in production, they'll need to be dropped; I'll wait to merge until after hours.

Anything else you'd like to include, @tie-rack?