### PR TITLE
Fix polling_location.txt dependency check

### DIFF
--- a/src/vip/data_processor/validation/csv/file_set.clj
+++ b/src/vip/data_processor/validation/csv/file_set.clj
@@ -127,7 +127,7 @@
    "locality_early_vote_site.txt" (and "locality.txt"
                                        "early_vote_site.txt")
    "polling_location.txt" (or "precinct_polling_location.txt"
-                              "precinct_polling_location.txt")
+                              "precinct_split_polling_location.txt")
    "precinct_early_vote_site.txt" (and "precinct.txt"
                                        "early_vote_site.txt")
    "precinct_electoral_district.txt" (and "precinct.txt"

--- a/test/vip/data_processor/validation/csv/file_set_test.clj
+++ b/test/vip/data_processor/validation/csv/file_set_test.clj
@@ -34,3 +34,24 @@
         (assert-some-problem out-ctx [:ballots :global :missing-dependency])
         (assert-some-problem out-ctx [:precincts :global :missing-dependency])
         (assert-error-format out-ctx)))))
+
+(deftest validate-v3-dependencies-test
+  (let [validator (validate-dependencies v3-0-file-dependencies)]
+    (testing "polling_location.txt dependencies"
+      (testing "with precinct splits"
+        (let [ctx {:input [(File. "polling_location.txt")
+                           (File. "precinct.txt")
+                           (File. "precinct_split.txt")
+                           (File. "polling_location.txt")
+                           (File. "precinct_split_polling_location.txt")]
+                   :data-specs v3-0/data-specs}
+              out-ctx (validator ctx)]
+          (assert-no-problems out-ctx [])))
+      (testing "with precincts"
+        (let [ctx {:input [(File. "polling_location.txt")
+                           (File. "precinct.txt")
+                           (File. "polling_location.txt")
+                           (File. "precinct_polling_location.txt")]
+                   :data-specs v3-0/data-specs}
+              out-ctx (validator ctx)]
+          (assert-no-problems out-ctx []))))))


### PR DESCRIPTION
Instead of checking for precinct_polling_location.txt twice, also allow precinct_split_polling_location.txt to satisfy polling_location.txt's needs.