### PR TITLE
Make "invalid data type" fatal

### DIFF
--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -18,15 +18,18 @@
 (defn create-format-rule
   "Create a function that applies a format check for a specific
   element of an import."
-  [scope {:keys [name required format severity] :or {severity :errors}}]
-  (let [{:keys [check message]} format
+  [scope {name :name
+          required :required
+          {:keys [check message severity]} :format
+          severity-override :severity}]
+  (let [severity (or severity-override severity :errors)
         test-fn (cond
-                 (sequential? check) (fn [val]
-                                       (let [lower-case-val (str/lower-case val)]
-                                         (some #{lower-case-val} check)))
-                 (instance? clojure.lang.IFn check) check
-                 (instance? java.util.regex.Pattern check) (fn [val] (re-find check val))
-                 :else (constantly true))]
+                  (sequential? check) (fn [val]
+                                        (let [lower-case-val (str/lower-case val)]
+                                          (some #{lower-case-val} check)))
+                  (instance? clojure.lang.IFn check) check
+                  (instance? java.util.regex.Pattern check) (fn [val] (re-find check val))
+                  :else (constantly true))]
     (fn [ctx element id-or-line-number]
       (let [identifier (or (get element "id") id-or-line-number)
             val (element name)]

--- a/src/vip/data_processor/validation/data_spec/value_format.clj
+++ b/src/vip/data_processor/validation/data_spec/value_format.clj
@@ -2,7 +2,8 @@
 
 (def all-digits
   {:check #"\A\d+\z"
-   :message "Invalid data type"})
+   :message "Invalid data type"
+   :severity :fatal})
 
 (def date
   {:check #"\A\d{4}-\d{2}-\d{2}\z"

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -250,7 +250,7 @@
       (is (get-in out-ctx [:errors :candidates "90001" "candidate_url"]))
       (is (get-in out-ctx [:errors :candidates "90001" "phone"]))
       (is (get-in out-ctx [:errors :candidates "90001" "email"]))
-      (is (get-in out-ctx [:errors :candidates "90001" "sort_order"])))
+      (is (get-in out-ctx [:fatal :candidates "90001" "sort_order"])))
     (testing "puts errors in the right format"
       (assert-error-format out-ctx))))
 


### PR DESCRIPTION
"Invalid data type" comes from the `all-digits` format check, which now has a default severity of `:fatal`.

Pivotal story: [127281899](https://www.pivotaltracker.com/story/show/127281899)