### PR TITLE
Index all the (seq scan) things

### DIFF
--- a/resources/migrations/20160912-add-partial-indices-for-feedlist.down.sql
+++ b/resources/migrations/20160912-add-partial-indices-for-feedlist.down.sql
@@ -1,0 +1,4 @@
+drop index if exists xml_tree_values_results_state_path_idx;
+drop index if exists xml_tree_values_results_date_path_idx;
+drop index if exists xml_tree_values_results_election_type_path_idx;
+drop index if exists validations_results_scoped_severity_idx;

--- a/resources/migrations/20160912-add-partial-indices-for-feedlist.up.sql
+++ b/resources/migrations/20160912-add-partial-indices-for-feedlist.up.sql
@@ -1,0 +1,13 @@
+-- the feed list has three seq scans on xml_tree_values and be pretty much unusable
+drop index if exists xml_tree_values_results_state_path_idx;
+create index xml_tree_values_results_state_path_idx on xml_tree_values(results_id, simple_path) where simple_path = 'VipObject.State.Name';
+
+drop index if exists xml_tree_values_results_date_path_idx;
+create index xml_tree_values_results_date_path_idx on xml_tree_values(results_id, simple_path) where simple_path = 'VipObject.Election.Date';
+
+drop index if exists xml_tree_values_results_election_type_path_idx;
+create index xml_tree_values_results_election_type_path_idx on xml_tree_values(results_id, path) where path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0';
+
+-- help the `approvable_status` query, as used on a feed's overview page
+drop index if exists validations_results_scoped_severity_idx;
+create index validations_results_scoped_severity_idx on validations(results_id, severity) where severity = 'critical' or severity = 'fatal';

--- a/resources/migrations/20160919-dashboard-performance-indexes.down.sql
+++ b/resources/migrations/20160919-dashboard-performance-indexes.down.sql
@@ -1,4 +1,4 @@
-drop index if exists street_segments_results_precinct_idx;
-drop index if exists precinct_polling_locations_results_precinct_idx;
-drop index if exists precinct_polling_locations_results_polling_location_idx;
+drop index if exists v3_0_street_segments_results_precinct_idx;
+drop index if exists v3_0_precinct_polling_locations_results_precinct_idx;
+drop index if exists v3_0_precinct_polling_locations_results_polling_location_idx;
 drop index if exists v3_0_precincts_results_locality_idx;

--- a/resources/migrations/20160919-dashboard-performance-indexes.down.sql
+++ b/resources/migrations/20160919-dashboard-performance-indexes.down.sql
@@ -1,0 +1,4 @@
+drop index if exists street_segments_results_precinct_idx;
+drop index if exists precinct_polling_locations_results_precinct_idx;
+drop index if exists precinct_polling_locations_results_polling_location_idx;
+drop index if exists v3_0_precincts_results_locality_idx;

--- a/resources/migrations/20160919-dashboard-performance-indexes.down.sql
+++ b/resources/migrations/20160919-dashboard-performance-indexes.down.sql
@@ -2,3 +2,4 @@ drop index if exists v3_0_street_segments_results_precinct_idx;
 drop index if exists v3_0_precinct_polling_locations_results_precinct_idx;
 drop index if exists v3_0_precinct_polling_locations_results_polling_location_idx;
 drop index if exists v3_0_precincts_results_locality_idx;
+drop index if exists xml_tree_output_sanity;

--- a/resources/migrations/20160919-dashboard-performance-indexes.down.sql
+++ b/resources/migrations/20160919-dashboard-performance-indexes.down.sql
@@ -2,4 +2,4 @@ drop index if exists v3_0_street_segments_results_precinct_idx;
 drop index if exists v3_0_precinct_polling_locations_results_precinct_idx;
 drop index if exists v3_0_precinct_polling_locations_results_polling_location_idx;
 drop index if exists v3_0_precincts_results_locality_idx;
-drop index if exists xml_tree_output_sanity;
+drop index if exists xml_tree_values_results_insert_counter_idx;

--- a/resources/migrations/20160919-dashboard-performance-indexes.up.sql
+++ b/resources/migrations/20160919-dashboard-performance-indexes.up.sql
@@ -10,5 +10,5 @@ create index v3_0_precinct_polling_locations_results_polling_location_idx on v3_
 drop index if exists v3_0_precincts_results_locality_idx;
 create index v3_0_precincts_results_locality_idx on v3_0_precincts (results_id, locality_id);
 
-drop index if exists xml_tree_output_sanity;
-create index xml_tree_output_sanity on xml_tree_values (results_id, insert_counter);
+drop index if exists xml_tree_values_results_insert_counter_idx;
+create index xml_tree_values_results_insert_counter_idx on xml_tree_values (results_id, insert_counter);

--- a/resources/migrations/20160919-dashboard-performance-indexes.up.sql
+++ b/resources/migrations/20160919-dashboard-performance-indexes.up.sql
@@ -9,3 +9,6 @@ create index v3_0_precinct_polling_locations_results_polling_location_idx on v3_
 
 drop index if exists v3_0_precincts_results_locality_idx;
 create index v3_0_precincts_results_locality_idx on v3_0_precincts (results_id, locality_id);
+
+drop index if exists xml_tree_output_sanity;
+create index xml_tree_output_sanity on xml_tree_values (results_id, insert_counter);

--- a/resources/migrations/20160919-dashboard-performance-indexes.up.sql
+++ b/resources/migrations/20160919-dashboard-performance-indexes.up.sql
@@ -1,0 +1,11 @@
+drop index if exists v3_0_street_segments_results_precinct_idx;
+create index v3_0_street_segments_results_precinct_idx on v3_0_street_segments(results_id, precinct_id);
+
+drop index if exists v3_0_precinct_polling_locations_results_precinct_idx;
+create index v3_0_precinct_polling_locations_results_precinct_idx on v3_0_precinct_polling_locations(results_id, precinct_id);
+
+drop index if exists v3_0_precinct_polling_locations_results_polling_location_idx;
+create index v3_0_precinct_polling_locations_results_polling_location_idx on v3_0_precinct_polling_locations(results_id, polling_location_id);
+
+drop index if exists v3_0_precincts_results_locality_idx;
+create index v3_0_precincts_results_locality_idx on v3_0_precincts (results_id, locality_id);

--- a/src/vip/data_processor/output/tree_xml.clj
+++ b/src/vip/data_processor/output/tree_xml.clj
@@ -94,7 +94,7 @@
     (let [last-seen-path (atom "VipObject.0")
           inside-open-tag (atom false)]
       (doseq [{:keys [path value simple_path] :as row}
-              (db.util/lazy-select 1000
+              (db.util/lazy-select 100000
                                    postgres/xml-tree-values
                                    (korma/where {:results_id import-id})
                                    (korma/order :insert_counter :ASC))]


### PR DESCRIPTION
These simple indexes should make the dashboard's slowest-executing queries run much more efficiently. These are all related to that [sneaky bug where the dashboard hits a timeout](https://www.pivotaltracker.com/story/show/130475205).