### PR TITLE
Indexes improve validation runtime

### DIFF
--- a/resources/migrations/20160921-add-idref-validations-index.down.sql
+++ b/resources/migrations/20160921-add-idref-validations-index.down.sql
@@ -1,0 +1,1 @@
+drop index if exists xml_tree_values_idref_validation_idx;

--- a/resources/migrations/20160921-add-idref-validations-index.up.sql
+++ b/resources/migrations/20160921-add-idref-validations-index.up.sql
@@ -1,0 +1,1 @@
+create index xml_tree_values_idref_validation_idx on xml_tree_values(results_id, simple_path) where simple_path ~ '*{2}.id';

--- a/resources/migrations/20160921-add-no-duplicate-id-index.down.sql
+++ b/resources/migrations/20160921-add-no-duplicate-id-index.down.sql
@@ -1,0 +1,1 @@
+drop index if exists xml_tree_values_no_duplicate_id_idx;

--- a/resources/migrations/20160921-add-no-duplicate-id-index.up.sql
+++ b/resources/migrations/20160921-add-no-duplicate-id-index.up.sql
@@ -1,0 +1,5 @@
+-- results_id increases monotonically, so sort desc; it will not be null, so we
+-- must override the default to see any improvement
+create index xml_tree_values_no_duplicate_id_idx
+          on xml_tree_values (results_id desc nulls last, value, path)
+where path ~ 'VipObject.0.*.id';


### PR DESCRIPTION
This removes a couple seq scans over `xml_tree_values` when checking IDs are referenced. Testing locally, this cut runtime by at least 30 minutes for NC's 5.1 feed.