### PR TITLE
Enable skipping feed validations

### DIFF
--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -43,12 +43,14 @@
            tree-stats/store-tree-stats]))
 
 (defn add-validations
-  [{:keys [spec-version] :as ctx}]
-  (let [validations (condp = spec-version
-                      "3.0" v3-validation-pipeline
-                      "5.1" v5-1-validation-pipeline
-                      nil)]
-    (update ctx :pipeline (partial concat validations))))
+  [{:keys [spec-version skip-validations?] :as ctx}]
+  (if skip-validations?
+    ctx
+    (let [validations (condp = spec-version
+                        "3.0" v3-validation-pipeline
+                        "5.1" v5-1-validation-pipeline
+                        nil)]
+      (update ctx :pipeline (partial concat validations)))))
 
 (def pipeline
   (concat download-pipeline

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -41,6 +41,7 @@
   context will result in logging the exception."
   [pipeline initial-input]
   (let [ctx {:input initial-input
+             :skip-validations? false
              :warnings {}
              :errors {}
              :critical {}

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -7,7 +7,8 @@
             [vip.data-processor.validation.xml :as xml]))
 
 (defn read-edn-sqs-message [ctx]
-  (assoc ctx :input (edn/read-string (get-in ctx [:input :body]))))
+  (let [message (edn/read-string (get-in ctx [:input :body]))]
+    (assoc ctx :input message :skip-validations? (get message :skip-validations false))))
 
 (defn assert-filename [ctx]
   (if-let [filename (get-in ctx [:input :filename])]


### PR DESCRIPTION
If the message sent over SQS contains `:skip-validations true`,
version-specific validation pipelines will be omitted from the pipeline.
While this might be useful in certain situations, the default is to keep
validations as part of the pipeline.