### PR TITLE
Fix "invalid positions" in element_type

### DIFF
--- a/resources/migrations/20160928-01-fix-invalid-positions-in-element-type.down.sql
+++ b/resources/migrations/20160928-01-fix-invalid-positions-in-element-type.down.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION element_type(path ltree) RETURNS varchar AS $$
+
+DECLARE
+element_type varchar;
+
+BEGIN
+  element_type := CASE
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*{1}.VoterService.*'
+    THEN 'VoterService'
+
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*'
+    THEN 'Department'
+
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*'
+    THEN 'ElectionAdministration'
+
+    ELSE ltree2text(subltree(path, 2, 3))
+   END;
+
+   RETURN element_type;
+END;
+$$ LANGUAGE plpgsql;

--- a/resources/migrations/20160928-01-fix-invalid-positions-in-element-type.up.sql
+++ b/resources/migrations/20160928-01-fix-invalid-positions-in-element-type.up.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION element_type(path ltree) RETURNS varchar AS $$
+
+DECLARE
+element_type varchar;
+
+BEGIN
+  element_type := CASE
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*{1}.VoterService.*'
+    THEN 'VoterService'
+
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*'
+    THEN 'Department'
+
+    WHEN path ~ 'VipObject.0.ElectionAdministration.*'
+    THEN 'ElectionAdministration'
+
+    WHEN nlevel(path) > 2
+    THEN ltree2text(subltree(path, 2, 3))
+
+    ELSE NULL
+   END;
+
+   RETURN element_type;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
The `element_type` function would cause an "invalid positions" error when given a path too short. This updates the function to handle that case.