### PR TITLE
Collect and process validation errors async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,8 @@
                  [democracyworks/squishy "2.0.0" :exclusions [joda-time
                                                               org.slf4j/slf4j-simple
                                                               org.slf4j/slf4j-api]]
+                 [org.clojure/core.async "0.2.391"]
+                 [democracyworks/utility-works "0.1.0-SNAPSHOT"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
                  [turbovote.resource-config "0.2.0"]
                  [joplin.jdbc "0.3.6"

--- a/src/vip/data_processor/db/sqlite.clj
+++ b/src/vip/data_processor/db/sqlite.clj
@@ -33,7 +33,7 @@
 (def bulk-import (partial util/bulk-import statement-parameter-limit))
 
 (defn attach-sqlite-db [{:keys [import-id spec-version] :as ctx}]
-  (let [db (temp-db import-id spec-version)
+  (let [db (temp-db import-id @spec-version)
         db-file (get-in db [:db :subname])]
     (-> ctx
         (merge db)

--- a/src/vip/data_processor/errors.clj
+++ b/src/vip/data_processor/errors.clj
@@ -23,13 +23,6 @@
 (defn add-errors [{:keys [errors-chan] :as ctx}
                   severity scope identifier error-type
                   & error-data]
-  ;;; Async version:
-  ;; (a/onto-chan errors-chan
-  ;;            (map (partial ->ValidationError ctx severity scope identifier error-type)
-  ;;                 error-data)
-  ;;            false)
-
-  ;;; Sync version:
   (doseq [error-value error-data]
     (a/>!! errors-chan
            (->ValidationError ctx severity scope identifier error-type error-value)))
@@ -41,15 +34,3 @@
     "3.0" (a/unmix v3-errors-mix errors-chan)
     "5.1" (a/unmix v5-errors-mix errors-chan))
   ctx)
-
-;;; TODO:
-;;; * DONE: Go back to one add-errors-fn
-;;; * DONE: make spec-version an atom, add a watcher from `add-watch-fn`
-;;; * DONE: update usages of spec-version deref the atom
-;;; * DONE: make new `batch-process` calls for each v*errors-chan (both
-;;;   data_processor.clj and dev-src/core.clj)
-;;; * DONE: try it out
-;;; * DONE: make the batch processors bulk-insert into tables
-;;; * update tests
-;;; * update batch-size and timeout for the batch processors
-;;; * make it blocking? (UNDO make it blocking?)

--- a/src/vip/data_processor/errors.clj
+++ b/src/vip/data_processor/errors.clj
@@ -1,0 +1,55 @@
+(ns vip.data-processor.errors
+  (:require [clojure.core.async :as a]))
+
+(def v3-errors-chan (a/chan 1024))
+(def v3-errors-mix (a/mix v3-errors-chan))
+
+(def v5-errors-chan (a/chan 1024))
+(def v5-errors-mix (a/mix v5-errors-chan))
+
+(defn route-messages [errors-chan spec-version]
+  (case spec-version
+    "3.0" (a/admix v3-errors-mix errors-chan)
+    "5.1" (a/admix v5-errors-mix errors-chan)))
+
+(defn add-watch-fn [errors-chan]
+  (fn [key ref _ spec-version]
+    (route-messages errors-chan spec-version)
+    (remove-watch ref key)))
+
+(defrecord ValidationError [ctx severity scope
+                            identifier error-type error-value])
+
+(defn add-errors [{:keys [errors-chan] :as ctx}
+                  severity scope identifier error-type
+                  & error-data]
+  ;;; Async version:
+  ;; (a/onto-chan errors-chan
+  ;;            (map (partial ->ValidationError ctx severity scope identifier error-type)
+  ;;                 error-data)
+  ;;            false)
+
+  ;;; Sync version:
+  (doseq [error-value error-data]
+    (a/>!! errors-chan
+           (->ValidationError ctx severity scope identifier error-type error-value)))
+
+  ctx)
+
+(defn detach-errors-chan [{:keys [errors-chan spec-version] :as ctx}]
+  (case @spec-version
+    "3.0" (a/unmix v3-errors-mix errors-chan)
+    "5.1" (a/unmix v5-errors-mix errors-chan))
+  ctx)
+
+;;; TODO:
+;;; * DONE: Go back to one add-errors-fn
+;;; * DONE: make spec-version an atom, add a watcher from `add-watch-fn`
+;;; * DONE: update usages of spec-version deref the atom
+;;; * DONE: make new `batch-process` calls for each v*errors-chan (both
+;;;   data_processor.clj and dev-src/core.clj)
+;;; * DONE: try it out
+;;; * DONE: make the batch processors bulk-insert into tables
+;;; * update tests
+;;; * update batch-size and timeout for the batch processors
+;;; * make it blocking? (UNDO make it blocking?)

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -20,7 +20,8 @@
             [clojure.walk :as walk]
             [com.climate.newrelic.trace :refer [defn-traced]]
             [vip.data-processor.output.v3-0.xml :as v3-0]
-            [vip.data-processor.output.xml-helpers :refer [create-xml-file]])
+            [vip.data-processor.output.xml-helpers :refer [create-xml-file]]
+            [vip.data-processor.errors :as errors])
   (:import [javax.xml XMLConstants]
            [javax.xml.transform.stream StreamSource]
            [javax.xml.validation SchemaFactory]
@@ -88,7 +89,7 @@
       (.validate validator (StreamSource. (.toFile xml-output-file)))
       ctx
       (catch SAXParseException e
-        (assoc-in ctx [:errors :xml-generation :global :invalid-xml] [(.getMessage e)])))))
+        (errors/add-errors ctx :errors :xml-generation :global :invalid-xml (.getMessage e))))))
 
 (def pipeline
   [create-xml-file

--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -51,7 +51,7 @@
 
 (defn zip-filename
   [{:keys [spec-version tables import-id] :as ctx}]
-  (condp = spec-version
+  (condp = @spec-version
     "3.0"
     (let [fips (-> tables
                    :sources

--- a/src/vip/data_processor/validation/csv/file_set.clj
+++ b/src/vip/data_processor/validation/csv/file_set.clj
@@ -2,7 +2,8 @@
   (:require [vip.data-processor.util :as util]
             [vip.data-processor.validation.data-spec :as data-spec]
             [clojure.string :as str]
-            [clojure.walk :as walk]))
+            [clojure.walk :as walk]
+            [vip.data-processor.errors :as errors]))
 
 (defn- build-dependency-pred [ctx-sym dependencies]
   (walk/postwalk
@@ -41,8 +42,8 @@
                               (if ~pred
                                 ~ctx
                                 (let [error-scope# (data-spec/filename->table (:data-specs ~ctx) ~filename)]
-                                  (assoc-in ~ctx [:errors error-scope# :global :missing-dependency]
-                                            [(error-message-for '~dependencies)]))))]
+                                  (errors/add-errors ~ctx :errors error-scope# :global :missing-dependency
+                                            (error-message-for '~dependencies)))))]
              (merge {~filename validator#} (build-dependencies ~@next-mappings))))
         (throw (IllegalArgumentException.
                 "build-dependencies requires an even number of forms"))))))

--- a/src/vip/data_processor/validation/data_spec.clj
+++ b/src/vip/data_processor/validation/data_spec.clj
@@ -2,7 +2,8 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [vip.data-processor.errors :as errors]))
 
 (def version-specs
   {"3.0" v3-0/data-specs
@@ -36,14 +37,14 @@
         (cond
           (empty? val)
           (if required
-            (assoc-in ctx [required scope identifier name] [(str "Missing " name)])
+            (errors/add-errors ctx required scope identifier name (str "Missing " name))
             ctx)
 
           (invalid-utf-8? val)
-          (assoc-in ctx [:errors scope identifier name] ["Is not valid UTF-8."])
+          (errors/add-errors ctx :errors scope identifier name "Is not valid UTF-8.")
 
           (not (test-fn val))
-          (assoc-in ctx [severity scope identifier name] [(str message ": " val)])
+          (errors/add-errors ctx severity scope identifier name (str message ": " val))
 
           :else ctx)))))
 

--- a/src/vip/data_processor/validation/db.clj
+++ b/src/vip/data_processor/validation/db.clj
@@ -4,12 +4,13 @@
             [vip.data-processor.validation.db.references :as refs]
             [vip.data-processor.validation.db.record-limit :as record-limit]
             [vip.data-processor.validation.db.reverse-references :as rev-refs]
-            [com.climate.newrelic.trace :refer [defn-traced]]))
+            [com.climate.newrelic.trace :refer [defn-traced]]
+            [vip.data-processor.errors :as errors]))
 
 (defn-traced validate-no-duplicated-ids [ctx]
   (let [dupes (dupe-ids/duplicated-ids ctx)]
     (reduce (fn [ctx [id tables]]
-              (assoc-in ctx [:errors :import id :duplicate-ids] tables))
+              (errors/add-errors ctx :errors :import id :duplicate-ids tables))
             ctx dupes)))
 
 (defn-traced validate-no-duplicated-rows [{:keys [data-specs] :as ctx}]

--- a/src/vip/data_processor/validation/db/duplicate_records.clj
+++ b/src/vip/data_processor/validation/db/duplicate_records.clj
@@ -1,7 +1,8 @@
 (ns vip.data-processor.validation.db.duplicate-records
   (:require [vip.data-processor.db.sqlite :as sqlite]
             [clojure.string :as str]
-            [korma.core :as korma]))
+            [korma.core :as korma]
+            [vip.data-processor.errors :as errors]))
 
 (defn columns-without-id [table]
   (remove (partial = "id") (sqlite/column-names table)))
@@ -46,6 +47,6 @@
   (let [sql-table (get-in ctx [:tables table])
         potential-dupes (find-potential-dupes sql-table)]
     (reduce (fn [ctx dupe]
-              (update-in ctx [:warnings table (:id dupe) :duplicate-rows]
-                         conj dupe))
+              (errors/add-errors ctx :warnings table (:id dupe) :duplicate-rows
+                                 dupe))
             ctx potential-dupes)))

--- a/src/vip/data_processor/validation/db/record_limit.clj
+++ b/src/vip/data_processor/validation/db/record_limit.clj
@@ -1,5 +1,6 @@
 (ns vip.data-processor.validation.db.record-limit
-  (:require [korma.core :as korma]))
+  (:require [korma.core :as korma]
+            [vip.data-processor.errors :as errors]))
 
 (defn count-rows [table]
   "Takes a single table and counts the number of rows in it."
@@ -15,8 +16,8 @@
 (defn error-if-not-one-row [ctx count]
   "If the count of the rows is not equal to 1, add an error."
   (if-not (= 1 (:count count))
-    (assoc-in ctx [:errors (:name count) :global :row-constraint]
-              ["File needs to contain exactly one row."])
+    (errors/add-errors ctx :errors (:name count) :global :row-constraint
+                       "File needs to contain exactly one row.")
     ctx))
 
 (defn tables-allow-only-one-record

--- a/src/vip/data_processor/validation/db/references.clj
+++ b/src/vip/data_processor/validation/db/references.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.db.references
   (:require [vip.data-processor.validation.db.util :as util]
-            [korma.core :as korma]))
+            [korma.core :as korma]
+            [vip.data-processor.errors :as errors]))
 
 (defn unmatched-references [tables from via to]
   (let [from-table (tables from)
@@ -25,8 +26,8 @@
                                           (:name column)
                                           (:references column))]
                 (reduce (fn [ctx unmatched-reference]
-                          (update-in ctx [:errors table (:id unmatched-reference) :unmatched-reference]
-                                     conj {(:name column) (get unmatched-reference (keyword (:name column)))}))
+                          (errors/add-errors ctx :errors table (:id unmatched-reference) :unmatched-reference
+                                             {(:name column) (get unmatched-reference (keyword (:name column)))}))
                         ctx unmatched-references)))
             ctx
             reference-columns)))

--- a/src/vip/data_processor/validation/db/reverse_references.clj
+++ b/src/vip/data_processor/validation/db/reverse_references.clj
@@ -1,7 +1,8 @@
 (ns vip.data-processor.validation.db.reverse-references
   (:require [vip.data-processor.validation.db.util :as util]
             [korma.core :as korma]
-            [korma.sql.engine :as eng]))
+            [korma.sql.engine :as eng]
+            [vip.data-processor.errors :as errors]))
 
 (defn find-referencing-column [table-name data-spec]
   (->> data-spec
@@ -71,6 +72,6 @@
   (let [tables (:tables ctx)
         unreferenced-rows (find-unreferenced-rows tables table-id references-map)]
     (reduce (fn [ctx unreferenced-row]
-              (update-in ctx [:warnings table-id (:id unreferenced-row) :unreferenced-row]
-                         conj unreferenced-row))
+              (errors/add-errors ctx :warnings table-id (:id unreferenced-row) :unreferenced-row
+                                 unreferenced-row))
             ctx unreferenced-rows)))

--- a/src/vip/data_processor/validation/db/v3_0/admin_addresses.clj
+++ b/src/vip/data_processor/validation/db/v3_0/admin_addresses.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.db.v3-0.admin-addresses
   (:require [korma.core :as korma]
-            [com.climate.newrelic.trace :refer [defn-traced]]))
+            [com.climate.newrelic.trace :refer [defn-traced]]
+            [vip.data-processor.errors :as errors]))
 
 (defn transform-field [address-type field-name]
   (keyword (str (name address-type)
@@ -24,8 +25,8 @@
         error-name (keyword (str "incomplete-" (name address-type) "-address"))]
     (if (seq bad-addresses)
       (reduce (fn [ctx bad-address-id]
-                (assoc-in ctx [:errors :election-administrations bad-address-id error-name]
-                          ["Incomplete address"]))
+                (errors/add-errors ctx :errors :election-administrations bad-address-id error-name
+                                   "Incomplete address"))
               ctx bad-addresses)
       ctx)))
 

--- a/src/vip/data_processor/validation/db/v3_0/fips.clj
+++ b/src/vip/data_processor/validation/db/v3_0/fips.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.db.v3-0.fips
   (:require [korma.core :as korma]
-            [vip.data-processor.validation.fips :refer [valid-fips?]]))
+            [vip.data-processor.validation.fips :refer [valid-fips?]]
+            [vip.data-processor.errors :as errors]))
 
 (defn validate-valid-source-vip-id [ctx]
   (let [sources (get-in ctx [:tables :sources])
@@ -8,4 +9,4 @@
         {:keys [id vip_id]} source]
     (if (valid-fips? vip_id)
       ctx
-      (assoc-in ctx [:errors :sources id :invalid-vip-id] [vip_id]))))
+      (errors/add-errors ctx :errors :sources id :invalid-vip-id vip_id))))

--- a/src/vip/data_processor/validation/db/v3_0/jurisdiction_references.clj
+++ b/src/vip/data_processor/validation/db/v3_0/jurisdiction_references.clj
@@ -1,7 +1,8 @@
 (ns vip.data-processor.validation.db.v3-0.jurisdiction-references
   (:require [vip.data-processor.validation.db.util :as util]
             [korma.core :as korma]
-            [com.climate.newrelic.trace :refer [defn-traced]]))
+            [com.climate.newrelic.trace :refer [defn-traced]]
+            [vip.data-processor.errors :as errors]))
 
 (defn unmatched-jurisdiction-references [tables from-table]
   (let [table (tables from-table)
@@ -34,8 +35,8 @@
   (let [unmatched-references (unmatched-jurisdiction-references
                               (:tables ctx) table)]
     (reduce (fn [ctx unmatched-reference]
-              (update-in ctx [:errors table (:id unmatched-reference) :unmatched-reference]
-                         conj (select-keys unmatched-reference [:jurisdiction_id])))
+              (errors/add-errors ctx :errors table (:id unmatched-reference) :unmatched-reference
+                                 (select-keys unmatched-reference [:jurisdiction_id])))
             ctx unmatched-references)))
 
 (defn-traced validate-jurisdiction-references [{:keys [data-specs] :as ctx}]

--- a/src/vip/data_processor/validation/db/v3_0/precinct.clj
+++ b/src/vip/data_processor/validation/db/v3_0/precinct.clj
@@ -1,5 +1,6 @@
 (ns vip.data-processor.validation.db.v3-0.precinct
-  (:require [korma.core :as korma]))
+  (:require [korma.core :as korma]
+            [vip.data-processor.errors :as errors]))
 
 (defn validate-no-missing-polling-locations
   "Precincts are missing a polling location if they are not mail only
@@ -17,7 +18,7 @@
                                            (korma/modifier "DISTINCT")
                                            (korma/fields :precinct_id))]}))]
     (reduce (fn [ctx bad-precinct-row]
-              (assoc-in ctx [:warnings :precincts
-                             (:id bad-precinct-row) :missing-polling-location]
-                        ["Missing polling location"]))
+              (errors/add-errors ctx :warnings :precincts
+                                 (:id bad-precinct-row) :missing-polling-location
+                                 "Missing polling location"))
             ctx bad-precincts)))

--- a/src/vip/data_processor/validation/db/v3_0/street_segment.clj
+++ b/src/vip/data_processor/validation/db/v3_0/street_segment.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.db.v3-0.street-segment
   (:require [korma.core :as korma]
-            [com.climate.newrelic.trace :refer [defn-traced]]))
+            [com.climate.newrelic.trace :refer [defn-traced]]
+            [vip.data-processor.errors :as errors]))
 
 (defn query-overlaps [street-segments]
   (korma/select [street-segments :street_segments]
@@ -37,6 +38,6 @@
                       set)]
     (reduce (fn [ctx overlap]
               (let [[id overlap-id] (sort overlap)]
-                (update-in ctx [:errors :street-segments id :overlaps]
-                           conj overlap-id)))
+                (errors/add-errors ctx :errors :street-segments id :overlaps
+                                   overlap-id)))
             ctx overlaps)))

--- a/src/vip/data_processor/validation/v5/candidate.clj
+++ b/src/vip/data_processor/validation/v5/candidate.clj
@@ -2,6 +2,7 @@
   (:require [korma.core :as korma]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.validation.v5.util :as util]
+            [vip.data-processor.errors :as errors]
             [clojure.tools.logging :as log]))
 
 (defn valid-pre-election-status? [status]
@@ -18,9 +19,9 @@
                                  :simple_path (postgres/path->ltree "VipObject.Candidate.PreElectionStatus")}))
         invalid-statuses (remove valid-pre-election-status? statuses)]
     (reduce (fn [ctx row]
-              (update-in ctx
-                         [:errors :candidates (-> row :path .getValue) :format]
-                         conj (:value row)))
+              (errors/add-errors ctx
+                         :errors :candidates (-> row :path .getValue) :format
+                         (:value row)))
             ctx invalid-statuses)))
 
 (defn validate-post-election-statuses [{:keys [import-id] :as ctx}]
@@ -30,9 +31,9 @@
                                  :simple_path (postgres/path->ltree "VipObject.Candidate.PostElectionStatus")}))
         invalid-statuses (remove valid-post-election-status? statuses)]
     (reduce (fn [ctx row]
-              (update-in ctx
-                         [:errors :candidates (-> row :path .getValue) :format]
-                         conj (:value row)))
+              (errors/add-errors ctx
+                                 :errors :candidates (-> row :path .getValue) :format
+                                 (:value row)))
             ctx invalid-statuses)))
 
 (def validate-no-missing-ballot-names

--- a/src/vip/data_processor/validation/v5/election.clj
+++ b/src/vip/data_processor/validation/v5/election.clj
@@ -2,6 +2,7 @@
   (:require [korma.core :as korma]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.validation.v5.util :as util]
+            [vip.data-processor.errors :as errors]
             [clojure.tools.logging :as log]))
 
 (defn validate-one-election [{:keys [import-id] :as ctx}]
@@ -17,8 +18,8 @@
                            first
                            :election_count)]
     (if (> election-count 1)
-      (update-in ctx [:fatal :election "VipObject.0.Election" :count]
-                 conj :more-than-one)
+      (errors/add-errors ctx :fatal :election "VipObject.0.Election" :count
+                         :more-than-one)
       ctx)))
 
 (def validate-date

--- a/src/vip/data_processor/validation/v5/election_administration.clj
+++ b/src/vip/data_processor/validation/v5/election_administration.clj
@@ -2,6 +2,7 @@
   (:require [korma.core :as korma]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.validation.v5.util :as util]
+            [vip.data-processor.errors :as errors]
             [clojure.tools.logging :as log]))
 
 (def validate-no-missing-departments
@@ -34,8 +35,8 @@
                                      (comp valid-voter-service-type? :value)
                                      imported-voter-service-types)]
     (reduce (fn [ctx row]
-              (update-in ctx
-                         [:errors :election-administration
-                          (-> row :path .getValue) :format]
-                         conj (:value row)))
+              (errors/add-errors ctx
+                                 :errors :election-administration
+                                 (-> row :path .getValue) :format
+                                 (:value row)))
             ctx invalid-voter-service-types)))

--- a/src/vip/data_processor/validation/v5/email.clj
+++ b/src/vip/data_processor/validation/v5/email.clj
@@ -2,6 +2,7 @@
   (:require [korma.core :as korma]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.validation.data-spec.value-format :as value-format]
+            [vip.data-processor.errors :as errors]
             [clojure.tools.logging :as log]))
 
 (defn validate-emails [{:keys [import-id] :as ctx}]
@@ -16,7 +17,7 @@
               (if (re-find (:check value-format/email)
                            (:value row))
                 ctx
-                (update-in ctx
-                          [:errors :email (-> row :path .getValue) :format]
-                          conj (:value row))))
+                (errors/add-errors ctx
+                                   :errors :email (-> row :path .getValue) :format
+                                   (:value row))))
             ctx emails)))

--- a/src/vip/data_processor/validation/v5/hours_open.clj
+++ b/src/vip/data_processor/validation/v5/hours_open.clj
@@ -1,5 +1,6 @@
 (ns vip.data-processor.validation.v5.hours-open
   (:require [vip.data-processor.validation.v5.util :as util]
+            [vip.data-processor.errors :as errors]
             [clojure.tools.logging :as log]))
 
 (defn valid-time-with-zone? [time]
@@ -15,7 +16,7 @@
                (str hours-open-path ".StartTime|EndTime.*{1}"))
         invalid-times (remove (comp valid-time-with-zone? :value) times)]
     (reduce (fn [ctx row]
-              (update-in ctx
-                         [:errors :hours-open (-> row :path .getValue) :format]
-                         conj (:value row)))
+              (errors/add-errors ctx
+                         :errors :hours-open (-> row :path .getValue) :format
+                         (:value row)))
             ctx invalid-times)))

--- a/src/vip/data_processor/validation/v5/street_segment.clj
+++ b/src/vip/data_processor/validation/v5/street_segment.clj
@@ -3,6 +3,7 @@
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.validation.v5.util :as util]
             [clojure.string :as str]
+            [vip.data-processor.errors :as errors]
             [clojure.tools.logging :as log]))
 
 (util/validate-no-missing-values :street-segment
@@ -49,9 +50,10 @@
                   [overlap-query [import-id]]
                   :results)]
     (reduce (fn [ctx overlap]
-              (update-in ctx [:errors
-                              :street-segment
-                              (.getValue (:path overlap))
-                              :overlaps]
-                         conj (:ss2_id overlap)))
+              (errors/add-errors ctx
+                                 :errors
+                                 :street-segment
+                                 (.getValue (:path overlap))
+                                 :overlaps
+                                 (:ss2_id overlap)))
             ctx overlaps)))

--- a/src/vip/data_processor/validation/v5/util.clj
+++ b/src/vip/data_processor/validation/v5/util.clj
@@ -3,7 +3,8 @@
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.validation.xml.spec :as spec]
             [clojure.string :as str]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [vip.data-processor.errors :as errors]))
 
 (defn two-import-ids
   "A common params-fn for build-xml-tree-value-query-validator that
@@ -25,8 +26,8 @@
       (->> missing-paths
            (map :path)
            (reduce (fn [ctx path]
-                     (update-in ctx [severity scope (.getValue path) error-type]
-                                conj error-data))
+                     (errors/add-errors ctx severity scope (.getValue path) error-type
+                                        error-data))
                    ctx)))))
 
 (defn select-lquery
@@ -167,9 +168,9 @@
             elements (elements-at-simple-path import-id simple-path)
             invalid-elements (remove (comp valid? :value) elements)]
         (reduce (fn [ctx row]
-                  (update-in ctx [error-severity error-root-element
-                                  (-> row :path .getValue) error-type]
-                             conj (:value row)))
+                  (errors/add-errors ctx error-severity error-root-element
+                                     (-> row :path .getValue) error-type
+                                     (:value row)))
                 ctx invalid-elements)))))
 
 (defn validate-elements
@@ -184,6 +185,7 @@
           xml-element-path (mapv keyword->xml-name element-path)
           validators (element-validators xml-schema-type xml-element-path valid?
                                          error-severity error-type)]
+      (log/info "Validating" xml-schema-type "elements")
       (reduce (fn [ctx validator] (validator ctx)) ctx validators))))
 
 (defn validate-enum-elements

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -36,44 +36,6 @@
     (is (= invalid-identifier (coerce-identifier '(a list))))
     (is (= invalid-identifier (coerce-identifier "ABC")))))
 
-(deftest validation-values-test
-  (testing "generates validation values for all kinds of errors"
-    (let [ctx {:import-id 34
-               :warnings {:ballots {:global {:missing-headers ["name" "id"]}
-                                    3 {:bad-format ["school must match /\\w+/"]
-                                       :too-long ["less than 140 characters"]}}
-                          :election-results {nil {:unreferenced-ids [12 45]}}}
-               :errors {:sources {:global {:number-of-rows ["sources.txt must have one row"]}}}}
-          values (validation-values ctx)]
-      (is (= 7 (count values)))
-      (is (every? #(= 34 (:results_id %)) values))
-      (testing "creates a validation value for each error-data"
-        (let [missing-header-values (filter #(= "missing-headers" (:error_type %)) values)]
-          (is (= 2 (count missing-header-values)))
-          (is (apply = (map #(dissoc % :error_data) missing-header-values))))
-        (is (= 1 (->> values
-                    (filter #(= "bad-format" (:error_type %)))
-                    count)))))))
-
-(deftest xml-tree-validation-values-test
-  (testing "generates validates values for 5.1 style errors"
-    (let [ctx {:import-id 25
-               :errors {}
-               :fatal {:id
-                       {"VipObject.0.Election.1.id"
-                        {:duplicate ["ele0001"]}
-                        "VipObject.0.Election.2.id"
-                        {:duplicate ["ele0001"]}}}
-               :warnings {:import
-                          {:global
-                           {:invalid-extensions [".exemell" ".seeesvee"]}}}}
-          values (xml-tree-validation-values ctx)]
-      (is (= 4 (count values)))
-      (is (= 2
-             (->> values
-                  (filter #(= "duplicate" (:error_type %)))
-                  count))))))
-
 (deftest election-id-test
   (testing "election-id generation"
    (is (= "2015-10-10-LOUISIANA-GENERAL"

--- a/test/vip/data_processor/db/translations/v5_1/ballot_measure_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ballot_measure_contests_postgres_test.clj
@@ -6,21 +6,25 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "ballot_measure_contest.txt is loaded and transformed"
     (let [csv-files (csv-inputs ["5-1/ballot_measure_contest.txt"])
+          errors-chan (a/chan 100)
           ctx {:input csv-files
-               :spec-version "5.1"
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "part duex" "VipObject.0.BallotMeasureContest.0.BallotSubTitle.2.Text.0"
         "hot shots" "VipObject.0.BallotMeasureContest.0.BallotTitle.3.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/ballot_measure_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ballot_measure_contests_postgres_test.clj
@@ -24,7 +24,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "part duex" "VipObject.0.BallotMeasureContest.0.BallotSubTitle.2.Text.0"
         "hot shots" "VipObject.0.BallotMeasureContest.0.BallotTitle.3.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/ballot_measure_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ballot_measure_selections_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres ballot-measure-selection-transforms-test
   (testing "ballot_measure_selection.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/ballot_measure_selection.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/ballot_measure_selection.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "bms001" "VipObject.0.BallotMeasureSelection.0.id"
         "1" "VipObject.0.BallotMeasureSelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/ballot_measure_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ballot_measure_selections_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "bms001" "VipObject.0.BallotMeasureSelection.0.id"
         "1" "VipObject.0.BallotMeasureSelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/ballot_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ballot_selections_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "bs001" "VipObject.0.BallotSelection.0.id"
         "1" "VipObject.0.BallotSelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/ballot_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ballot_selections_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres ballot-selection-transforms-test
   (testing "ballot_selection.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/ballot_selection.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/ballot_selection.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "bs001" "VipObject.0.BallotSelection.0.id"
         "1" "VipObject.0.BallotSelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/candidate_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/candidate_contests_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres contest->ltree-entries-test
   (testing "tests run the important function"
-    (let [ctx {:input (csv-inputs ["5-1/candidate_contest.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/candidate_contest.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "cancon001" "VipObject.0.CandidateContest.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/candidate_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/candidate_contests_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "cancon001" "VipObject.0.CandidateContest.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/candidate_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/candidate_selections_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres candidate-selection-transforms-test
   (testing "candidate_selection.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/candidate_selection.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/candidate_selection.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "cs001" "VipObject.0.CandidateSelection.0.id"
         "3" "VipObject.0.CandidateSelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/candidate_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/candidate_selections_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "cs001" "VipObject.0.CandidateSelection.0.id"
         "3" "VipObject.0.CandidateSelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/candidates_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/candidates_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "can001" "VipObject.0.Candidate.0.id"
         "Jude Fawley" "VipObject.0.Candidate.0.BallotName.0.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/candidates_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/candidates_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres candidates-transforms-test
   (testing "candidate.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/candidate.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/candidate.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "can001" "VipObject.0.Candidate.0.id"
         "Jude Fawley" "VipObject.0.Candidate.0.BallotName.0.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/contests_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
        "con001" "VipObject.0.Contest.0.id"
        "Die Hard Series" "VipObject.0.Contest.0.BallotTitle.3.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/contests_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres contest->ltree-entries-test
   (testing "tests run the important function"
-    (let [ctx {:input (csv-inputs ["5-1/contest.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/contest.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
        "con001" "VipObject.0.Contest.0.id"
        "Die Hard Series" "VipObject.0.Contest.0.BallotTitle.3.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/election_administrations_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/election_administrations_postgres_test.clj
@@ -24,7 +24,7 @@
                         (get csv/version-pipelines "5.1"))}
         out-ctx (pipeline/run-pipeline ctx)
         errors (all-errors errors-chan)]
-    (assert-no-problems-2 errors {})
+    (assert-no-problems errors {})
 
     (testing "election_administration.txt is loaded and transformed"
       (are-xml-tree-values

--- a/test/vip/data_processor/db/translations/v5_1/election_administrations_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/election_administrations_postgres_test.clj
@@ -5,22 +5,26 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
-  (let [ctx {:input (csv-inputs ["5-1/contact_information.txt"
+  (let [errors-chan (a/chan 100)
+        ctx {:input (csv-inputs ["5-1/contact_information.txt"
                                  "5-1/department.txt"
                                  "5-1/voter_service.txt"
                                  "5-1/election_administration.txt"])
-             :spec-version "5.1"
+             :errors-chan errors-chan
+             :spec-version (atom "5.1")
              :pipeline (concat
                         [postgres/start-run
                          (data-spec/add-data-specs v5-1/data-specs)]
                         (get csv/version-pipelines "5.1"))}
-        out-ctx (pipeline/run-pipeline ctx)]
-    (assert-no-problems out-ctx [])
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
+    (assert-no-problems-2 errors {})
 
     (testing "election_administration.txt is loaded and transformed"
       (are-xml-tree-values

--- a/test/vip/data_processor/db/translations/v5_1/election_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/election_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "e001" "VipObject.0.Election.0.id"
         "Best Hot Dog" "VipObject.0.Election.0.Name.6.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/election_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/election_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres election-transforms-test
   (testing "election.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/election.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/election.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "e001" "VipObject.0.Election.0.id"
         "Best Hot Dog" "VipObject.0.Election.0.Name.6.Text.0"

--- a/test/vip/data_processor/db/translations/v5_1/electoral_districts_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/electoral_districts_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "ed001" "VipObject.0.ElectoralDistrict.0.id"
         "ocd-id" "VipObject.0.ElectoralDistrict.0.ExternalIdentifiers.0.ExternalIdentifier.0.Type.0"

--- a/test/vip/data_processor/db/translations/v5_1/electoral_districts_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/electoral_districts_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres electoral-district-transforms-test
   (testing "electoral_district.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/electoral_district.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/electoral_district.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "ed001" "VipObject.0.ElectoralDistrict.0.id"
         "ocd-id" "VipObject.0.ElectoralDistrict.0.ExternalIdentifiers.0.ExternalIdentifier.0.Type.0"

--- a/test/vip/data_processor/db/translations/v5_1/hours_open_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/hours_open_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (testing "multiple Schedules for one HoursOpen"
         (are-xml-tree-values out-ctx
          "ho001" "VipObject.0.HoursOpen.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/hours_open_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/hours_open_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres hours-open->ltree-entries-test
   (testing "schedule.txt is loaded and transformed into HoursOpen entities"
-    (let [ctx {:input (csv-inputs ["5-1/schedule.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/schedule.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (testing "multiple Schedules for one HoursOpen"
         (are-xml-tree-values out-ctx
          "ho001" "VipObject.0.HoursOpen.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/localities_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/localities_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "loc001" "VipObject.0.Locality.0.id"
         "ele123" "VipObject.0.Locality.0.ElectionAdministrationId.0"

--- a/test/vip/data_processor/db/translations/v5_1/localities_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/localities_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "locality.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/locality.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/locality.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "loc001" "VipObject.0.Locality.0.id"
         "ele123" "VipObject.0.Locality.0.ElectionAdministrationId.0"

--- a/test/vip/data_processor/db/translations/v5_1/offices_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/offices_postgres_test.clj
@@ -5,21 +5,25 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "office.txt and contact_information.txt are loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/office.txt"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/office.txt"
                                    "5-1/contact_information.txt"])
-               :spec-version "5.1"
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (testing "with a contact information"
         (are-xml-tree-values out-ctx
           "off001" "VipObject.0.Office.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/offices_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/offices_postgres_test.clj
@@ -23,7 +23,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (testing "with a contact information"
         (are-xml-tree-values out-ctx
           "off001" "VipObject.0.Office.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/ordered_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ordered_contests_postgres_test.clj
@@ -7,21 +7,25 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "ordered_contest.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/ordered_contest.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/ordered_contest.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1")
                           [oc/transformer])}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "oc2025" "VipObject.0.OrderedContest.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/ordered_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/ordered_contests_postgres_test.clj
@@ -25,7 +25,7 @@
                           [oc/transformer])}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "oc2025" "VipObject.0.OrderedContest.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/parties_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/parties_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "par01" "VipObject.0.Party.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/parties_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/parties_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "party.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/party.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/party.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "par01" "VipObject.0.Party.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/party_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/party_contests_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "pcon001" "VipObject.0.PartyContest.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/party_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/party_contests_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "party_contest.txt can be loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/party_contest.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/party_contest.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "pcon001" "VipObject.0.PartyContest.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/party_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/party_selections_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "ps001" "VipObject.0.PartySelection.0.id"
         "1" "VipObject.0.PartySelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/party_selections_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/party_selections_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres -transformer-test
   (testing "party_selection.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/party_selection.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/party_selection.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "ps001" "VipObject.0.PartySelection.0.id"
         "1" "VipObject.0.PartySelection.0.SequenceOrder.0"

--- a/test/vip/data_processor/db/translations/v5_1/people_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/people_postgres_test.clj
@@ -23,7 +23,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "per50001" "VipObject.0.Person.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/people_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/people_postgres_test.clj
@@ -6,20 +6,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres candidates-transforms-test
   (testing "person.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/contact_information.txt" "5-1/person.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/contact_information.txt" "5-1/person.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "per50001" "VipObject.0.Person.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/polling_locations_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/polling_locations_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "pl81274" "VipObject.0.PollingLocation.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/precincts_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/precincts_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "pre90111" "VipObject.0.Precinct.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/precincts_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/precincts_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "precinct.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/precinct.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/precinct.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "pre90111" "VipObject.0.Precinct.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/retention_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/retention_contests_postgres_test.clj
@@ -5,21 +5,25 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "retention_contest.txt is loaded and transformed"
     (let [csv-files (csv-inputs ["5-1/retention_contest.txt"])
+errors-chan (a/chan 100)
           ctx {:input csv-files
-               :spec-version "5.1"
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "rc001" "VipObject.0.RetentionContest.0.id"
         "Judge Dredd" "VipObject.0.RetentionContest.0.Abbreviation.0"

--- a/test/vip/data_processor/db/translations/v5_1/retention_contests_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/retention_contests_postgres_test.clj
@@ -23,7 +23,7 @@ errors-chan (a/chan 100)
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "rc001" "VipObject.0.RetentionContest.0.id"
         "Judge Dredd" "VipObject.0.RetentionContest.0.Abbreviation.0"

--- a/test/vip/data_processor/db/translations/v5_1/sources_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/sources_postgres_test.clj
@@ -22,7 +22,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "ci1024" "VipObject.0.Source.0.FeedContactInformation.2.label"

--- a/test/vip/data_processor/db/translations/v5_1/sources_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/sources_postgres_test.clj
@@ -5,20 +5,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "source.txt is loaded and transformed with contact_information"
-    (let [ctx {:input (csv-inputs ["5-1/contact_information.txt" "5-1/source.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/contact_information.txt" "5-1/source.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "ci1024" "VipObject.0.Source.0.FeedContactInformation.2.label"

--- a/test/vip/data_processor/db/translations/v5_1/states_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/states_postgres_test.clj
@@ -23,7 +23,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values
        out-ctx
        "st51" "VipObject.0.State.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/states_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/states_postgres_test.clj
@@ -6,20 +6,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres -transformer-test
   (testing "state.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/state.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/state.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values
        out-ctx
        "st51" "VipObject.0.State.0.id"

--- a/test/vip/data_processor/db/translations/v5_1/street_segment_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/street_segment_postgres_test.clj
@@ -23,7 +23,7 @@
                           (get csv/version-pipelines "5.1"))}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are-xml-tree-values out-ctx
         "ss000001" "VipObject.0.StreetSegment.0.id"
         "N" "VipObject.0.StreetSegment.0.AddressDirection.0"

--- a/test/vip/data_processor/db/translations/v5_1/street_segment_postgres_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/street_segment_postgres_test.clj
@@ -6,20 +6,24 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 
 (deftest ^:postgres transformer-test
   (testing "street_segment.txt is loaded and transformed"
-    (let [ctx {:input (csv-inputs ["5-1/street_segment.txt"])
-               :spec-version "5.1"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["5-1/street_segment.txt"])
+               :errors-chan errors-chan
+               :spec-version (atom "5.1")
                :pipeline (concat
                           [postgres/start-run
                            (data-spec/add-data-specs v5-1/data-specs)]
                           (get csv/version-pipelines "5.1"))}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are-xml-tree-values out-ctx
         "ss000001" "VipObject.0.StreetSegment.0.id"
         "N" "VipObject.0.StreetSegment.0.AddressDirection.0"

--- a/test/vip/data_processor/output/tree_xml_postgres_test.clj
+++ b/test/vip/data_processor/output/tree_xml_postgres_test.clj
@@ -68,7 +68,7 @@
              :pipeline pipeline}
         out-ctx (pipeline/run-pipeline ctx)
         errors (all-errors errors-chan)]
-    (assert-no-problems-2 errors {})
+    (assert-no-problems errors {})
     (is (= (-> out-ctx
                :xml-output-file
                .toFile

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -37,7 +37,7 @@
                       slurp
                       xpath/xml->doc)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (are [path text] (= text (xpath/$x:text path xml-doc))
            "/vip_object/ballot[@id=200000]/image_url" "http://i.imgur.com/PMgfJSm.jpg"
            "/vip_object/ballot[@id=200000]/candidate_id[@sort_order=3]" "10000"
@@ -100,7 +100,7 @@
                :vip-version "3.0"}
           results-ctx (validate-xml-output ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})))
+      (assert-no-problems errors {})))
 
   (testing "bad XML won't validate, adding to `:errors`"
     (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -22,8 +22,10 @@
                          csv/csv-filenames
                          (map #(io/as-file (io/resource (str "csv/full-good-run/" %))))
                          (remove nil?))
+          errors-chan (a/chan 100)
           ctx (merge {:input filenames
                       :spec-version (atom "3.0")
+                      :errors-chan errors-chan
                       :pipeline (concat [(data-spec/add-data-specs
                                           v3-0/data-specs)]
                                         transforms/csv-validations
@@ -33,8 +35,9 @@
                       :xml-output-file
                       .toString
                       slurp
-                      xpath/xml->doc)]
-      (assert-no-problems results-ctx [])
+                      xpath/xml->doc)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})
       (are [path text] (= text (xpath/$x:text path xml-doc))
            "/vip_object/ballot[@id=200000]/image_url" "http://i.imgur.com/PMgfJSm.jpg"
            "/vip_object/ballot[@id=200000]/candidate_id[@sort_order=3]" "10000"
@@ -91,10 +94,13 @@
                       io/resource
                       io/file
                       .toPath)
+          errors-chan (a/chan 100)
           ctx {:xml-output-file good-xml
+               :errors-chan errors-chan
                :vip-version "3.0"}
-          results-ctx (validate-xml-output ctx)]
-      (assert-no-problems results-ctx [])))
+          results-ctx (validate-xml-output ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})))
 
   (testing "bad XML won't validate, adding to `:errors`"
     (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/pipeline_test.clj
+++ b/test/vip/data_processor/pipeline_test.clj
@@ -46,8 +46,4 @@
           pipeline [incrementor incrementor incrementor]
           result (process pipeline intial-input)]
       (is (= 3 (:input result)))
-      (is (empty? (:pipeline result)))
-      (is (empty? (:warnings result)))
-      (is (empty? (:errors result)))
-      (is (empty? (:critical result)))
-      (is (empty? (:fatal result))))))
+      (is (empty? (:pipeline result))))))

--- a/test/vip/data_processor/test_helpers.clj
+++ b/test/vip/data_processor/test_helpers.clj
@@ -14,25 +14,6 @@
 
 (def problem-types [:warnings :errors :critical :fatal])
 
-(defn assert-no-problems
-  "Test that there are no errors of any level for the key-path below
-  that level.
-
-    (assert-no-problems ctx [:missing :ballot])
-
-  That will check there is nothing
-  at [:warnings :missing :ballot], [:errors :missing :ballot], etc."
-  [ctx key-path]
-  (is (nil? (:stop ctx)))
-  (is (nil? (:exception ctx)))
-  (doseq [problem-type problem-types]
-    (is (empty? (get-in ctx (cons problem-type key-path))))))
-
-(defn assert-some-problem
-  "Test that there is an error of some level for the key-path."
-  [ctx key-path]
-  (is (seq (remove nil? (map #(get-in ctx (cons % key-path)) problem-types)))))
-
 (defn csv-inputs [file-names]
   (map #(->> %
              (str "csv/")
@@ -52,17 +33,6 @@
               (korma/select (get-in ctx [:tables table])
                             (korma/fields column)
                             (korma/order :id :ASC))))))
-
-(defn assert-error-format
-  [out-ctx]
-  (doseq [severity problem-types]
-    (if-let [errors (get out-ctx severity)]
-      (let [flattened (util/flatten-keys errors)]
-        (doseq [[path-to-errors errors] flattened]
-          (is (keyword? (first path-to-errors)))
-          (is (= 3 (count path-to-errors)))
-          (is (sequential? errors))
-          (is (not (empty? errors))))))))
 
 (defonce setup-postgres-has-run (atom false))
 
@@ -131,5 +101,5 @@
 (defn contains-error? [errors error]
   (seq (matching-errors errors error)))
 
-(defn assert-no-problems-2 [errors error]
+(defn assert-no-problems [errors error]
   (is (not (contains-error? errors error))))

--- a/test/vip/data_processor/validation/csv/file_set_test.clj
+++ b/test/vip/data_processor/validation/csv/file_set_test.clj
@@ -2,7 +2,8 @@
   (:require [vip.data-processor.validation.csv.file-set :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
-            [clojure.test :refer :all])
+            [clojure.test :refer :all]
+            [clojure.core.async :as a])
   (:import [java.io File]))
 
 (deftest validate-dependencies-test
@@ -27,31 +28,45 @@
               out-ctx (validator ctx)]
           (assert-no-problems out-ctx []))))
     (testing "adds errors when dependencies are not met"
-      (let [ctx {:input [(File. "ballot.txt")
+      (let [errors-chan (a/chan 100)
+            ctx {:input [(File. "ballot.txt")
                          (File. "precinct.txt")]
+                 :errors-chan errors-chan
                  :data-specs v3-0/data-specs}
-            out-ctx (validator ctx)]
-        (assert-some-problem out-ctx [:ballots :global :missing-dependency])
-        (assert-some-problem out-ctx [:precincts :global :missing-dependency])
-        (assert-error-format out-ctx)))))
+            out-ctx (validator ctx)
+            errors (all-errors errors-chan)]
+        (is (contains-error? errors
+                             {:scope :ballots
+                              :identifier :global
+                              :error-type :missing-dependency}))
+        (is (contains-error? errors
+                             {:scope :precincts
+                              :identifier :global
+                              :error-type :missing-dependency}))))))
 
 (deftest validate-v3-dependencies-test
   (let [validator (validate-dependencies v3-0-file-dependencies)]
     (testing "polling_location.txt dependencies"
       (testing "with precinct splits"
-        (let [ctx {:input [(File. "polling_location.txt")
+        (let [errors-chan (a/chan 100)
+              ctx {:input [(File. "polling_location.txt")
                            (File. "precinct.txt")
                            (File. "precinct_split.txt")
                            (File. "polling_location.txt")
                            (File. "precinct_split_polling_location.txt")]
+                   :errors-chan errors-chan
                    :data-specs v3-0/data-specs}
-              out-ctx (validator ctx)]
-          (assert-no-problems out-ctx [])))
+              out-ctx (validator ctx)
+              errors (all-errors errors-chan)]
+          (assert-no-problems-2 errors {})))
       (testing "with precincts"
-        (let [ctx {:input [(File. "polling_location.txt")
+        (let [errors-chan (a/chan 100)
+              ctx {:input [(File. "polling_location.txt")
                            (File. "precinct.txt")
                            (File. "polling_location.txt")
                            (File. "precinct_polling_location.txt")]
+                   :errors-chan errors-chan
                    :data-specs v3-0/data-specs}
-              out-ctx (validator ctx)]
-          (assert-no-problems out-ctx []))))))
+              out-ctx (validator ctx)
+              errors (all-errors errors-chan)]
+          (assert-no-problems-2 errors {}))))))

--- a/test/vip/data_processor/validation/csv/file_set_test.clj
+++ b/test/vip/data_processor/validation/csv/file_set_test.clj
@@ -21,7 +21,7 @@
                  :data-specs v3-0/data-specs}
             out-ctx (validator ctx)
             errors (all-errors errors-chan)]
-        (assert-no-problems-2 errors {}))
+        (assert-no-problems errors {}))
       (testing "with sub-dependencies"
         (let [errors-chan (a/chan 100)
               ctx {:input [(File. "ballot.txt")
@@ -32,7 +32,7 @@
                    :data-specs v3-0/data-specs}
               out-ctx (validator ctx)
               errors (all-errors errors-chan)]
-          (assert-no-problems-2 errors {}))))
+          (assert-no-problems errors {}))))
     (testing "adds errors when dependencies are not met"
       (let [errors-chan (a/chan 100)
             ctx {:input [(File. "ballot.txt")
@@ -64,7 +64,7 @@
                    :data-specs v3-0/data-specs}
               out-ctx (validator ctx)
               errors (all-errors errors-chan)]
-          (assert-no-problems-2 errors {})))
+          (assert-no-problems errors {})))
       (testing "with precincts"
         (let [errors-chan (a/chan 100)
               ctx {:input [(File. "polling_location.txt")
@@ -75,4 +75,4 @@
                    :data-specs v3-0/data-specs}
               out-ctx (validator ctx)
               errors (all-errors errors-chan)]
-          (assert-no-problems-2 errors {}))))))
+          (assert-no-problems errors {}))))))

--- a/test/vip/data_processor/validation/csv/file_set_test.clj
+++ b/test/vip/data_processor/validation/csv/file_set_test.clj
@@ -13,20 +13,26 @@
                       "precinct.txt" "source.txt")
         validator (validate-dependencies dependencies)]
     (testing "does not add errors when dependencies are met"
-      (let [ctx {:input [(File. "ballot.txt")
+      (let [errors-chan (a/chan 100)
+            ctx {:input [(File. "ballot.txt")
                          (File. "candidate.txt")
                          (File. "election.txt")]
+                 :errors-chan errors-chan
                  :data-specs v3-0/data-specs}
-            out-ctx (validator ctx)]
-        (assert-no-problems out-ctx []))
+            out-ctx (validator ctx)
+            errors (all-errors errors-chan)]
+        (assert-no-problems-2 errors {}))
       (testing "with sub-dependencies"
-        (let [ctx {:input [(File. "ballot.txt")
+        (let [errors-chan (a/chan 100)
+              ctx {:input [(File. "ballot.txt")
                            (File. "candidate.txt")
                            (File. "precinct.txt")
                            (File. "source.txt")]
+                   :errors-chan errors-chan
                    :data-specs v3-0/data-specs}
-              out-ctx (validator ctx)]
-          (assert-no-problems out-ctx []))))
+              out-ctx (validator ctx)
+              errors (all-errors errors-chan)]
+          (assert-no-problems-2 errors {}))))
     (testing "adds errors when dependencies are not met"
       (let [errors-chan (a/chan 100)
             ctx {:input [(File. "ballot.txt")

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -5,95 +5,159 @@
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.pipeline :as pipeline]
-            [korma.core :as korma])
+            [korma.core :as korma]
+            [clojure.core.async :as a])
   (:import [java.io File]))
 
 (deftest remove-bad-filenames-test
   (let [bad-filenames [(File. "/data/BAD_FILE_NAME")
                        (File. "/data/BAD_FILE_NAME_2")]
         good-filenames (map #(File. (str "/data/" %)) (csv-filenames v3-0/data-specs))
+        errors-chan (a/chan 100)
         ctx {:input good-filenames
+             :errors-chan errors-chan
+             :spec-version (atom "3.0")
              :data-specs v3-0/data-specs}]
     (testing "with good filenames passes the context through"
       (is (= ctx (remove-bad-filenames ctx))))
     (testing "with bad filenames removes the bad files and warns"
       (let [ctx (update ctx :input (partial concat bad-filenames))
-            out-ctx (remove-bad-filenames ctx)]
-        (is (get-in out-ctx [:warnings :import :global :bad-filenames]))
+            out-ctx (remove-bad-filenames ctx)
+            errors (all-errors errors-chan)]
+        (is (contains-error? errors
+                             {:severity :warnings
+                              :scope :import
+                              :identifier :global
+                              :error-type :bad-filenames}))
         (is (not-every? (partial good-filename? v3-0/data-specs) (:input ctx)))
-        (is (every? (partial good-filename? v3-0/data-specs) (:input out-ctx)))
-        (assert-error-format out-ctx)))))
+        (is (every? (partial good-filename? v3-0/data-specs) (:input out-ctx)))))))
 
 (deftest missing-files-test
   (testing "reports errors or warnings when certain files are missing"
-    (let [ctx {:input (csv-inputs ["full-good-run/source.txt"])
+    (let [errors-chan (a/chan 100)
+          ctx {:input (csv-inputs ["full-good-run/source.txt"])
+               :errors-chan errors-chan
                :data-specs v3-0/data-specs}
           out-ctx (-> ctx
-                      error-on-missing-files)]
-      (is (get-in out-ctx [:errors :elections :global :missing-csv])) ;required, missing
-      (is (not (contains? (:errors out-ctx) :sources))) ; required, present
-      (is (not (contains? (:errors out-ctx) :contests))) ; not required, missing
-      (assert-error-format out-ctx))))
+                      error-on-missing-files)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :elections
+                            :identifier :global
+                            :error-type :missing-csv}))
+
+      ;; required, present
+      (is (not (contains-error? errors
+                                {:serverity :errors
+                                 :scope :sources})))
+      ;; not required, missing
+      (is (not (contains-error? errors
+                                {:serverity :errors
+                                 :scope :contests}))))))
 
 (deftest csv-loader-test
   (testing "ignores unknown columns"
-    (let [ctx (merge {:input (csv-inputs ["bad-columns/state.txt"])
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (csv-inputs ["bad-columns/state.txt"])
+                      :errors-chan errors-chan
                       :data-specs v3-0/data-specs}
                      (sqlite/temp-db "ignore-columns-test" "3.0"))
-          out-ctx (load-csvs ctx)]
+          out-ctx (load-csvs ctx)
+          errors (all-errors errors-chan)]
       (is (= [{:id 1 :name "NORTH CAROLINA" :election_administration_id 8}]
              (korma/select (get-in out-ctx [:tables :states]))))
       (testing "but warns about them"
-        (is (get-in out-ctx [:warnings :states :global :extraneous-headers]))
-        (assert-error-format out-ctx))))
+        (is (contains-error? errors
+                             {:severity :warnings
+                              :scope :states
+                              :identifier :global
+                              :error-type :extraneous-headers})))))
   (testing "requires a header row"
-    (let [ctx (merge {:input (csv-inputs ["no-header-row/ballot.txt"])
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (csv-inputs ["no-header-row/ballot.txt"])
+                      :errors-chan errors-chan
                       :data-specs v3-0/data-specs}
                      (sqlite/temp-db "no-headers-test" "3.0"))
-          out-ctx (load-csvs ctx)]
-      (is (= ["No header row"] (get-in out-ctx [:critical :ballots :global :no-header])))
-      (assert-error-format out-ctx))))
+          out-ctx (load-csvs ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :critical
+                            :scope :ballots
+                            :identifier :global
+                            :error-type :no-header
+                            :error-value "No header row"})))))
 
 (deftest missing-required-columns-test
-  (let [ctx (merge {:input (csv-inputs ["missing-required-columns/contest.txt"])
+  (let [errors-chan (a/chan 100)
+        ctx (merge {:input (csv-inputs ["missing-required-columns/contest.txt"])
+                    :errors-chan errors-chan
                     :data-specs v3-0/data-specs}
                    (sqlite/temp-db "missing-required-columns" "3.0"))
-        out-ctx (load-csvs ctx)]
+        out-ctx (load-csvs ctx)
+        errors (all-errors errors-chan)]
     (testing "adds a critical error for contest.txt"
-      (is (get-in out-ctx [:critical :contests :global :missing-headers]))
-      (assert-error-format out-ctx))
+      (is (contains-error? errors
+                           {:severity :critical
+                            :scope :contests
+                            :identifier :global
+                            :error-type :missing-headers})))
     (testing "does not import contest.txt"
       (is (empty? (korma/select (get-in ctx [:tables :contests])))))))
 
 (deftest report-bad-rows-test
-  (let [ctx (merge {:input (csv-inputs ["bad-number-of-values/contest.txt"])
-                    :spec-version "3.0"
+  (let [errors-chan (a/chan 100)
+        ctx (merge {:input (csv-inputs ["bad-number-of-values/contest.txt"])
+                    :errors-chan errors-chan
+                    :spec-version (atom "3.0")
                     :data-specs v3-0/data-specs}
                    (sqlite/temp-db "bad-number-of-values" "3.0"))
-        out-ctx (load-csvs ctx)]
+        out-ctx (load-csvs ctx)
+        errors (all-errors errors-chan)]
     (testing "reports critical errors for rows with wrong number of values"
-      (is (get-in out-ctx [:critical :contests 3 :number-of-values]))
-      (is (get-in out-ctx [:critical :contests 5 :number-of-values]))
-      (assert-error-format out-ctx))))
+      (is (contains-error? errors
+                           {:severity :critical
+                            :scope :contests
+                            :identifier 3
+                            :error-type :number-of-values}))
+      (is (contains-error? errors
+                           {:severity :critical
+                            :scope :contests
+                            :identifier 5
+                            :error-type :number-of-values})))))
 
 (deftest in-file-duplicate-ids-test
-  (let [db (sqlite/temp-db "in-file-duplicate-ids" "3.0")
+  (let [errors-chan (a/chan 100)
+        db (sqlite/temp-db "in-file-duplicate-ids" "3.0")
         ctx (merge {:input (csv-inputs ["in-file-duplicate-ids/contest.txt"])
+                    :errors-chan errors-chan
                     :data-specs v3-0/data-specs}
                    db)]
     (korma/insert (get-in db [:tables :contests])
                   (korma/values {:id 6}))
-    (let [out-ctx (load-csvs ctx)]
+    (let [out-ctx (load-csvs ctx)
+          errors (all-errors errors-chan)]
       (testing "reports fatal errors for duplicate ids"
-        (is (get-in out-ctx [:fatal :contests "3" :duplicate-ids]))
-        (is (get-in out-ctx [:fatal :contests "5" :duplicate-ids]))
-        (is (get-in out-ctx [:fatal :contests "6" :duplicate-ids]))
+        (is (contains-error? errors
+                             {:severity :fatal
+                              :scope :contests
+                              :identifier "3"
+                              :error-type :duplicate-ids}))
+        (is (contains-error? errors
+                             {:severity :fatal
+                              :scope :contests
+                              :identifier "5"
+                              :error-type :duplicate-ids}))
+        (is (contains-error? errors
+                             {:severity :fatal
+                              :scope :contests
+                              :identifier "6"
+                              :error-type :duplicate-ids}))
         (is (= [1 2 4 6]
                (map :id
                     (korma/select (get-in db [:tables :contests])
                                   (korma/fields :id)
-                                  (korma/order :id :ASC)))))
-        (assert-error-format out-ctx)))))
+                                  (korma/order :id :ASC)))))))))
 
 (deftest byte-order-marker-test
   (let [db (sqlite/temp-db "byte-order-marker" "3.0")
@@ -125,38 +189,40 @@
 
 (deftest determine-spec-version-test
   (testing "finds and assocs the version of the csv feed for 3.0 files"
-    (let [ctx {:input (csv-inputs ["full-good-run/source.txt"])}
+    (let [ctx {:input (csv-inputs ["full-good-run/source.txt"])
+               :spec-version (atom nil)}
           out-ctx (determine-spec-version ctx)]
-      (is (= "3.0" (get out-ctx :spec-version)))))
+      (is (= "3.0" @(get out-ctx :spec-version)))))
 
   (testing "finds and assocs the version of the csv feed for 5.1 files"
-    (let [ctx {:input (csv-inputs ["5-1/spec-version/source.txt"])}
+    (let [ctx {:input (csv-inputs ["5-1/spec-version/source.txt"])
+               :spec-version (atom nil)}
           out-ctx (determine-spec-version ctx)]
-      (is (= "5.1" (get out-ctx :spec-version))))))
+      (is (= "5.1" @(get out-ctx :spec-version))))))
 
 (deftest branch-on-spec-version-test
   (testing "add the 3.0 import pipeline to the front of the pipeline for 3.0 feeds"
-    (let [ctx {:spec-version "3.0"}
+    (let [ctx {:spec-version (atom "3.0")}
           out-ctx (branch-on-spec-version ctx)
           three-point-0-pipeline (get version-pipelines "3.0")]
       (is (= three-point-0-pipeline
              (take (count three-point-0-pipeline) (:pipeline out-ctx))))))
 
   (testing "add the 5.1 import pipeline to the front of the pipeline for 5.1 feeds"
-    (let [ctx {:spec-version "5.1"}
+    (let [ctx {:spec-version (atom "5.1")}
           out-ctx (branch-on-spec-version ctx)
           five-point-0-pipeline (get version-pipelines "5.1")]
       (is (= five-point-0-pipeline
              (take (count five-point-0-pipeline) (:pipeline out-ctx))))))
 
   (testing "stops with unsupported version for other versions"
-    (let [ctx {:spec-version "2.0" ; 2.0 is too old
+    (let [ctx {:spec-version (atom "2.0")   ; 2.0 is too old
                :pipeline [branch-on-spec-version]}
           out-ctx (pipeline/run-pipeline ctx)]
       (is (.startsWith (:stop out-ctx) "Unsupported CSV version"))))
 
   (testing "stops with unsupported version for other versions"
-    (let [ctx {:spec-version "5.2" ; 5.1 is cool; 5.2 is vaporware
+    (let [ctx {:spec-version (atom "5.2")  ; 5.1 is cool; 5.2 is vaporware
                :pipeline [branch-on-spec-version]}
           out-ctx (pipeline/run-pipeline ctx)]
       (is (.startsWith (:stop out-ctx) "Unsupported CSV version")))))

--- a/test/vip/data_processor/validation/csv_test.clj
+++ b/test/vip/data_processor/validation/csv_test.clj
@@ -170,8 +170,7 @@
              (map :name
                   (korma/select
                    (get-in out-ctx [:tables :sources])
-                   (korma/fields :name)))))
-      (assert-error-format out-ctx))))
+                   (korma/fields :name))))))))
 
 (deftest low-number-vip-id-test
   (let [db (sqlite/temp-db "low-number-vip-id-test" "3.0")
@@ -184,8 +183,7 @@
              (map :vip_id
                   (korma/select
                    (get-in out-ctx [:tables :sources])
-                   (korma/fields :vip_id)))))
-      (assert-error-format out-ctx))))
+                   (korma/fields :vip_id))))))))
 
 (deftest determine-spec-version-test
   (testing "finds and assocs the version of the csv feed for 3.0 files"

--- a/test/vip/data_processor/validation/data_spec_test.clj
+++ b/test/vip/data_processor/validation/data_spec_test.clj
@@ -74,7 +74,7 @@
                   ctx {:errors-chan errors-chan}
                   result-ctx (format-rule ctx {column "1234" "id" id} line-number)
                   errors (all-errors errors-chan)]
-              (is (assert-no-problems-2 errors {}))))))
+              (is (assert-no-problems errors {}))))))
       (testing "optional column"
         (let [format-rule (create-format-rule filename {:name column :format format})]
           (testing "if it's not there, it's okay"
@@ -82,14 +82,14 @@
                   ctx {:errors-chan errors-chan}
                   result-ctx (format-rule ctx {} line-number)
                   errors (all-errors errors-chan)]
-              (is (assert-no-problems-2 errors {}))))
+              (is (assert-no-problems errors {}))))
           (testing "if it is there"
             (testing "it matches the format, everything's okay"
               (let [errors-chan (a/chan 100)
                     ctx {:errors-chan errors-chan}
                     result-ctx (format-rule ctx {column "1234" "id" id} line-number)
                     errors (all-errors errors-chan)]
-                (is (assert-no-problems-2 errors {}))))
+                (is (assert-no-problems errors {}))))
             (testing "it doesn't match the format, you get an error"
               (let [errors-chan (a/chan 100)
                     ctx {:errors-chan errors-chan}
@@ -107,12 +107,12 @@
                   ctx {:errors-chan errors-chan}
                   result-ctx (format-rule ctx {column "yes" "id" id} line-number)
                   errors (all-errors errors-chan)]
-              (is (assert-no-problems-2 errors {})))
+              (is (assert-no-problems errors {})))
             (let [errors-chan (a/chan 100)
                   ctx {:errors-chan errors-chan}
                   result-ctx (format-rule ctx {column "no" "id" id} line-number)
                   errors (all-errors errors-chan)]
-              (is (assert-no-problems-2 errors {}))))
+              (is (assert-no-problems errors {}))))
           (testing "non-matches"
             (let [errors-chan (a/chan 100)
                   ctx {:errors-chan errors-chan}
@@ -138,7 +138,7 @@
                       ctx {:errors-chan errors-chan}
                       result-ctx (format-rule ctx {column value "id" id} line-number)
                       errors (all-errors errors-chan)]
-                  (is (assert-no-problems-2 errors {})))
+                  (is (assert-no-problems errors {})))
               "YES"
               "NO"
               "Yes"))))
@@ -151,7 +151,7 @@
                       ctx {:errors-chan errors-chan}
                       result-ctx (format-rule ctx {column value "id" id} line-number)
                       errors (all-errors errors-chan)]
-                  (is (assert-no-problems-2 errors {})))
+                  (is (assert-no-problems errors {})))
               "able was I ere I saw elba"
               "racecar"))
           (testing "non-matches"
@@ -188,7 +188,7 @@
                     ctx {:errors-chan errors-chan}
                     result-ctx (format-rule ctx {column value "id" id} line-number)
                     errors (all-errors errors-chan)]
-                (is (assert-no-problems-2 errors {})))
+                (is (assert-no-problems errors {})))
             "hi"
             nil))))
     (testing "without an id, uses the line number"
@@ -219,7 +219,7 @@
                   ctx {:errors-chan errors-chan}
                   result-ctx (format-rule ctx {column "1234"} line-number)
                   errors (all-errors errors-chan)]
-              (assert-no-problems-2 errors {}))))))
+              (assert-no-problems errors {}))))))
     (testing "with a severity set on the format"
       (let [format {:check #"\A\d+\z"
                     :message "Invalid data type"

--- a/test/vip/data_processor/validation/db/v3_0/fips_test.clj
+++ b/test/vip/data_processor/validation/db/v3_0/fips_test.clj
@@ -7,23 +7,36 @@
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
             [vip.data-processor.db.sqlite :as sqlite]
-            [vip.data-processor.pipeline :as pipeline]))
+            [vip.data-processor.pipeline :as pipeline]
+            [clojure.core.async :as a]))
 
 (deftest validate-valid-source-vip-id-test
   (testing "adds an error if the source's vip_id is bad from a csv"
-    (let [ctx (merge {:input (csv-inputs ["invalid-source-vip-id/source.txt"])
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (csv-inputs ["invalid-source-vip-id/source.txt"])
+                      :errors-chan errors-chan
                       :pipeline [(data-spec/add-data-specs v3-0/data-specs)
                                  csv/load-csvs
                                  validate-valid-source-vip-id]}
                      (sqlite/temp-db "invalid-source-vip-id-csv" "3.0"))
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (= ["5199955554447"] (get-in out-ctx [:errors :sources 1 :invalid-vip-id])))
-      (assert-error-format out-ctx)))
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors {:severity :errors
+                                   :scope :sources
+                                   :identifier 1
+                                   :error-type :invalid-vip-id
+                                   :error-value "5199955554447"}))))
   (testing "adds an error if the source's vip_id is bad from a xml"
-    (let [ctx (merge {:input (xml-input "invalid-source-vip-id.xml")
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (xml-input "invalid-source-vip-id.xml")
                       :data-specs v3-0/data-specs
+                      :errors-chan errors-chan
                       :pipeline [xml/load-xml validate-valid-source-vip-id]}
                      (sqlite/temp-db "invalid-source-vip-id-xml" "3.0"))
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (= ["99999"] (get-in out-ctx [:errors :sources 0 :invalid-vip-id])))
-      (assert-error-format out-ctx))))
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors {:severity :errors
+                                   :scope :sources
+                                   :identifier 0
+                                   :error-type :invalid-vip-id
+                                   :error-value "99999"})))))

--- a/test/vip/data_processor/validation/db/v3_0/jurisdiction_references_test.clj
+++ b/test/vip/data_processor/validation/db/v3_0/jurisdiction_references_test.clj
@@ -6,27 +6,34 @@
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
             [vip.data-processor.db.sqlite :as sqlite]
-            [vip.data-processor.pipeline :as pipeline]))
+            [vip.data-processor.pipeline :as pipeline]
+            [clojure.core.async :as a]))
 
 (deftest validate-jurisdiction-references-test
   (testing "finds bad jurisdiction references"
-    (let [ctx (merge {:input (csv-inputs ["bad-references/ballot_line_result.txt"
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (csv-inputs ["bad-references/ballot_line_result.txt"
                                           "bad-references/state.txt"
                                           "bad-references/locality.txt"
                                           "bad-references/precinct.txt"
                                           "bad-references/precinct_split.txt"
                                           "bad-references/electoral_district.txt"])
+                      :errors-chan errors-chan
                       :pipeline [(data-spec/add-data-specs v3-0/data-specs)
                                  csv/load-csvs
                                  validate-jurisdiction-references]}
                      (sqlite/temp-db "bad-jurisdiction-references" "3.0"))
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (= 8 (-> out-ctx
-                   (get-in [:errors :ballot-line-results 100 :unmatched-reference])
-                   first
-                   :jurisdiction_id)))
-      (is (= 800 (-> out-ctx
-                     (get-in [:errors :ballot-line-results 101 :unmatched-reference])
-                     first
-                     :jurisdiction_id)))
-      (assert-error-format out-ctx))))
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :ballot-line-results
+                            :identifier 100
+                            :error-type :unmatched-reference
+                            :error-value {:jurisdiction_id 8}}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :ballot-line-results
+                            :identifier 101
+                            :error-type :unmatched-reference
+                            :error-value {:jurisdiction_id 800}})))))

--- a/test/vip/data_processor/validation/db/v3_0/precinct_test.clj
+++ b/test/vip/data_processor/validation/db/v3_0/precinct_test.clj
@@ -6,19 +6,35 @@
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
             [vip.data-processor.db.sqlite :as sqlite]
-            [vip.data-processor.pipeline :as pipeline]))
+            [vip.data-processor.pipeline :as pipeline]
+            [clojure.core.async :as a]))
 
 (deftest validate-no-missing-polling-locations-test
   (testing "finds precincts without polling locations"
-    (let [ctx (merge {:input (csv-inputs ["missing-polling-locations/precinct.txt"
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (csv-inputs ["missing-polling-locations/precinct.txt"
                                           "missing-polling-locations/polling_location.txt"
                                           "missing-polling-locations/precinct_polling_location.txt"])
+                      :errors-chan errors-chan
                       :pipeline [(data-spec/add-data-specs v3-0/data-specs)
                                  csv/load-csvs
                                  validate-no-missing-polling-locations]}
                      (sqlite/temp-db "missing-polling-locations" "3.0"))
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:warnings :precincts 3 :missing-polling-location]))
-      (is (get-in out-ctx [:warnings :precincts 4 :missing-polling-location]))
-      (is (nil? (get-in out-ctx [:warnings :precincts 2 :missing-polling-location])))
-      (is (nil? (get-in out-ctx [:warnings :precincts 1 :missing-polling-location]))))))
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors {:severity :warnings
+                                   :scope :precincts
+                                   :identifier 3
+                                   :error-type :missing-polling-location}))
+      (is (contains-error? errors {:severity :warnings
+                                   :scope :precincts
+                                   :identifier 4
+                                   :error-type :missing-polling-location}))
+      (is (not (contains-error? errors {:severity :warnings
+                                        :scope :precincts
+                                        :identifier 2
+                                        :error-type :missing-polling-location})))
+      (is (not (contains-error? errors {:severity :warnings
+                                        :scope :precincts
+                                        :identifier 1
+                                        :error-type :missing-polling-location}))))))

--- a/test/vip/data_processor/validation/db/v3_0/street_segment_test.clj
+++ b/test/vip/data_processor/validation/db/v3_0/street_segment_test.clj
@@ -6,24 +6,35 @@
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
             [vip.data-processor.db.sqlite :as sqlite]
-            [vip.data-processor.pipeline :as pipeline]))
+            [vip.data-processor.pipeline :as pipeline]
+            [clojure.core.async :as a]))
 
 (deftest validate-no-overlapping-street-segments-test
-  (let [ctx (merge {:input (csv-inputs ["overlapping-street-segments/street_segment.txt"])
+  (let [errors-chan (a/chan 100)
+        ctx (merge {:input (csv-inputs ["overlapping-street-segments/street_segment.txt"])
+                    :errors-chan errors-chan
                     :pipeline [(data-spec/add-data-specs v3-0/data-specs)
                                csv/load-csvs
                                validate-no-overlapping-street-segments]}
                    (sqlite/temp-db "overlapping-street-segments" "3.0"))
-        out-ctx (pipeline/run-pipeline ctx)]
-    (is (= '(12) (get-in out-ctx [:errors :street-segments 11 :overlaps])))
-    (is (= '(14) (get-in out-ctx [:errors :street-segments 13 :overlaps])))
-    (is (= #{16 17} (set (get-in out-ctx [:errors :street-segments 15 :overlaps]))))
-    (is (= '(19) (get-in out-ctx [:errors :street-segments 18 :overlaps])))
-    (is (= '(21) (get-in out-ctx [:errors :street-segments 20 :overlaps])))
-    (is (not (get-in out-ctx [:errors :street-segments 22 :overlaps])))
-    (is (not (get-in out-ctx [:errors :street-segments 23 :overlaps])))
-    (is (not (get-in out-ctx [:errors :street-segments 24 :overlaps])))
-    (is (not (get-in out-ctx [:errors :street-segments 25 :overlaps])))
-    (is (not (get-in out-ctx [:errors :street-segments 26 :overlaps])))
-    (is (= '(28) (get-in out-ctx [:errors :street-segments 27 :overlaps])))
-    (assert-error-format out-ctx)))
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
+    (are [id overlap-id] (is (contains-error? errors
+                                              {:severity :errors
+                                               :scope :street-segments
+                                               :identifier id
+                                               :error-type :overlaps
+                                               :error-value overlap-id}))
+      11 12
+      13 14
+      15 16
+      15 17
+      18 19
+      20 21
+      27 28)
+    (doseq [id [22 23 24 25 26]]
+      (is (nil? (contains-error?  errors
+                                  {:severity :errors
+                                   :scope :street-segments
+                                   :identifier id
+                                   :error-type :overlaps}))))))

--- a/test/vip/data_processor/validation/db_test.clj
+++ b/test/vip/data_processor/validation/db_test.clj
@@ -27,7 +27,7 @@
                             :identifier 5882300
                             :error-type :duplicate-ids
                             :error-value '("contests" "candidates")}))
-      (assert-no-problems-2 errors
+      (assert-no-problems errors
                             {:severity :errors
                              :scope :import
                              :identifier 7
@@ -68,7 +68,7 @@
                                           :ballot_id 410004746}}))
       (testing "does not add errors for ballots"
         (doseq [id [1 2 3]]
-          (assert-no-problems-2 errors
+          (assert-no-problems errors
                                 {:severity :warnings
                                  :scope :ballots
                                  :identifier id
@@ -136,7 +136,7 @@
         :candidates 13
         :candidates 14)
       (testing "except for contests"
-        (assert-no-problems-2 errors
+        (assert-no-problems errors
                               {:severity :warnings
                                :scope :contests
                                :identifier 100

--- a/test/vip/data_processor/validation/transforms_test.clj
+++ b/test/vip/data_processor/validation/transforms_test.clj
@@ -31,7 +31,7 @@
           errors (all-errors errors-chan)]
       (is (nil? (:stop results-ctx)))
       (is (nil? (:exception results-ctx)))
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))
 
 (deftest remove-invalid-extensions-test
   (testing "removes non-csv, txt, or xml files from :input"

--- a/test/vip/data_processor/validation/transforms_test.clj
+++ b/test/vip/data_processor/validation/transforms_test.clj
@@ -20,15 +20,18 @@
                          csv/csv-filenames
                          (map #(io/as-file (io/resource (str "csv/full-good-run/" %))))
                          (remove nil?))
+          errors-chan (a/chan 100)
           ctx (merge {:input filenames
+                      :errors-chan errors-chan
                       :spec-version (atom nil)
                       :pipeline (concat [(data-spec/add-data-specs v3-0/data-specs)]
                                         csv-validations
                                         db/validations)} db)
-          results-ctx (pipeline/run-pipeline ctx)]
+          results-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
       (is (nil? (:stop results-ctx)))
       (is (nil? (:exception results-ctx)))
-      (assert-no-problems results-ctx []))))
+      (assert-no-problems-2 errors {}))))
 
 (deftest remove-invalid-extensions-test
   (testing "removes non-csv, txt, or xml files from :input"

--- a/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
@@ -3,45 +3,58 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-types-test
-  (let [ctx {:input (xml-input "v5-ballot-measure-contests.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-ballot-measure-contests.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.bmc/validate-no-missing-types)]
+                    v5.bmc/validate-no-missing-types)
+        errors (all-errors errors-chan)]
     (testing "type missing is an error"
-      (is (get-in out-ctx [:errors :ballot-measure-contest
-                           "VipObject.0.BallotMeasureContest.0.Type" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :ballot-measure-contest
+                            :identifier "VipObject.0.BallotMeasureContest.0.Type"
+                            :error-type :missing})))
     (testing "type present is OK"
       (doseq [path ["VipObject.0.BallotMeasureContest.1.Type"
                     "VipObject.0.BallotMeasureContest.2.Type"
                     "VipObject.0.BallotMeasureContest.3.Type"
                     "VipObject.0.BallotMeasureContest.4.Type"
                     "VipObject.0.BallotMeasureContest.5.Type"]]
-        (assert-no-problems out-ctx [:ballot-measure-contest
-                                     path
-                                     :missing])))))
+        (assert-no-problems-2 errors {:scope :ballot-measure-contest
+                                      :identifier path
+                                      :error-type :missing})))))
 
 (deftest ^:postgres validate-ballot-measure-types-test
-  (let [ctx {:input (xml-input "v5-ballot-measure-contests.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-ballot-measure-contests.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.bmc/validate-ballot-measure-types)]
+                    v5.bmc/validate-ballot-measure-types)
+        errors (all-errors errors-chan)]
     (testing "a bad type is an error"
-      (is (get-in out-ctx [:errors :ballot-measure-contest
-                           "VipObject.0.BallotMeasureContest.1.Type.0"
-                           :format])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :ballot-measure-contest
+                            :identifier "VipObject.0.BallotMeasureContest.1.Type.0"
+                            :error-type :format})))
     (testing "a good type is okay"
       (doseq [path ["VipObject.0.BallotMeasureContest.2.Type.0"
                     "VipObject.0.BallotMeasureContest.3.Type.0"
                     "VipObject.0.BallotMeasureContest.4.Type.0"
                     "VipObject.0.BallotMeasureContest.5.Type.0"]]
-        (assert-no-problems out-ctx [:ballot-measure-contest
-                                     path
-                                     :format])))))
+        (assert-no-problems-2 errors
+                              {:scope :ballot-measure-contest
+                               :identifier path
+                               :error-type :format})))))

--- a/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
@@ -30,7 +30,7 @@
                     "VipObject.0.BallotMeasureContest.3.Type"
                     "VipObject.0.BallotMeasureContest.4.Type"
                     "VipObject.0.BallotMeasureContest.5.Type"]]
-        (assert-no-problems-2 errors {:scope :ballot-measure-contest
+        (assert-no-problems errors {:scope :ballot-measure-contest
                                       :identifier path
                                       :error-type :missing})))))
 
@@ -54,7 +54,7 @@
                     "VipObject.0.BallotMeasureContest.3.Type.0"
                     "VipObject.0.BallotMeasureContest.4.Type.0"
                     "VipObject.0.BallotMeasureContest.5.Type.0"]]
-        (assert-no-problems-2 errors
+        (assert-no-problems errors
                               {:scope :ballot-measure-contest
                                :identifier path
                                :error-type :format})))))

--- a/test/vip/data_processor/validation/v5/candidate_test.clj
+++ b/test/vip/data_processor/validation/v5/candidate_test.clj
@@ -20,10 +20,10 @@
         out-ctx (pipeline/run-pipeline ctx)
         errors (all-errors errors-chan)]
     (are [path]
-        (assert-no-problems-2 errors
-                              {:severity :errors
-                               :scope :candidates
-                               :identifier path})
+        (assert-no-problems errors
+                            {:severity :errors
+                             :scope :candidates
+                             :identifier path})
       "VipObject.0.Candidate.0.PreElectionStatus.0"
       "VipObject.0.Candidate.1.PreElectionStatus.0"
       "VipObject.0.Candidate.2.PreElectionStatus.0"
@@ -48,10 +48,10 @@
         out-ctx (pipeline/run-pipeline ctx)
         errors (all-errors errors-chan)]
     (are [path]
-        (assert-no-problems-2 errors
-                              {:severity :errors
-                               :scope :candidates
-                               :identifier path})
+        (assert-no-problems errors
+                            {:severity :errors
+                             :scope :candidates
+                             :identifier path})
       "VipObject.0.Candidate.0.PostElectionStatus.1"
       "VipObject.0.Candidate.1.PostElectionStatus.1"
       "VipObject.0.Candidate.2.PostElectionStatus.1"
@@ -87,14 +87,14 @@
                             :identifier "VipObject.0.Candidate.1.BallotName"
                             :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :candidates
-                             :identifier "VipObject.0.Candidate.2.BallotName"
-                             :error-type :missing}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :candidates
+                           :identifier "VipObject.0.Candidate.2.BallotName"
+                           :error-type :missing}))
     (testing "doesn't care if BallotName isn't first"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :candidates
-                             :identifier "VipObject.0.Candidate.3.BallotName"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :candidates
+                           :identifier "VipObject.0.Candidate.3.BallotName"
+                           :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/candidate_test.clj
+++ b/test/vip/data_processor/validation/v5/candidate_test.clj
@@ -4,81 +4,97 @@
              [vip.data-processor.db.postgres :as psql]
              [vip.data-processor.validation.xml :as xml]
              [vip.data-processor.test-helpers :refer :all]
-             [vip.data-processor.validation.v5.candidate :as v5.candidate]))
+             [vip.data-processor.validation.v5.candidate :as v5.candidate]
+             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-pre-election-statuses-test
-  (let [ctx {:input (xml-input "v5-election-statuses.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:errors-chan errors-chan
+             :input (xml-input "v5-election-statuses.xml")
              :pipeline [psql/start-run
                         xml/load-xml-ltree
                         v5.candidate/validate-pre-election-statuses]}
-        out-ctx (pipeline/run-pipeline ctx)]
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.0.PreElectionStatus.0"])))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.1.PreElectionStatus.0"])))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.2.PreElectionStatus.0"])))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.3.PreElectionStatus.0"])))
-    (is (get-in out-ctx [:errors
-                         :candidates
-                         "VipObject.0.Candidate.4.PreElectionStatus.0"
-                         :format]))
-    (is (get-in out-ctx [:errors
-                         :candidates
-                         "VipObject.0.Candidate.5.PreElectionStatus.0"
-                         :format]))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.6.PreElectionStatus.0"])))))
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
+    (are [path]
+        (assert-no-problems-2 errors
+                              {:severity :errors
+                               :scope :candidates
+                               :identifier path})
+      "VipObject.0.Candidate.0.PreElectionStatus.0"
+      "VipObject.0.Candidate.1.PreElectionStatus.0"
+      "VipObject.0.Candidate.2.PreElectionStatus.0"
+      "VipObject.0.Candidate.3.PreElectionStatus.0"
+      "VipObject.0.Candidate.6.PreElectionStatus.0")
+    (are [path]
+        (is (contains-error? errors
+                             {:severity :errors
+                              :scope :candidates
+                              :identifier path
+                              :error-type :format}))
+      "VipObject.0.Candidate.4.PreElectionStatus.0"
+      "VipObject.0.Candidate.5.PreElectionStatus.0")))
 
 (deftest ^:postgres validate-post-election-statuses-test
-  (let [ctx {:input (xml-input "v5-election-statuses.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-election-statuses.xml")
+             :errors-chan errors-chan
              :pipeline [psql/start-run
                         xml/load-xml-ltree
                         v5.candidate/validate-post-election-statuses]}
-        out-ctx (pipeline/run-pipeline ctx)]
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.0.PostElectionStatus.1"])))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.1.PostElectionStatus.1"])))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.2.PostElectionStatus.1"])))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.3.PostElectionStatus.1"])))
-    (is (get-in out-ctx [:errors
-                         :candidates
-                         "VipObject.0.Candidate.4.PostElectionStatus.1"
-                         :format]))
-    (is (get-in out-ctx [:errors
-                         :candidates
-                         "VipObject.0.Candidate.5.PostElectionStatus.1"
-                         :format]))
-    (is (not (get-in out-ctx [:errors
-                              :candidates
-                              "VipObject.0.Candidate.6.PostElectionStatus.1"])))))
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
+    (are [path]
+        (assert-no-problems-2 errors
+                              {:severity :errors
+                               :scope :candidates
+                               :identifier path})
+      "VipObject.0.Candidate.0.PostElectionStatus.1"
+      "VipObject.0.Candidate.1.PostElectionStatus.1"
+      "VipObject.0.Candidate.2.PostElectionStatus.1"
+      "VipObject.0.Candidate.3.PostElectionStatus.1"
+      "VipObject.0.Candidate.6.PostElectionStatus.1")
+    (are [path]
+        (is (contains-error? errors
+                             {:severity :errors
+                              :scope :candidates
+                              :identifier path
+                              :error-type :format}))
+      "VipObject.0.Candidate.4.PostElectionStatus.1"
+      "VipObject.0.Candidate.5.PostElectionStatus.1")))
 
 (deftest ^:postgres validate-no-missing-ballot-names-test
-  (let [ctx {:input (xml-input "v5-missing-ballot-names.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-missing-ballot-names.xml")
+             :errors-chan errors-chan
              :pipeline [psql/start-run
                         xml/load-xml-ltree
                         v5.candidate/validate-no-missing-ballot-names]}
-        out-ctx (pipeline/run-pipeline ctx)]
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing BallotNames are flagged"
-      (is (get-in out-ctx [:errors :candidates "VipObject.0.Candidate.0.BallotName" :missing]))
-      (is (get-in out-ctx [:errors :candidates "VipObject.0.Candidate.1.BallotName" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :candidates
+                            :identifier "VipObject.0.Candidate.0.BallotName"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :candidates
+                            :identifier "VipObject.0.Candidate.1.BallotName"
+                            :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (is (not (get-in out-ctx [:errors :candidates "VipObject.0.Candidate.2.BallotName" :missing]))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :candidates
+                             :identifier "VipObject.0.Candidate.2.BallotName"
+                             :error-type :missing}))
     (testing "doesn't care if BallotName isn't first"
-      (is (not (get-in out-ctx [:errors :candidates "VipObject.0.Candidate.3.BallotName" :missing]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :candidates
+                             :identifier "VipObject.0.Candidate.3.BallotName"
+                             :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/district_type_test.clj
+++ b/test/vip/data_processor/validation/v5/district_type_test.clj
@@ -20,17 +20,17 @@
                       v5.district-type/validate)
           errors (all-errors errors-chan)]
       (testing "type missing is OK"
-        (assert-no-problems-2 errors
-                              {:severity :errors
-                               :scope :locality
-                               :identifier "VipObject.0.Locality.0.Type"
-                               :error-type :missing}))
+        (assert-no-problems errors
+                            {:severity :errors
+                             :scope :locality
+                             :identifier "VipObject.0.Locality.0.Type"
+                             :error-type :missing}))
       (testing "type present and valid is OK"
-        (assert-no-problems-2 errors
-                              {:severity :errors
-                               :scope :locality
-                               :identifier "VipObject.0.Locality.1.Type.2"
-                               :error-type :format}))
+        (assert-no-problems errors
+                            {:severity :errors
+                             :scope :locality
+                             :identifier "VipObject.0.Locality.1.Type.2"
+                             :error-type :format}))
       (testing "type present and invalid is an error"
         (is (contains-error? errors
                              {:severity :errors
@@ -48,11 +48,11 @@
           errors (all-errors errors-chan)]
       (testing "type valid is OK"
         (are [path]
-            (assert-no-problems-2 errors
-                                  {:severity :errors
-                                   :scope :electoral-district
-                                   :identifier path
-                                   :error-type :format})
+            (assert-no-problems errors
+                                {:severity :errors
+                                 :scope :electoral-district
+                                 :identifier path
+                                 :error-type :format})
           "VipObject.0.ElectoralDistrict.0.Type.1"
           "VipObject.0.ElectoralDistrict.1.Type.1"
           "VipObject.0.ElectoralDistrict.4.Type.0"))

--- a/test/vip/data_processor/validation/v5/election_administration_test.clj
+++ b/test/vip/data_processor/validation/v5/election_administration_test.clj
@@ -25,14 +25,14 @@
                             :scope :election-administration
                             :identifier "VipObject.0.ElectionAdministration.2.Department"
                             :error-type :missing}))
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :election-administration
-                             :identifier "VipObject.0.ElectionAdministration.0.Department"})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :election-administration
-                             :identifier "VipObject.0.ElectionAdministration.1.Department"}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :election-administration
+                           :identifier "VipObject.0.ElectionAdministration.0.Department"})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :election-administration
+                           :identifier "VipObject.0.ElectionAdministration.1.Department"}))))
 
 (deftest ^:postgres validate-voter-service-type-format-test
   (let [errors-chan (a/chan 100)
@@ -44,14 +44,14 @@
                     v5.election-admin/validate-voter-service-type-format)
         errors (all-errors errors-chan)]
     (testing "valid VoterService -> Type is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :election-administration
-                             :identifier (str/join "." ["VipObject" "0"
-                                                        "ElectionAdministration" "0"
-                                                        "Department" "0"
-                                                        "VoterService" "0"
-                                                        "Type" "0"])}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :election-administration
+                           :identifier (str/join "." ["VipObject" "0"
+                                                      "ElectionAdministration" "0"
+                                                      "Department" "0"
+                                                      "VoterService" "0"
+                                                      "Type" "0"])}))
     (testing "invalid VoterService -> Type is an error"
       (is (contains-error? errors
                            {:severity :errors

--- a/test/vip/data_processor/validation/v5/election_administration_test.clj
+++ b/test/vip/data_processor/validation/v5/election_administration_test.clj
@@ -4,48 +4,61 @@
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
             [vip.data-processor.validation.xml :as xml]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-departments-test
   (testing "missing Department element is an error"
-    (let [ctx {:input (xml-input "v5-election-administrations.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-election-administrations.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.election-admin/validate-no-missing-departments)]
-      (is (get-in out-ctx [:errors :election-administration
-                           "VipObject.0.ElectionAdministration.2.Department"
-                           :missing]))
-      (is (not (get-in out-ctx
-                       [:errors :election-administration
-                        "VipObject.0.ElectionAdministration.0.Department"])))
-      (is (not (get-in out-ctx
-                       [:errors :election-administration
-                        "VipObject.0.ElectionAdministration.1.Department"]))))))
+                      v5.election-admin/validate-no-missing-departments)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :election-administration
+                            :identifier "VipObject.0.ElectionAdministration.2.Department"
+                            :error-type :missing}))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :election-administration
+                             :identifier "VipObject.0.ElectionAdministration.0.Department"})
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :election-administration
+                             :identifier "VipObject.0.ElectionAdministration.1.Department"}))))
 
 (deftest ^:postgres validate-voter-service-type-format-test
-  (let [ctx {:input (xml-input "v5-election-administrations.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-election-administrations.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.election-admin/validate-voter-service-type-format)]
+                    v5.election-admin/validate-voter-service-type-format)
+        errors (all-errors errors-chan)]
     (testing "valid VoterService -> Type is OK"
-      (is (not (get-in out-ctx
-                       [:errors :election-administration
-                        (str/join "." ["VipObject" "0"
-                                       "ElectionAdministration" "0"
-                                       "Department" "0"
-                                       "VoterService" "0"
-                                       "Type" "0"])]))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :election-administration
+                             :identifier (str/join "." ["VipObject" "0"
+                                                        "ElectionAdministration" "0"
+                                                        "Department" "0"
+                                                        "VoterService" "0"
+                                                        "Type" "0"])}))
     (testing "invalid VoterService -> Type is an error"
-      (is (get-in out-ctx
-                  [:errors :election-administration
-                   (str/join "." ["VipObject" "0"
-                                  "ElectionAdministration" "1"
-                                  "Department" "0"
-                                  "VoterService" "0"
-                                  "Type" "0"])
-                   :format])))))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :election-administration
+                            :identifier (str/join "." ["VipObject" "0"
+                                                       "ElectionAdministration" "1"
+                                                       "Department" "0"
+                                                       "VoterService" "0"
+                                                       "Type" "0"])
+                            :error-type :format})))))

--- a/test/vip/data_processor/validation/v5/election_test.clj
+++ b/test/vip/data_processor/validation/v5/election_test.clj
@@ -3,58 +3,87 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-one-election-test
   (testing "more than one Election element is a fatal error"
-    (let [ctx {:input (xml-input "v5-more-than-one-election.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-more-than-one-election.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.election/validate-one-election)]
-      (is (get-in out-ctx [:fatal :election "VipObject.0.Election" :count]))))
+                      v5.election/validate-one-election)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :election
+                            :identifier "VipObject.0.Election"
+                            :error-type :count}))))
   (testing "one and only one Election element is OK"
-    (let [ctx {:input (xml-input "v5-one-election.xml")
-               :pipeline []}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-one-election.xml")
+               :pipeline []
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.election/validate-one-election)]
-      (assert-no-problems out-ctx []))))
+                      v5.election/validate-one-election)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))
 
 (deftest ^:postgres validate-date-test
   (testing "Date element missing is a fatal error"
-    (let [ctx {:input (xml-input "v5-one-election.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-one-election.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.election/validate-date)]
-      (is (get-in out-ctx [:fatal :election "VipObject.0.Election.0.Date"
-                           :missing]))))
+                      v5.election/validate-date)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :election
+                            :identifier "VipObject.0.Election.0.Date"
+                            :error-type :missing}))))
   (testing "Date element present is OK"
-    (let [ctx {:input (xml-input "v5-election-with-date.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-election-with-date.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.election/validate-date)]
-      (assert-no-problems out-ctx []))))
+                      v5.election/validate-date)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))
 
 (deftest ^:postgres validate-state-id-test
   (testing "StateId element missing is a fatal error"
-    (let [ctx {:input (xml-input "v5-one-election.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-one-election.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.election/validate-state-id)]
-      (is (get-in out-ctx [:fatal :election "VipObject.0.Election.0.StateId"
-                           :missing]))))
+                      v5.election/validate-state-id)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :election
+                            :identifier "VipObject.0.Election.0.StateId"
+                            :error-type :missing}))))
   (testing "StateId element present is OK"
-    (let [ctx {:input (xml-input "v5-election-with-state-id.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-election-with-state-id.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.election/validate-state-id)]
-      (assert-no-problems out-ctx []))))
+                      v5.election/validate-state-id)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))

--- a/test/vip/data_processor/validation/v5/election_test.clj
+++ b/test/vip/data_processor/validation/v5/election_test.clj
@@ -34,7 +34,7 @@
                       xml/load-xml-ltree
                       v5.election/validate-one-election)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))
 
 (deftest ^:postgres validate-date-test
   (testing "Date element missing is a fatal error"
@@ -60,7 +60,7 @@
                       xml/load-xml-ltree
                       v5.election/validate-date)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))
 
 (deftest ^:postgres validate-state-id-test
   (testing "StateId element missing is a fatal error"
@@ -86,4 +86,4 @@
                       xml/load-xml-ltree
                       v5.election/validate-state-id)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))

--- a/test/vip/data_processor/validation/v5/electoral_district_test.clj
+++ b/test/vip/data_processor/validation/v5/electoral_district_test.clj
@@ -3,47 +3,60 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
   (testing "missing Name is an error"
-    (let [ctx {:input (xml-input "v5-electoral-districts.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-electoral-districts.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.electoral-district/validate-no-missing-names)]
-      (is (get-in out-ctx [:errors :electoral-district
-                           "VipObject.0.ElectoralDistrict.4.Name" :missing]))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.0.Name"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.1.Name"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.2.Name"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.3.Name"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.5.Name"]))))))
+                      v5.electoral-district/validate-no-missing-names)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :electoral-district
+                            :identifier "VipObject.0.ElectoralDistrict.4.Name"
+                            :error-type :missing}))
+      (are [path]
+          (assert-no-problems-2 errors
+                                {:severity :errors
+                                 :scope :electoral-district
+                                 :identifier path})
+        "VipObject.0.ElectoralDistrict.0.Name"
+        "VipObject.0.ElectoralDistrict.1.Name"
+        "VipObject.0.ElectoralDistrict.2.Name"
+        "VipObject.0.ElectoralDistrict.3.Name"
+        "VipObject.0.ElectoralDistrict.5.Name"))))
 
 (deftest ^:postgres validate-no-missing-types-test
   (testing "missing Type is an error"
-    (let [ctx {:input (xml-input "v5-electoral-districts.xml")}
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-electoral-districts.xml")
+               :errors-chan errors-chan}
           out-ctx (-> ctx
                       psql/start-run
                       xml/load-xml-ltree
-                      v5.electoral-district/validate-no-missing-types)]
-      (is (get-in out-ctx [:errors :electoral-district
-                           "VipObject.0.ElectoralDistrict.5.Type" :missing]))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.0.Type"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.1.Type"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.2.Type"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.3.Type"])))
-      (is (not (get-in out-ctx [:errors :electoral-district
-                                "VipObject.0.ElectoralDistrict.4.Type"]))))))
+                      v5.electoral-district/validate-no-missing-types)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :electoral-district
+                            :identifier "VipObject.0.ElectoralDistrict.5.Type"
+                            :error-type :missing}))
+      (are [path]
+          (assert-no-problems-2 errors
+                                {:severity :errors
+                                 :scope :electoral-district
+                                 :identifier path})
+        "VipObject.0.ElectoralDistrict.0.Type"
+        "VipObject.0.ElectoralDistrict.1.Type"
+        "VipObject.0.ElectoralDistrict.2.Type"
+        "VipObject.0.ElectoralDistrict.3.Type"
+        "VipObject.0.ElectoralDistrict.4.Type"))))

--- a/test/vip/data_processor/validation/v5/electoral_district_test.clj
+++ b/test/vip/data_processor/validation/v5/electoral_district_test.clj
@@ -25,10 +25,10 @@
                             :identifier "VipObject.0.ElectoralDistrict.4.Name"
                             :error-type :missing}))
       (are [path]
-          (assert-no-problems-2 errors
-                                {:severity :errors
-                                 :scope :electoral-district
-                                 :identifier path})
+          (assert-no-problems errors
+                              {:severity :errors
+                               :scope :electoral-district
+                               :identifier path})
         "VipObject.0.ElectoralDistrict.0.Name"
         "VipObject.0.ElectoralDistrict.1.Name"
         "VipObject.0.ElectoralDistrict.2.Name"
@@ -51,10 +51,10 @@
                             :identifier "VipObject.0.ElectoralDistrict.5.Type"
                             :error-type :missing}))
       (are [path]
-          (assert-no-problems-2 errors
-                                {:severity :errors
-                                 :scope :electoral-district
-                                 :identifier path})
+          (assert-no-problems errors
+                              {:severity :errors
+                               :scope :electoral-district
+                               :identifier path})
         "VipObject.0.ElectoralDistrict.0.Type"
         "VipObject.0.ElectoralDistrict.1.Type"
         "VipObject.0.ElectoralDistrict.2.Type"

--- a/test/vip/data_processor/validation/v5/external_identifiers_test.clj
+++ b/test/vip/data_processor/validation/v5/external_identifiers_test.clj
@@ -4,39 +4,54 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.xml :as xml]
             [vip.data-processor.test-helpers :refer :all]
-            [vip.data-processor.validation.v5.external-identifiers :as external-identifiers]))
+            [vip.data-processor.validation.v5.external-identifiers :as external-identifiers]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-types-test
-  (let [ctx {:input (xml-input "v5-external-identifiers.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-external-identifiers.xml")
              :pipeline [psql/start-run
                         xml/load-xml-ltree
-                        external-identifiers/validate-no-missing-types]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        external-identifiers/validate-no-missing-types]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing Types are flagged"
-      (is (get-in out-ctx
-                  [:errors
-                   :external-identifiers
-                   "VipObject.0.Party.1.ExternalIdentifiers.1.ExternalIdentifier.0.Type"
-                   :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :external-identifiers
+                            :identifier "VipObject.0.Party.1.ExternalIdentifiers.1.ExternalIdentifier.0.Type"
+                            :error-type :missing})))
     (testing "existing Types are not flagged"
-      (assert-no-problems out-ctx [:external-identifiers "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Type"])
-      (assert-no-problems out-ctx [:external-identifiers "VipObject.0.Party.2.ExternalIdentifiers.1.ExternalIdentifier.0.Type"]))))
+      (assert-no-problems-2 errors
+                            {:scope :external-identifiers
+                             :identifier "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Type"})
+      (assert-no-problems-2 errors
+                            {:scope :external-identifiers
+                             :identifier "VipObject.0.Party.2.ExternalIdentifiers.1.ExternalIdentifier.0.Type"}))))
 
 (deftest ^:postgres validate-no-missing-values-test
-  (let [ctx {:input (xml-input "v5-external-identifiers.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-external-identifiers.xml")
              :pipeline [psql/start-run
                         xml/load-xml-ltree
-                        external-identifiers/validate-no-missing-values]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        external-identifiers/validate-no-missing-values]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing Values are flagged"
-      (is (get-in out-ctx
-                  [:errors
-                   :external-identifiers
-                   "VipObject.0.Party.2.ExternalIdentifiers.1.ExternalIdentifier.0.Value"
-                   :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :external-identifiers
+                            :identifier "VipObject.0.Party.2.ExternalIdentifiers.1.ExternalIdentifier.0.Value"
+                            :error-type :missing})))
     (testing "existing Values are not flagged"
-      (assert-no-problems out-ctx [:external-identifiers "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Value"])
-      (assert-no-problems out-ctx [:external-identifiers "VipObject.0.Party.1.ExternalIdentifiers.1.ExternalIdentifier.0.Value"]))))
+      (assert-no-problems-2 errors
+                            {:scope :external-identifiers
+                             :identifier "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Value"})
+      (assert-no-problems-2 errors
+                            {:scope :external-identifiers
+                             :identifier "VipObject.0.Party.1.ExternalIdentifiers.1.ExternalIdentifier.0.Value"}))))

--- a/test/vip/data_processor/validation/v5/external_identifiers_test.clj
+++ b/test/vip/data_processor/validation/v5/external_identifiers_test.clj
@@ -26,12 +26,12 @@
                             :identifier "VipObject.0.Party.1.ExternalIdentifiers.1.ExternalIdentifier.0.Type"
                             :error-type :missing})))
     (testing "existing Types are not flagged"
-      (assert-no-problems-2 errors
-                            {:scope :external-identifiers
-                             :identifier "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Type"})
-      (assert-no-problems-2 errors
-                            {:scope :external-identifiers
-                             :identifier "VipObject.0.Party.2.ExternalIdentifiers.1.ExternalIdentifier.0.Type"}))))
+      (assert-no-problems errors
+                          {:scope :external-identifiers
+                           :identifier "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Type"})
+      (assert-no-problems errors
+                          {:scope :external-identifiers
+                           :identifier "VipObject.0.Party.2.ExternalIdentifiers.1.ExternalIdentifier.0.Type"}))))
 
 (deftest ^:postgres validate-no-missing-values-test
   (let [errors-chan (a/chan 100)
@@ -49,9 +49,9 @@
                             :identifier "VipObject.0.Party.2.ExternalIdentifiers.1.ExternalIdentifier.0.Value"
                             :error-type :missing})))
     (testing "existing Values are not flagged"
-      (assert-no-problems-2 errors
-                            {:scope :external-identifiers
-                             :identifier "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Value"})
-      (assert-no-problems-2 errors
-                            {:scope :external-identifiers
-                             :identifier "VipObject.0.Party.1.ExternalIdentifiers.1.ExternalIdentifier.0.Value"}))))
+      (assert-no-problems errors
+                          {:scope :external-identifiers
+                           :identifier "VipObject.0.Party.0.ExternalIdentifiers.1.ExternalIdentifier.0.Value"})
+      (assert-no-problems errors
+                          {:scope :external-identifiers
+                           :identifier "VipObject.0.Party.1.ExternalIdentifiers.1.ExternalIdentifier.0.Value"}))))

--- a/test/vip/data_processor/validation/v5/hours_open_test.clj
+++ b/test/vip/data_processor/validation/v5/hours_open_test.clj
@@ -19,39 +19,39 @@
                     v5.hours-open/validate-times)
         errors (all-errors errors-chan)]
     (testing "StartTime and EndTime valid produces no errors"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :hours-open
-                             :identifier "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.StartTime.0"})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :hours-open
-                             :identifier "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.EndTime.1"}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :hours-open
+                           :identifier "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.StartTime.0"})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :hours-open
+                           :identifier "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.EndTime.1"}))
     (testing "StartTime hours out of range produces one error"
       (is (contains-error? errors
                            {:severity :errors
                             :scope :hours-open
                             :identifier "VipObject.0.HoursOpen.1.Schedule.0.Hours.0.StartTime.0"
                             :error-type :format}))
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :hours-open
-                             :identifier "VipObject.0.HoursOpen.1.Schedule.0.Hours.0.EndTime.1"}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :hours-open
+                           :identifier "VipObject.0.HoursOpen.1.Schedule.0.Hours.0.EndTime.1"}))
     (testing "StartTime missing time zone produces one error"
       (is (contains-error? errors
                            {:severity :errors
                             :scope :hours-open
                             :identifier "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.StartTime.0"
                             :error-type :format}))
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :hours-open
-                             :identifier "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.EndTime.1"}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :hours-open
+                           :identifier "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.EndTime.1"}))
     (testing "EndTime invalid produces one error"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :hours-open
-                             :identifier "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.StartTime.0"})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :hours-open
+                           :identifier "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.StartTime.0"})
       (is (contains-error? errors
                            {:severity :errors
                             :scope :hours-open

--- a/test/vip/data_processor/validation/v5/hours_open_test.clj
+++ b/test/vip/data_processor/validation/v5/hours_open_test.clj
@@ -3,44 +3,68 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-times-test
-  (let [ctx {:input (xml-input "v5-hours-open.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-hours-open.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.hours-open/validate-times)]
+                    v5.hours-open/validate-times)
+        errors (all-errors errors-chan)]
     (testing "StartTime and EndTime valid produces no errors"
-      (is (not (get-in out-ctx [:errors :hours-open
-                                "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.StartTime.0"])))
-      (is (not (get-in out-ctx [:errors :hours-open
-                                "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.EndTime.1"]))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :hours-open
+                             :identifier "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.StartTime.0"})
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :hours-open
+                             :identifier "VipObject.0.HoursOpen.0.Schedule.0.Hours.0.EndTime.1"}))
     (testing "StartTime hours out of range produces one error"
-      (is (get-in out-ctx [:errors :hours-open
-                           "VipObject.0.HoursOpen.1.Schedule.0.Hours.0.StartTime.0"
-                           :format]))
-      (is (not (get-in out-ctx [:errors :hours-open
-                                "VipObject.0.HoursOpen.1.Schedule.0.Hours.0.EndTime.1"]))))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :hours-open
+                            :identifier "VipObject.0.HoursOpen.1.Schedule.0.Hours.0.StartTime.0"
+                            :error-type :format}))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :hours-open
+                             :identifier "VipObject.0.HoursOpen.1.Schedule.0.Hours.0.EndTime.1"}))
     (testing "StartTime missing time zone produces one error"
-      (is (get-in out-ctx [:errors :hours-open
-                           "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.StartTime.0"
-                           :format]))
-      (is (not (get-in out-ctx [:errors :hours-open
-                                "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.EndTime.1"]))))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :hours-open
+                            :identifier "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.StartTime.0"
+                            :error-type :format}))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :hours-open
+                             :identifier "VipObject.0.HoursOpen.2.Schedule.0.Hours.0.EndTime.1"}))
     (testing "EndTime invalid produces one error"
-      (is (not (get-in out-ctx [:errors :hours-open
-                                "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.StartTime.0"])))
-      (is (get-in out-ctx [:errors :hours-open
-                           "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.EndTime.1"
-                           :format])))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :hours-open
+                             :identifier "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.StartTime.0"})
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :hours-open
+                            :identifier "VipObject.0.HoursOpen.3.Schedule.0.Hours.0.EndTime.1"
+                            :error-type :format})))
     (testing "StartTime and EndTime invalid produces two errors"
-      (is (get-in out-ctx [:errors :hours-open
-                           "VipObject.0.HoursOpen.4.Schedule.0.Hours.0.StartTime.0"
-                           :format]))
-      (is (get-in out-ctx [:errors :hours-open
-                           "VipObject.0.HoursOpen.4.Schedule.0.Hours.0.EndTime.1"
-                           :format])))))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :hours-open
+                            :identifier "VipObject.0.HoursOpen.4.Schedule.0.Hours.0.StartTime.0"
+                            :error-type :format}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :hours-open
+                            :identifier "VipObject.0.HoursOpen.4.Schedule.0.Hours.0.EndTime.1"
+                            :error-type :format})))))

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -4,71 +4,129 @@
              [vip.data-processor.db.postgres :as psql]
              [vip.data-processor.validation.xml :refer :all]
              [vip.data-processor.test-helpers :refer :all]
-             [vip.data-processor.validation.v5.id :as v5.id]))
+             [vip.data-processor.validation.v5.id :as v5.id]
+             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres id-uniqueness-test
-  (let [ctx {:input (xml-input "v5-duplicate-ids.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-duplicate-ids.xml")
              :pipeline [psql/start-run
                         load-xml-ltree
-                        v5.id/validate-unique-ids]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        v5.id/validate-unique-ids]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
 
     (testing "duplicate IDs are flagged"
-      (is (= (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.0.id" :duplicates])
-             ["super-duper"]))
-      (is (= (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.1.id" :duplicates])
-             ["super-duper"])))
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :id
+                            :identifier "VipObject.0.ElectionAuthority.0.id"
+                            :error-type :duplicates
+                            :error-value "super-duper"}))
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :id
+                            :identifier "VipObject.0.ElectionAuthority.1.id"
+                            :error-type :duplicates
+                            :error-value "super-duper"})))
 
     (testing "unique IDs are not flagged"
-      (is (not (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.2.id" :duplicates])))
-      (is (not (get-in out-ctx [:fatal :id "VipObject.0.ElectionAuthority.3.id" :duplicates]))))))
+      (assert-no-problems errors
+                          {:severity :fatal
+                           :scope :id
+                           :identifier "VipObject.0.ElectionAuthority.2.id"
+                           :error-type :duplicates})
+      (assert-no-problems errors
+                          {:severity :fatal
+                           :scope :id
+                           :identifier "VipObject.0.ElectionAuthority.3.id"
+                           :error-type :duplicates}))))
 
 (deftest ^:postgres validate-no-missing-ids-test
-  (let [ctx {:input (xml-input "v5-missing-ids.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-missing-ids.xml")
              :pipeline [psql/start-run
                         load-xml-ltree
-                        v5.id/validate-no-missing-ids]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        v5.id/validate-no-missing-ids]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing IDs are flagged"
-      (is (get-in out-ctx [:fatal :id "VipObject.0.Person.0.id" :missing]))
-      (is (get-in out-ctx [:fatal :id "VipObject.0.Person.2.id" :missing])))
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :id
+                            :identifier "VipObject.0.Person.0.id"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :id
+                            :identifier "VipObject.0.Person.2.id"
+                            :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (is (not (get-in out-ctx [:fatal :id "VipObject.0.Person.1.id" :missing]))))))
+      (assert-no-problems errors
+                          {:severity :fatal
+                           :scope :id
+                           :identifier "VipObject.0.Person.1.id"
+                           :error-type :missing}))))
 
 (deftest ^:postgres validate-idrefs-refer-test
-  (let [ctx {:input (xml-input "v5-idrefs.xml")
-             :spec-version "5.1"
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-idrefs.xml")
+             :spec-version (atom "5.1")
              :pipeline [psql/start-run
                         load-xml-ltree
                         v5.id/validate-idref-references
-                        v5.id/validate-idrefs-references]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        v5.id/validate-idrefs-references]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
 
     (testing "IDREF elements that don't have referents are flagged"
-      (is (get-in out-ctx [:errors :id "VipObject.0.Person.1.PartyId.1" :no-referent]))
-      (is (get-in out-ctx [:errors :id "VipObject.0.Person.3.PartyId.1" :no-referent])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :id
+                            :identifier "VipObject.0.Person.1.PartyId.1"
+                            :error-type :no-referent}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :id
+                            :identifier "VipObject.0.Person.3.PartyId.1"
+                            :error-type :no-referent})))
 
     (testing "IDREF elements that point to something are good"
-      (assert-no-problems out-ctx [:errors :id "VipObject.0.Person.0.PartyId.1"])
-      (assert-no-problems out-ctx [:errors :id "VipObject.0.Person.2.PartyId.1"]))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :id
+                             :identifier "VipObject.0.Person.0.PartyId.1"})
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :id
+                             :identifier "VipObject.0.Person.2.PartyId.1"}))))
 
 (deftest ^:postgres validate-idrefs-plural-refer-test
-  (let [ctx {:input (xml-input "v5-idrefs.xml")
-             :spec-version "5.1"
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-idrefs.xml")
+             :spec-version (atom "5.1")
              :pipeline [psql/start-run
                         load-xml-ltree
-                        v5.id/validate-idrefs-references]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        v5.id/validate-idrefs-references]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
 
     (testing "IDREFS elements that don't have any referents are flagged"
-      (is (get-in
-           out-ctx
-           [:errors :id "VipObject.0.Locality.8.PollingLocationIds.2" :no-referent])))
+      (is (contains-error? errors
+           {:severity :errors
+            :scope :id
+            :identifier "VipObject.0.Locality.8.PollingLocationIds.2"
+            :error-type :no-referent})))
 
     (testing "IDREFS elements that point to some things are good"
-      (assert-no-problems
-       out-ctx
-       [:errors :id "VipObject.0.Locality.11.PollingLocationIds.3"]))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :id
+                             :identifier "VipObject.0.Locality.11.PollingLocationIds.3"}))))

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -35,16 +35,16 @@
                             :error-value "super-duper"})))
 
     (testing "unique IDs are not flagged"
-      (assert-no-problems-2 errors
-                            {:severity :fatal
-                             :scope :id
-                             :identifier "VipObject.0.ElectionAuthority.2.id"
-                             :error-type :duplicates})
-      (assert-no-problems-2 errors
-                            {:severity :fatal
-                             :scope :id
-                             :identifier "VipObject.0.ElectionAuthority.3.id"
-                             :error-type :duplicates}))))
+      (assert-no-problems errors
+                          {:severity :fatal
+                           :scope :id
+                           :identifier "VipObject.0.ElectionAuthority.2.id"
+                           :error-type :duplicates})
+      (assert-no-problems errors
+                          {:severity :fatal
+                           :scope :id
+                           :identifier "VipObject.0.ElectionAuthority.3.id"
+                           :error-type :duplicates}))))
 
 (deftest ^:postgres validate-no-missing-ids-test
   (let [errors-chan (a/chan 100)
@@ -67,11 +67,11 @@
                             :identifier "VipObject.0.Person.2.id"
                             :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems-2 errors
-                            {:severity :fatal
-                             :scope :id
-                             :identifier "VipObject.0.Person.1.id"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :fatal
+                           :scope :id
+                           :identifier "VipObject.0.Person.1.id"
+                           :error-type :missing}))))
 
 (deftest ^:postgres validate-idrefs-refer-test
   (let [errors-chan (a/chan 100)
@@ -98,14 +98,14 @@
                             :error-type :no-referent})))
 
     (testing "IDREF elements that point to something are good"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :id
-                             :identifier "VipObject.0.Person.0.PartyId.1"})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :id
-                             :identifier "VipObject.0.Person.2.PartyId.1"}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :id
+                           :identifier "VipObject.0.Person.0.PartyId.1"})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :id
+                           :identifier "VipObject.0.Person.2.PartyId.1"}))))
 
 (deftest ^:postgres validate-idrefs-plural-refer-test
   (let [errors-chan (a/chan 100)
@@ -126,7 +126,7 @@
             :error-type :no-referent})))
 
     (testing "IDREFS elements that point to some things are good"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :id
-                             :identifier "VipObject.0.Locality.11.PollingLocationIds.3"}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :id
+                           :identifier "VipObject.0.Locality.11.PollingLocationIds.3"}))))

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -35,16 +35,16 @@
                             :error-value "super-duper"})))
 
     (testing "unique IDs are not flagged"
-      (assert-no-problems errors
-                          {:severity :fatal
-                           :scope :id
-                           :identifier "VipObject.0.ElectionAuthority.2.id"
-                           :error-type :duplicates})
-      (assert-no-problems errors
-                          {:severity :fatal
-                           :scope :id
-                           :identifier "VipObject.0.ElectionAuthority.3.id"
-                           :error-type :duplicates}))))
+      (assert-no-problems-2 errors
+                            {:severity :fatal
+                             :scope :id
+                             :identifier "VipObject.0.ElectionAuthority.2.id"
+                             :error-type :duplicates})
+      (assert-no-problems-2 errors
+                            {:severity :fatal
+                             :scope :id
+                             :identifier "VipObject.0.ElectionAuthority.3.id"
+                             :error-type :duplicates}))))
 
 (deftest ^:postgres validate-no-missing-ids-test
   (let [errors-chan (a/chan 100)
@@ -67,11 +67,11 @@
                             :identifier "VipObject.0.Person.2.id"
                             :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems errors
-                          {:severity :fatal
-                           :scope :id
-                           :identifier "VipObject.0.Person.1.id"
-                           :error-type :missing}))))
+      (assert-no-problems-2 errors
+                            {:severity :fatal
+                             :scope :id
+                             :identifier "VipObject.0.Person.1.id"
+                             :error-type :missing}))))
 
 (deftest ^:postgres validate-idrefs-refer-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/internationalized_text_test.clj
+++ b/test/vip/data_processor/validation/v5/internationalized_text_test.clj
@@ -20,11 +20,11 @@
         errors (all-errors errors-chan)]
     (testing "Text present is OK"
       (are [element-path]
-          (assert-no-problems-2 errors
-                                {:severity :errors
-                                 :scope :internationalized-text
-                                 :identifier element-path
-                                 :error-type :missing})
+          (assert-no-problems errors
+                              {:severity :errors
+                               :scope :internationalized-text
+                               :identifier element-path
+                               :error-type :missing})
         "VipObject.0.BallotMeasureContest.0.BallotTitle.0.Text"
         "VipObject.0.BallotMeasureContest.0.BallotSubTitle.1.Text"
         "VipObject.0.BallotMeasureContest.0.ConStatement.2.Text"

--- a/test/vip/data_processor/validation/v5/locality_test.clj
+++ b/test/vip/data_processor/validation/v5/locality_test.clj
@@ -25,11 +25,11 @@
                             :identifier "VipObject.0.Locality.0.Name"
                             :error-type :missing})))
     (testing "name present is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :locality
-                             :identifier "VipObject.0.Locality.1.Name"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :locality
+                           :identifier "VipObject.0.Locality.1.Name"
+                           :error-type :missing}))))
 
 (deftest ^:postgres validate-no-missing-state-ids-test
   (let [errors-chan (a/chan 100)
@@ -47,8 +47,8 @@
                             :identifier "VipObject.0.Locality.0.StateId"
                             :error-type :missing})))
     (testing "state-id present is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :locality
-                             :identifier "VipObject.0.Locality.1.StateId"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :locality
+                           :identifier "VipObject.0.Locality.1.StateId"
+                           :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/office_test.clj
+++ b/test/vip/data_processor/validation/v5/office_test.clj
@@ -25,11 +25,11 @@
                             :identifier "VipObject.0.Office.0.Name"
                             :error-type :missing})))
     (testing "name present is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :office
-                             :identifier "VipObject.0.Office.1.Name"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :office
+                           :identifier "VipObject.0.Office.1.Name"
+                           :error-type :missing}))))
 
 (deftest ^:postgres validate-no-missing-term-types-test
   (let [errors-chan (a/chan 100)
@@ -41,22 +41,22 @@
                     v5.office/validate-no-missing-term-types)
         errors (all-errors errors-chan)]
     (testing "term missing is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :office
-                             :identifier "VipObject.0.Office.0.Term"
-                             :error-type :missing})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :office
-                             :identifier "VipObject.0.Office.1.Term"
-                             :error-type :missing}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :office
+                           :identifier "VipObject.0.Office.0.Term"
+                           :error-type :missing})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :office
+                           :identifier "VipObject.0.Office.1.Term"
+                           :error-type :missing}))
     (testing "term present w/ type is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :office
-                             :identifier "VipObject.0.Office.2.Term.0.Type"
-                             :error-type :missing}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :office
+                           :identifier "VipObject.0.Office.2.Term.0.Type"
+                           :error-type :missing}))
     (testing "term present w/o type is an error"
       (is (contains-error? errors
                            {:severity :errors
@@ -74,11 +74,11 @@
                     v5.office/validate-term-types)
         errors (all-errors errors-chan)]
     (testing "valid term type is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :term
-                             :identifier "VipObject.0.Office.2.Term.1.Type.0"
-                             :error-type :format}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :term
+                           :identifier "VipObject.0.Office.2.Term.1.Type.0"
+                           :error-type :format}))
     (testing "invalid term type is an error"
       (is (contains-error? errors
                            {:severity :errors

--- a/test/vip/data_processor/validation/v5/ordered_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ordered_contest_test.clj
@@ -3,21 +3,30 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-contest-ids-test
-  (let [ctx {:input (xml-input "v5-ordered-contests.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-ordered-contests.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.ordered-contest/validate-no-missing-contest-ids)]
+                    v5.ordered-contest/validate-no-missing-contest-ids)
+        errors (all-errors errors-chan)]
     (testing "contest-id missing is an error"
-      (is (get-in out-ctx [:errors :ordered-contest
-                           "VipObject.0.OrderedContest.0.ContestId" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :ordered-contest
+                            :identifier "VipObject.0.OrderedContest.0.ContestId"
+                            :error-type :missing})))
     (testing "contest-id present is OK"
-      (is (not (get-in out-ctx [:errors :ordered-contest
-                                "VipObject.0.OrderedContest.1.ContestId"
-                                :missing]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :ordered-contest
+                             :identifier "VipObject.0.OrderedContest.1.ContestId"
+                             :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/ordered_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ordered_contest_test.clj
@@ -25,8 +25,8 @@
                             :identifier "VipObject.0.OrderedContest.0.ContestId"
                             :error-type :missing})))
     (testing "contest-id present is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :ordered-contest
-                             :identifier "VipObject.0.OrderedContest.1.ContestId"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :ordered-contest
+                           :identifier "VipObject.0.OrderedContest.1.ContestId"
+                           :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/party_selection_test.clj
+++ b/test/vip/data_processor/validation/v5/party_selection_test.clj
@@ -25,8 +25,8 @@
                             :identifier "VipObject.0.PartySelection.0.PartyIds"
                             :error-type :missing})))
     (testing "party-ids present is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :party-selection
-                             :identifier "VipObject.0.PartySelection.1.PartyIds"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :party-selection
+                           :identifier "VipObject.0.PartySelection.1.PartyIds"
+                           :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/party_test.clj
+++ b/test/vip/data_processor/validation/v5/party_test.clj
@@ -3,20 +3,30 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-colors-test
-  (let [ctx {:input (xml-input "v5-parties.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-parties.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.party/validate-colors)]
+                    v5.party/validate-colors)
+        errors (all-errors errors-chan)]
     (testing "color invalid is an error"
-      (is (get-in out-ctx [:errors :party "VipObject.0.Party.0.Color.0"
-                           :format])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :party
+                            :identifier "VipObject.0.Party.0.Color.0"
+                            :error-type :format})))
     (testing "color valid is OK"
-      (is (not (get-in out-ctx [:errors :party "VipObject.0.Party.1.Color.0"
-                                :format]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :party
+                             :identifier "VipObject.0.Party.1.Color.0"
+                             :error-type :format}))))

--- a/test/vip/data_processor/validation/v5/party_test.clj
+++ b/test/vip/data_processor/validation/v5/party_test.clj
@@ -25,8 +25,8 @@
                             :identifier "VipObject.0.Party.0.Color.0"
                             :error-type :format})))
     (testing "color valid is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :party
-                             :identifier "VipObject.0.Party.1.Color.0"
-                             :error-type :format}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :party
+                           :identifier "VipObject.0.Party.1.Color.0"
+                           :error-type :format}))))

--- a/test/vip/data_processor/validation/v5/polling_location_test.clj
+++ b/test/vip/data_processor/validation/v5/polling_location_test.clj
@@ -25,11 +25,11 @@
                             :identifier "VipObject.0.PollingLocation.0.AddressLine"
                             :error-type :missing})))
     (testing "address-line present is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :polling-location
-                             :identifier "VipObject.0.PollingLocation.1.AddressLine"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :polling-location
+                           :identifier "VipObject.0.PollingLocation.1.AddressLine"
+                           :error-type :missing}))))
 
 (deftest ^:postgres validate-latitude-longitude-test
   (let [errors-chan (a/chan 100)
@@ -44,27 +44,27 @@
                     v5.polling-location/validate-longitude)
         errors (all-errors errors-chan)]
     (testing "lat-lng missing is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :lat-lng
-                             :identifier "VipObject.0.PollingLocation.0.LatLng"
-                             :error-type :missing})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :lat-lng
-                             :identifier "VipObject.0.PollingLocation.1.LatLng"
-                             :error-type :missing}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :lat-lng
+                           :identifier "VipObject.0.PollingLocation.0.LatLng"
+                           :error-type :missing})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :lat-lng
+                           :identifier "VipObject.0.PollingLocation.1.LatLng"
+                           :error-type :missing}))
     (testing "valid lat-lng is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :lat-lng
-                             :identifier "VipObject.0.PollingLocation.2.LatLng.1.Latitude.0"
-                             :error-type :format})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :lat-lng
-                             :identifier "VipObject.0.PollingLocation.2.LatLng.1.Latitude.1"
-                             :error-type :format}))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :lat-lng
+                           :identifier "VipObject.0.PollingLocation.2.LatLng.1.Latitude.0"
+                           :error-type :format})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :lat-lng
+                           :identifier "VipObject.0.PollingLocation.2.LatLng.1.Latitude.1"
+                           :error-type :format}))
     (testing "missing latitude is an error"
       (is (contains-error? errors
                            {:severity :errors

--- a/test/vip/data_processor/validation/v5/polling_location_test.clj
+++ b/test/vip/data_processor/validation/v5/polling_location_test.clj
@@ -3,61 +3,88 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-address-lines-test
-  (let [ctx {:input (xml-input "v5-polling-locations.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-polling-locations.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.polling-location/validate-no-missing-address-lines)]
+                    v5.polling-location/validate-no-missing-address-lines)
+        errors (all-errors errors-chan)]
     (testing "address-line missing is an error"
-      (is (get-in out-ctx [:errors :polling-location
-                           "VipObject.0.PollingLocation.0.AddressLine"
-                           :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :polling-location
+                            :identifier "VipObject.0.PollingLocation.0.AddressLine"
+                            :error-type :missing})))
     (testing "address-line present is OK"
-      (is (not (get-in out-ctx [:errors :polling-location
-                                "VipObject.0.PollingLocation.1.AddressLine"
-                                :missing]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :polling-location
+                             :identifier "VipObject.0.PollingLocation.1.AddressLine"
+                             :error-type :missing}))))
 
 (deftest ^:postgres validate-latitude-longitude-test
-  (let [ctx {:input (xml-input "v5-polling-locations.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-polling-locations.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
                     v5.polling-location/validate-no-missing-latitudes
                     v5.polling-location/validate-no-missing-longitudes
                     v5.polling-location/validate-latitude
-                    v5.polling-location/validate-longitude)]
+                    v5.polling-location/validate-longitude)
+        errors (all-errors errors-chan)]
     (testing "lat-lng missing is OK"
-      (is (not (get-in out-ctx [:errors :lat-lng
-                                "VipObject.0.PollingLocation.0.LatLng"
-                                :missing])))
-      (is (not (get-in out-ctx [:errors :lat-lng
-                                "VipObject.0.PollingLocation.1.LatLng"
-                                :missing]))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :lat-lng
+                             :identifier "VipObject.0.PollingLocation.0.LatLng"
+                             :error-type :missing})
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :lat-lng
+                             :identifier "VipObject.0.PollingLocation.1.LatLng"
+                             :error-type :missing}))
     (testing "valid lat-lng is OK"
-      (is (not (get-in out-ctx [:errors :lat-lng
-                                "VipObject.0.PollingLocation.2.LatLng.1.Latitude.0"
-                                :format])))
-      (is (not (get-in out-ctx [:errors :lat-lng
-                                "VipObject.0.PollingLocation.2.LatLng.1.Longitude.1"
-                                :format]))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :lat-lng
+                             :identifier "VipObject.0.PollingLocation.2.LatLng.1.Latitude.0"
+                             :error-type :format})
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :lat-lng
+                             :identifier "VipObject.0.PollingLocation.2.LatLng.1.Latitude.1"
+                             :error-type :format}))
     (testing "missing latitude is an error"
-      (is (get-in out-ctx [:errors :lat-lng
-                           "VipObject.0.PollingLocation.3.LatLng.1.Latitude"
-                           :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :lat-lng
+                            :identifier "VipObject.0.PollingLocation.3.LatLng.1.Latitude"
+                            :error-type :missing})))
     (testing "missing longitude is an error"
-      (is (get-in out-ctx [:errors :lat-lng
-                           "VipObject.0.PollingLocation.4.LatLng.1.Longitude"
-                           :missing]))
-      (is (get-in out-ctx [:errors :lat-lng
-                           "VipObject.0.PollingLocation.5.LatLng.1.Longitude"
-                           :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :lat-lng
+                            :identifier "VipObject.0.PollingLocation.4.LatLng.1.Longitude"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :lat-lng
+                            :identifier "VipObject.0.PollingLocation.5.LatLng.1.Longitude"
+                            :error-type :missing})))
     (testing "invalid latitude is an error"
-      (is (get-in out-ctx [:errors :lat-lng
-                           "VipObject.0.PollingLocation.5.LatLng.1.Latitude.0"
-                           :format])))))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :lat-lng
+                            :identifier "VipObject.0.PollingLocation.5.LatLng.1.Latitude.0"
+                            :error-type :format})))))

--- a/test/vip/data_processor/validation/v5/precinct_test.clj
+++ b/test/vip/data_processor/validation/v5/precinct_test.clj
@@ -4,33 +4,72 @@
              [vip.data-processor.db.postgres :as psql]
              [vip.data-processor.validation.xml :as xml]
              [vip.data-processor.test-helpers :refer :all]
-             [vip.data-processor.validation.v5.precinct :as precinct]))
+             [vip.data-processor.validation.v5.precinct :as precinct]
+             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
-  (let [ctx {:input (xml-input "v5-precincts.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-precincts.xml")
              :pipeline [psql/start-run
                         xml/load-xml-ltree
-                        precinct/validate-no-missing-names]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        precinct/validate-no-missing-names]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing Names are flagged"
-      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.0.Name" :missing]))
-      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.1.Name" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :precincts
+                            :identifier "VipObject.0.Precinct.0.Name"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :precincts
+                            :identifier "VipObject.0.Precinct.1.Name"
+                            :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.2.Name" :missing])))
-      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.3.Name" :missing]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :precincts
+                             :identifier "VipObject.0.Precinct.2.Name"
+                             :error-type :missing})
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :precincts
+                             :identifier "VipObject.0.Precinct.3.Name"
+                             :error-type :missing}))))
 
 (deftest ^:postgres validate-no-missing-locality-ids-test
-  (let [ctx {:input (xml-input "v5-precincts.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-precincts.xml")
              :pipeline [psql/start-run
                         xml/load-xml-ltree
-                        precinct/validate-no-missing-locality-ids]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        precinct/validate-no-missing-locality-ids]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing LocalityIds are flagged"
-      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.0.LocalityId" :missing]))
-      (is (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.2.LocalityId" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :precincts
+                            :identifier "VipObject.0.Precinct.0.LocalityId"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :precincts
+                            :identifier "VipObject.0.Precinct.2.LocalityId"
+                            :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.1.LocalityId" :missing])))
-      (is (not (get-in out-ctx [:errors :precincts "VipObject.0.Precinct.3.LocalityId" :missing]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :precincts
+                             :identifier "VipObject.0.Precinct.1.LocalityId"
+                             :error-type :missing})
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :precincts
+                             :identifier "VipObject.0.Precinct.3.LocalityId"
+                             :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/precinct_test.clj
+++ b/test/vip/data_processor/validation/v5/precinct_test.clj
@@ -31,16 +31,16 @@
                             :identifier "VipObject.0.Precinct.1.Name"
                             :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :precincts
-                             :identifier "VipObject.0.Precinct.2.Name"
-                             :error-type :missing})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :precincts
-                             :identifier "VipObject.0.Precinct.3.Name"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :precincts
+                           :identifier "VipObject.0.Precinct.2.Name"
+                           :error-type :missing})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :precincts
+                           :identifier "VipObject.0.Precinct.3.Name"
+                           :error-type :missing}))))
 
 (deftest ^:postgres validate-no-missing-locality-ids-test
   (let [errors-chan (a/chan 100)
@@ -63,13 +63,13 @@
                             :identifier "VipObject.0.Precinct.2.LocalityId"
                             :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :precincts
-                             :identifier "VipObject.0.Precinct.1.LocalityId"
-                             :error-type :missing})
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :precincts
-                             :identifier "VipObject.0.Precinct.3.LocalityId"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :precincts
+                           :identifier "VipObject.0.Precinct.1.LocalityId"
+                           :error-type :missing})
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :precincts
+                           :identifier "VipObject.0.Precinct.3.LocalityId"
+                           :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/retention_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/retention_contest_test.clj
@@ -26,8 +26,8 @@
                             :identifier "VipObject.0.RetentionContest.0.CandidateId"
                             :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                             :scope :retention-contests
-                             :identifier "VipObject.0.RetentionContest.1.CandidateId"
-                             :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :retention-contests
+                           :identifier "VipObject.0.RetentionContest.1.CandidateId"
+                           :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/retention_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/retention_contest_test.clj
@@ -4,18 +4,30 @@
             [vip.data-processor.db.postgres :as psql]
             [vip.data-processor.validation.xml :as xml]
             [vip.data-processor.test-helpers :refer :all]
-            [vip.data-processor.validation.v5.retention-contest :as v5.retention-contest]))
+            [vip.data-processor.validation.v5.retention-contest :as v5.retention-contest]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-candidate-ids-test
-  (let [ctx {:input (xml-input "v5-missing-candidate-ids.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-missing-candidate-ids.xml")
              :pipeline [psql/start-run
                         xml/load-xml-ltree
-                        v5.retention-contest/validate-no-missing-candidate-ids]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        v5.retention-contest/validate-no-missing-candidate-ids]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing CandidateIds are flagged"
-      (is (get-in out-ctx [:errors :retention-contests "VipObject.0.RetentionContest.0.CandidateId" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :retention-contests
+                            :identifier "VipObject.0.RetentionContest.0.CandidateId"
+                            :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (is (not (get-in out-ctx [:errors :retention-contests "VipObject.0.RetentionContest.1.CandidateId" :missing]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                             :scope :retention-contests
+                             :identifier "VipObject.0.RetentionContest.1.CandidateId"
+                             :error-type :missing}))))

--- a/test/vip/data_processor/validation/v5/source_test.clj
+++ b/test/vip/data_processor/validation/v5/source_test.clj
@@ -34,7 +34,7 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))
 
 (deftest ^:postgres validate-name-test
   (testing "missing Name is a fatal error"
@@ -60,7 +60,7 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})))
+      (assert-no-problems errors {})))
   (testing "Name present is OK even if it's not first"
     (let [errors-chan (a/chan 100)
           ctx {:input (xml-input "v5-source-second-with-name-second.xml")
@@ -70,7 +70,7 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))
 
 (deftest ^:postgres validate-date-time-test
   (testing "missing DateTime is a fatal error"
@@ -96,7 +96,7 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})))
+      (assert-no-problems errors {})))
   (testing "DateTime present is OK even if it's not first"
     (let [errors-chan (a/chan 100)
           ctx {:input (xml-input "v5-source-second-with-date-time-second.xml")
@@ -106,7 +106,7 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))
 
 (deftest ^:postgres validate-vip-id-test
   (testing "missing VipId is a fatal error"
@@ -132,7 +132,7 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))
 
 (deftest ^:postgres validate-vip-id-valid-fips-test
   (testing "invalid 2-digit FIPS in VipId is a critical error"
@@ -158,7 +158,7 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {})))
+      (assert-no-problems errors {})))
   (testing "invalid 5-digit FIPS in VipId is a critical error"
     (let [errors-chan (a/chan 100)
           ctx {:input (xml-input "v5-source-vip-id-invalid-5-digit-fips.xml")
@@ -182,4 +182,4 @@
                :errors-chan errors-chan}
           out-ctx (pipeline/run-pipeline ctx)
           errors (all-errors errors-chan)]
-      (assert-no-problems-2 errors {}))))
+      (assert-no-problems errors {}))))

--- a/test/vip/data_processor/validation/v5/source_test.clj
+++ b/test/vip/data_processor/validation/v5/source_test.clj
@@ -4,120 +4,182 @@
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-one-source-test
   (testing "more than one Source element is a fatal error"
-    (let [ctx {:input (xml-input "v5-more-than-one-source.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-more-than-one-source.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-one-source]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:fatal :source "VipObject.0.Source" :count]))))
+                          v5.source/validate-one-source]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :source
+                            :identifier "VipObject.0.Source"
+                            :error-type :count}))))
   (testing "one and only one Source element is OK"
-    (let [ctx {:input (xml-input "v5-one-source.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-one-source.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-one-source]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx []))))
+                          v5.source/validate-one-source]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))
 
 (deftest ^:postgres validate-name-test
   (testing "missing Name is a fatal error"
-    (let [ctx {:input (xml-input "v5-source-without-name.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-without-name.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-name]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:fatal :source "VipObject.0.Source.0.Name"
-                           :missing]))))
+                          v5.source/validate-name]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :source
+                            :identifier "VipObject.0.Source.0.Name"
+                            :error-type :missing}))))
   (testing "Name present is OK"
-    (let [ctx {:input (xml-input "v5-source-with-name.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-with-name.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-name]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])))
+                          v5.source/validate-name]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})))
   (testing "Name present is OK even if it's not first"
-    (let [ctx {:input (xml-input "v5-source-second-with-name-second.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-second-with-name-second.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-name]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx []))))
+                          v5.source/validate-name]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))
 
 (deftest ^:postgres validate-date-time-test
   (testing "missing DateTime is a fatal error"
-    (let [ctx {:input (xml-input "v5-source-without-date-time.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-without-date-time.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-date-time]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:fatal :source "VipObject.0.Source.0.DateTime"
-                           :missing]))))
+                          v5.source/validate-date-time]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :source
+                            :identifier "VipObject.0.Source.0.DateTime"
+                            :error-type :missing}))))
   (testing "DateTime present is OK"
-    (let [ctx {:input (xml-input "v5-source-with-date-time.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-with-date-time.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-date-time]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])))
+                          v5.source/validate-date-time]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})))
   (testing "DateTime present is OK even if it's not first"
-    (let [ctx {:input (xml-input "v5-source-second-with-date-time-second.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-second-with-date-time-second.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-date-time]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx []))))
+                          v5.source/validate-date-time]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))
 
 (deftest ^:postgres validate-vip-id-test
   (testing "missing VipId is a fatal error"
-    (let [ctx {:input (xml-input "v5-source-without-vip-id.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-without-vip-id.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-vip-id]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:fatal :source "VipObject.0.Source.0.VipId"
-                           :missing]))))
+                          v5.source/validate-vip-id]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :source
+                            :identifier "VipObject.0.Source.0.VipId"
+                            :error-type :missing}))))
   (testing "VipId present is OK"
-    (let [ctx {:input (xml-input "v5-source-with-vip-id.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-with-vip-id.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-vip-id]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx []))))
+                          v5.source/validate-vip-id]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))
 
 (deftest ^:postgres validate-vip-id-valid-fips-test
   (testing "invalid 2-digit FIPS in VipId is a critical error"
-    (let [ctx {:input (xml-input "v5-source-vip-id-invalid-2-digit-fips.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-vip-id-invalid-2-digit-fips.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-vip-id-valid-fips]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:critical :source "VipObject.0.Source.1.VipId.2"
-                           :invalid-fips]))))
+                          v5.source/validate-vip-id-valid-fips]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :critical
+                            :scope :source
+                            :identifier "VipObject.0.Source.1.VipId.2"
+                            :error-type :invalid-fips}))))
   (testing "valid 2-digit FIPS in VipId is OK"
-    (let [ctx {:input (xml-input "v5-source-vip-id-valid-2-digit-fips.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-vip-id-valid-2-digit-fips.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-vip-id-valid-fips]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx [])))
+                          v5.source/validate-vip-id-valid-fips]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {})))
   (testing "invalid 5-digit FIPS in VipId is a critical error"
-    (let [ctx {:input (xml-input "v5-source-vip-id-invalid-5-digit-fips.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-vip-id-invalid-5-digit-fips.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-vip-id-valid-fips]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:critical :source "VipObject.0.Source.1.VipId.2"
-                           :invalid-fips]))))
+                          v5.source/validate-vip-id-valid-fips]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :critical
+                            :scope :source
+                            :identifier "VipObject.0.Source.1.VipId.2"
+                            :error-type :invalid-fips}))))
   (testing "valid 5-digit FIPS in VipId is OK"
-    (let [ctx {:input (xml-input "v5-source-vip-id-valid-5-digit-fips.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-source-vip-id-valid-5-digit-fips.xml")
                :pipeline [psql/start-run
                           xml/load-xml-ltree
-                          v5.source/validate-vip-id-valid-fips]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (assert-no-problems out-ctx []))))
+                          v5.source/validate-vip-id-valid-fips]
+               :errors-chan errors-chan}
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (assert-no-problems-2 errors {}))))

--- a/test/vip/data_processor/validation/v5/state_test.clj
+++ b/test/vip/data_processor/validation/v5/state_test.clj
@@ -4,19 +4,33 @@
              [vip.data-processor.db.postgres :as psql]
              [vip.data-processor.validation.xml :as xml]
              [vip.data-processor.test-helpers :refer :all]
-             [vip.data-processor.validation.v5.state :as state]))
+             [vip.data-processor.validation.v5.state :as state]
+             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
-  (let [ctx {:input (xml-input "v5-states.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-states.xml")
              :pipeline [psql/start-run
                         xml/load-xml-ltree
-                        state/validate-no-missing-names]}
-        out-ctx (pipeline/run-pipeline ctx)]
+                        state/validate-no-missing-names]
+             :errors-chan errors-chan}
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
     (testing "missing Names are flagged"
-      (is (get-in out-ctx [:fatal :states "VipObject.0.State.0.Name" :missing]))
-      (is (get-in out-ctx [:fatal :states "VipObject.0.State.1.Name" :missing])))
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :states
+                            :identifier "VipObject.0.State.0.Name"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :states
+                            :identifier "VipObject.0.State.1.Name"
+                            :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems out-ctx [:states "VipObject.0.State.2.Name"]))))
+      (assert-no-problems-2 errors
+                            {:scope :states
+                             :identifier "VipObject.0.State.2.Name"}))))

--- a/test/vip/data_processor/validation/v5/state_test.clj
+++ b/test/vip/data_processor/validation/v5/state_test.clj
@@ -31,6 +31,6 @@
                             :identifier "VipObject.0.State.1.Name"
                             :error-type :missing})))
     (testing "doesn't for those that aren't"
-      (assert-no-problems-2 errors
-                            {:scope :states
-                             :identifier "VipObject.0.State.2.Name"}))))
+      (assert-no-problems errors
+                          {:scope :states
+                           :identifier "VipObject.0.State.2.Name"}))))

--- a/test/vip/data_processor/validation/v5/street_segment_test.clj
+++ b/test/vip/data_processor/validation/v5/street_segment_test.clj
@@ -26,11 +26,11 @@
                             :identifier "VipObject.0.StreetSegment.0.OddEvenBoth"
                             :error-type :missing})))
     (testing "odd-even-both present is OK"
-      (assert-no-problems-2 errors
-                            {:severity :errors
-                            :scope :street-segment
-                            :identifier "VipObject.0.StreetSegment.1.OddEvenBoth"
-                            :error-type :missing}))))
+      (assert-no-problems errors
+                          {:severity :errors
+                           :scope :street-segment
+                           :identifier "VipObject.0.StreetSegment.1.OddEvenBoth"
+                           :error-type :missing}))))
 
 (deftest ^:postgres validate-odd-even-both-value
   (let [errors-chan (a/chan 100)
@@ -45,10 +45,10 @@
       (doseq [path ["VipObject.0.StreetSegment.1.OddEvenBoth.0"
                     "VipObject.0.StreetSegment.2.OddEvenBoth.0"
                     "VipObject.0.StreetSegment.3.OddEvenBoth.0"]]
-        (assert-no-problems-2 errors
-                              {:scope :street-segment
-                               :identifier path
-                               :error-type :format})))
+        (assert-no-problems errors
+                            {:scope :street-segment
+                             :identifier path
+                             :error-type :format})))
     (testing "anything else is not"
       (is (contains-error? errors
                            {:severity :errors
@@ -80,7 +80,7 @@
       (doseq [path ["VipObject.0.StreetSegment.1.City"
                     "VipObject.0.StreetSegment.2.City"
                     "VipObject.0.StreetSegment.3.City"]]
-        (assert-no-problems-2 errors
+        (assert-no-problems errors
                             {:scope :street-segment
                              :identifier path
                              :error-type :missing})))))
@@ -109,10 +109,10 @@
       (doseq [path ["VipObject.0.StreetSegment.1.State"
                     "VipObject.0.StreetSegment.2.State"
                     "VipObject.0.StreetSegment.3.State"]]
-        (assert-no-problems-2 errors
-                              {:scope :street-segment
-                               :identifier path
-                               :error-type :missing})))))
+        (assert-no-problems errors
+                            {:scope :street-segment
+                             :identifier path
+                             :error-type :missing})))))
 
 (deftest ^:postgres validate-no-missing-zip
   (let [errors-chan (a/chan 100)
@@ -138,10 +138,10 @@
       (doseq [path ["VipObject.0.StreetSegment.1.Zip"
                     "VipObject.0.StreetSegment.2.Zip"
                     "VipObject.0.StreetSegment.3.Zip"]]
-        (assert-no-problems-2 errors
-                              {:scope :street-segment
-                               :identifier path
-                               :error-type :missing})))))
+        (assert-no-problems errors
+                            {:scope :street-segment
+                             :identifier path
+                             :error-type :missing})))))
 
 (deftest ^:postgres validate-no-missing-street-name
   (let [errors-chan (a/chan 100)
@@ -167,10 +167,10 @@
       (doseq [path ["VipObject.0.StreetSegment.1.StreetName"
                     "VipObject.0.StreetSegment.2.StreetName"
                     "VipObject.0.StreetSegment.3.StreetName"]]
-        (assert-no-problems-2 errors
-                              {:scope :street-segment
-                               :identifier path
-                               :error-type :missing})))))
+        (assert-no-problems errors
+                            {:scope :street-segment
+                             :identifier path
+                             :error-type :missing})))))
 
 (deftest ^:postgres validate-no-street-segment-overlaps-test
   (let [errors-chan (a/chan 100)
@@ -190,11 +190,11 @@
                                 :identifier path
                                 :error-type :overlaps
                                 :error-value overlap}))
-          (assert-no-problems-2 errors
-                                {:severity :errors
-                                :scope :street-segment
-                                :identifier path
-                                :error-type :overlaps}))
+          (assert-no-problems errors
+                              {:severity :errors
+                               :scope :street-segment
+                               :identifier path
+                               :error-type :overlaps}))
       "simple, complete overlap"    "VipObject.0.StreetSegment.0" "ss002"
       "partial overlap"             "VipObject.0.StreetSegment.2" "ss004"
       "single address overlap"      "VipObject.0.StreetSegment.4" "ss006"

--- a/test/vip/data_processor/validation/v5/street_segment_test.clj
+++ b/test/vip/data_processor/validation/v5/street_segment_test.clj
@@ -4,148 +4,207 @@
             [clojure.test :refer :all]
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
-            [vip.data-processor.validation.xml :as xml]))
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-odd-even-both
-  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-street-segment.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.ss/validate-no-missing-odd-even-both)]
+                    v5.ss/validate-no-missing-odd-even-both)
+        errors (all-errors errors-chan)]
     (testing "odd-even-both missing is an error"
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.0.OddEvenBoth" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.0.OddEvenBoth"
+                            :error-type :missing})))
     (testing "odd-even-both present is OK"
-      (is (not (get-in out-ctx [:errors :street-segment
-                                "VipObject.0.StreetSegment.1.OddEvenBoth"
-                                :missing]))))))
+      (assert-no-problems-2 errors
+                            {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.1.OddEvenBoth"
+                            :error-type :missing}))))
 
 (deftest ^:postgres validate-odd-even-both-value
-  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-street-segment.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.ss/validate-odd-even-both-value)]
+                    v5.ss/validate-odd-even-both-value)
+        errors (all-errors errors-chan)]
     (testing "odd/even/both are good values"
       (doseq [path ["VipObject.0.StreetSegment.1.OddEvenBoth.0"
                     "VipObject.0.StreetSegment.2.OddEvenBoth.0"
                     "VipObject.0.StreetSegment.3.OddEvenBoth.0"]]
-        (assert-no-problems out-ctx
-                            [:street-segment
-                             path
-                             :format])))
+        (assert-no-problems-2 errors
+                              {:scope :street-segment
+                               :identifier path
+                               :error-type :format})))
     (testing "anything else is not"
-      (is (get-in out-ctx [:errors
-                           :street-segment
-                           "VipObject.0.StreetSegment.4.OddEvenBoth.0"
-                           :format])))))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.4.OddEvenBoth.0"
+                            :error-type :format})))))
 
 (deftest ^:postgres validate-no-missing-city
-  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-street-segment.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.ss/validate-no-missing-city)]
+                    v5.ss/validate-no-missing-city)
+        errors (all-errors errors-chan)]
     (testing "city missing is an error"
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.0.City" :missing]))
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.4.City" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.0.City"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.4.City"
+                            :error-type :missing})))
     (testing "city present is OK"
       (doseq [path ["VipObject.0.StreetSegment.1.City"
                     "VipObject.0.StreetSegment.2.City"
                     "VipObject.0.StreetSegment.3.City"]]
-        (assert-no-problems out-ctx
-                            [:street-segment
-                             path
-                             :missing])))))
+        (assert-no-problems-2 errors
+                            {:scope :street-segment
+                             :identifier path
+                             :error-type :missing})))))
 
 (deftest ^:postgres validate-no-missing-state
-  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-street-segment.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.ss/validate-no-missing-state)]
+                    v5.ss/validate-no-missing-state)
+        errors (all-errors errors-chan)]
     (testing "state missing is an error"
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.0.State" :missing]))
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.4.State" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.0.State"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.4.State"
+                            :error-type :missing})))
     (testing "state present is OK"
       (doseq [path ["VipObject.0.StreetSegment.1.State"
                     "VipObject.0.StreetSegment.2.State"
                     "VipObject.0.StreetSegment.3.State"]]
-        (assert-no-problems out-ctx
-                            [:street-segment
-                             path
-                             :missing])))))
+        (assert-no-problems-2 errors
+                              {:scope :street-segment
+                               :identifier path
+                               :error-type :missing})))))
 
 (deftest ^:postgres validate-no-missing-zip
-  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-street-segment.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.ss/validate-no-missing-zip)]
+                    v5.ss/validate-no-missing-zip)
+        errors (all-errors errors-chan)]
     (testing "zip missing is an error"
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.0.Zip" :missing]))
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.4.Zip" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.0.Zip"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.4.Zip"
+                            :error-type :missing})))
     (testing "zip present is OK"
       (doseq [path ["VipObject.0.StreetSegment.1.Zip"
                     "VipObject.0.StreetSegment.2.Zip"
                     "VipObject.0.StreetSegment.3.Zip"]]
-        (assert-no-problems out-ctx
-                            [:street-segment
-                             path
-                             :missing])))))
+        (assert-no-problems-2 errors
+                              {:scope :street-segment
+                               :identifier path
+                               :error-type :missing})))))
 
 (deftest ^:postgres validate-no-missing-street-name
-  (let [ctx {:input (xml-input "v5-street-segment.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-street-segment.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
-                    v5.ss/validate-no-missing-street-name)]
+                    v5.ss/validate-no-missing-street-name)
+        errors (all-errors errors-chan)]
     (testing "street-name missing is an error"
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.0.StreetName" :missing]))
-      (is (get-in out-ctx [:errors :street-segment
-                           "VipObject.0.StreetSegment.4.StreetName" :missing])))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.0.StreetName"
+                            :error-type :missing}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :street-segment
+                            :identifier "VipObject.0.StreetSegment.4.StreetName"
+                            :error-type :missing})))
     (testing "street-name present is OK"
       (doseq [path ["VipObject.0.StreetSegment.1.StreetName"
                     "VipObject.0.StreetSegment.2.StreetName"
                     "VipObject.0.StreetSegment.3.StreetName"]]
-        (assert-no-problems out-ctx
-                            [:street-segment
-                             path
-                             :missing])))))
+        (assert-no-problems-2 errors
+                              {:scope :street-segment
+                               :identifier path
+                               :error-type :missing})))))
 
 (deftest ^:postgres validate-no-street-segment-overlaps-test
-  (let [ctx {:input (xml-input "v5-street-segment-overlaps.xml")}
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-street-segment-overlaps.xml")
+             :errors-chan errors-chan}
         out-ctx (-> ctx
                     psql/start-run
                     xml/load-xml-ltree
                     xml.v5/load-xml-street-segments
-                    v5.ss/validate-no-street-segment-overlaps)]
-    (are [_ path overlaps] (is (= (get-in out-ctx
-                                          [:errors
-                                           :street-segment
-                                           path
-                                           :overlaps])
-                                  overlaps))
-      "simple, complete overlap"    "VipObject.0.StreetSegment.0" '("ss002")
-      "partial overlap"             "VipObject.0.StreetSegment.2" '("ss004")
-      "single address overlap"      "VipObject.0.StreetSegment.4" '("ss006")
+                    v5.ss/validate-no-street-segment-overlaps)
+        errors (all-errors errors-chan)]
+    (are [_ path overlap]
+        (if overlap
+          (is (contains-error? errors
+                               {:severity :errors
+                                :scope :street-segment
+                                :identifier path
+                                :error-type :overlaps
+                                :error-value overlap}))
+          (assert-no-problems-2 errors
+                                {:severity :errors
+                                :scope :street-segment
+                                :identifier path
+                                :error-type :overlaps}))
+      "simple, complete overlap"    "VipObject.0.StreetSegment.0" "ss002"
+      "partial overlap"             "VipObject.0.StreetSegment.2" "ss004"
+      "single address overlap"      "VipObject.0.StreetSegment.4" "ss006"
       "even/odd don't overlap"      "VipObject.0.StreetSegment.6" nil
       "even/odd don't overlap"      "VipObject.0.StreetSegment.7" nil
-      "even/both overlap"           "VipObject.0.StreetSegment.8" '("ss010")
-      "odd/both overlap"            "VipObject.0.StreetSegment.10" '("ss012")
+      "even/both overlap"           "VipObject.0.StreetSegment.8" "ss010"
+      "odd/both overlap"            "VipObject.0.StreetSegment.10" "ss012"
       "shared precinct"             "VipObject.0.StreetSegment.12" nil
       "shared precinct"             "VipObject.0.StreetSegment.13" nil
-      "matching more fields"        "VipObject.0.StreetSegment.14" '("ss016")
+      "matching more fields"        "VipObject.0.StreetSegment.14" "ss016"
       "different address direction" "VipObject.0.StreetSegment.16" nil
       "different address direction" "VipObject.0.StreetSegment.17" nil
       "different street direction"  "VipObject.0.StreetSegment.18" nil

--- a/test/vip/data_processor/validation/v5_test.clj
+++ b/test/vip/data_processor/validation/v5_test.clj
@@ -6,19 +6,24 @@
              [vip.data-processor.validation.xml :as xml]
              [vip.data-processor.test-helpers :refer :all]
              [vip.data-processor.validation.v5 :as v5]
-             [clojure.java.io :as io]))
+             [clojure.java.io :as io]
+             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres full-good-v5-test
-  (let [ctx {:input (xml-input "v5_sample_feed.xml")
+  (let [errors-chan (a/chan 100)
+        ctx {:errors-chan errors-chan
+             :input (xml-input "v5_sample_feed.xml")
+             :spec-version (atom nil)
              :pipeline (concat [psql/start-run
                                 xml/determine-spec-version
                                 xml/load-xml-ltree]
                                v5/validations)}
-        out-ctx (pipeline/run-pipeline ctx)]
-    (assert-no-problems out-ctx [])))
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
+    (assert-no-problems-2 errors {})))
 
 (deftest ^:postgres full-good-v51-csv-test
   (let [csvs (-> "csv/5-1/full-good-run"
@@ -26,13 +31,17 @@
                  io/as-file
                  .listFiles
                  seq)
+        errors-chan (a/chan 100)
         ctx {:input csvs
+             :errors-chan errors-chan
+             :spec-version (atom nil)
              :pipeline (concat [psql/start-run
                                 csv/determine-spec-version]
                                (csv/version-pipelines "5.1")
                                v5/validations)}
-        out-ctx (pipeline/run-pipeline ctx)]
-    (assert-no-problems out-ctx [])
+        out-ctx (pipeline/run-pipeline ctx)
+        errors (all-errors errors-chan)]
+    (assert-no-problems-2 errors {})
 
     (testing "the data for building a public_id is correctly fetched"
       (is (= {:date "10/08/2016"

--- a/test/vip/data_processor/validation/v5_test.clj
+++ b/test/vip/data_processor/validation/v5_test.clj
@@ -23,7 +23,7 @@
                                v5/validations)}
         out-ctx (pipeline/run-pipeline ctx)
         errors (all-errors errors-chan)]
-    (assert-no-problems-2 errors {})))
+    (assert-no-problems errors {})))
 
 (deftest ^:postgres full-good-v51-csv-test
   (let [csvs (-> "csv/5-1/full-good-run"
@@ -41,7 +41,7 @@
                                v5/validations)}
         out-ctx (pipeline/run-pipeline ctx)
         errors (all-errors errors-chan)]
-    (assert-no-problems-2 errors {})
+    (assert-no-problems errors {})
 
     (testing "the data for building a public_id is correctly fetched"
       (is (= {:date "10/08/2016"

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -157,7 +157,7 @@
           errors (all-errors errors-chan)]
       (is (nil? (:stop out-ctx)))
       (is (nil? (:exception out-ctx)))
-      (assert-no-problems-2 errors {})
+      (assert-no-problems errors {})
       (testing "inserts values for columns not in the first element of a type"
         (let [mail-only-precinct (first
                                   (korma/select (get-in out-ctx [:tables :precincts])

--- a/test/vip/data_processor/validation/xml_test.clj
+++ b/test/vip/data_processor/validation/xml_test.clj
@@ -202,8 +202,7 @@
           (is (nil? (contains-error? errors {:severity :warnings
                                              :scope :ballots
                                              :identifier id
-                                             :error-type :duplicate-rows})))))
-      (assert-error-format out-ctx))))
+                                             :error-type :duplicate-rows}))))))))
 
 (deftest validate-references-test
   (testing "returns an error if there are unreferenced objects"
@@ -310,8 +309,7 @@
                            {:severity :errors
                             :scope :election-administrations
                             :identifier 3456
-                            :error-type :incomplete-mailing-address}))
-      (assert-error-format out-ctx))))
+                            :error-type :incomplete-mailing-address})))))
 
 (deftest validate-data-formats
   (let [errors-chan (a/chan 100)
@@ -373,8 +371,7 @@
       (testing "but still loads some data"
         (is (= [{:id 103}]
                (korma/select (get-in out-ctx [:tables :localities])
-                             (korma/fields :id)))))
-      (assert-error-format out-ctx))))
+                             (korma/fields :id))))))))
 
 (deftest determine-spec-version-test
   (testing "finds and assocs the schemaVersion of the xml feed"

--- a/test/vip/data_processor/validation/xml_with_postgres_test.clj
+++ b/test/vip/data_processor/validation/xml_with_postgres_test.clj
@@ -48,8 +48,8 @@
                             :identifier "VipObject.0.Person.1.ContactInformation.0.Email.0"
                             :error-type :format}))
       (testing "but not for good emails"
-        (assert-no-problems-2 errors
-                              {:severity :errors
-                               :scope :email
-                               :identifier "VipObject.0.Person.2.ContactInformation.0.Email.0"
-                               :error-type :format})))))
+        (assert-no-problems errors
+                            {:severity :errors
+                             :scope :email
+                             :identifier "VipObject.0.Person.2.ContactInformation.0.Email.0"
+                             :error-type :format})))))

--- a/test/vip/data_processor/validation/xml_with_postgres_test.clj
+++ b/test/vip/data_processor/validation/xml_with_postgres_test.clj
@@ -6,7 +6,8 @@
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.db.postgres :as psql]
             [squishy.data-readers]
-            [korma.core :as korma]))
+            [korma.core :as korma]
+            [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
 (use-fixtures :each with-clean-postgres)
@@ -26,56 +27,29 @@
                  :value)
              "51")))))
 
-(deftest ^:postgres load-xml-tree-validations-test
-  (testing "well-formed 5.1 style errors will be saved to the database"
-    (let [ctx {:fatal {:id
-                       {"VipObject.0.Election.1.id"
-                        {:duplicate ["ele0001"]}
-                        "VipObject.0.Election.2.id"
-                        {:duplicate ["ele0001"]}}}
-               :warnings {:import
-                          {:global
-                           {:invalid-extensions [".exemell" ".seeesvee"]}}}
-               :pipeline [psql/start-run
-                          load-xml-tree-validations]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (= (-> (korma/select psql/xml-tree-validations
-                   (korma/where {:results_id (:import-id out-ctx)})
-                   (korma/where (psql/ltree-match
-                                 psql/xml-tree-validations
-                                 :path
-                                 "VipObject.0.Election.1.id")))
-                 first
-                 :error_data)
-             "\"ele0001\""))
-      (is (= (->> (korma/select psql/xml-tree-validations
-                    (korma/where {:results_id (:import-id out-ctx)
-                                  :path nil}))
-                  (map :error_data)
-                  set)
-             #{"\".exemell\"" "\".seeesvee\""}))))
-
-  (testing "when there are no errors, the errors table doesn't grow"
-    (let [ctx {:fatal {}
-               :critical {}
-               :warnings {:import
-                          {:global
-                           {:invalid-extensions []}}}
-               :errors {}
-               :pipeline [psql/start-run
-                          load-xml-tree-validations]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (= 0 (count (korma/select psql/xml-tree-validations
-                        (korma/where {:results_id (:import-id out-ctx)}))))))))
-
 (deftest ^:postgres validate-emails-test
   (testing "adds errors to the context for badly formatted emails"
-    (let [ctx {:input (xml-input "v5-bad-emails.xml")
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-bad-emails.xml")
+               :errors-chan errors-chan
                :pipeline [psql/start-run
                           load-xml-ltree
                           v5.email/validate-emails]}
-          out-ctx (pipeline/run-pipeline ctx)]
-      (is (get-in out-ctx [:errors :email "VipObject.0.Person.0.ContactInformation.0.Email.0" :format]))
-      (is (get-in out-ctx [:errors :email "VipObject.0.Person.1.ContactInformation.0.Email.0" :format]))
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :email
+                            :identifier "VipObject.0.Person.0.ContactInformation.0.Email.0"
+                            :error-type :format}))
+      (is (contains-error? errors
+                           {:severity :errors
+                            :scope :email
+                            :identifier "VipObject.0.Person.1.ContactInformation.0.Email.0"
+                            :error-type :format}))
       (testing "but not for good emails"
-        (is (nil? (get-in out-ctx [:errors :email "VipObject.0.Person.2.ContactInformation.0.Email.0" :format])))))))
+        (assert-no-problems-2 errors
+                              {:severity :errors
+                               :scope :email
+                               :identifier "VipObject.0.Person.2.ContactInformation.0.Email.0"
+                               :error-type :format})))))


### PR DESCRIPTION
# Async errors!

When a validation error is reported, instead of storing it on the context—which balloons and balloons as time goes on—instead, put it on a core.async channel. That channel is taken from and, every so often (once a number of messages is received or a timeout reached), the validation errors are committed to the database.

Because some errors are gathered before the specification version is known (and thus which table the errors must go to), the errors aren't processed until the spec version is decided. This was  accomplished by turning the spec-version into an atom with a watch.

This is a big one, and a long time coming. This may result in a very slight performance boost, but will definitely alleviate some OutOfMemory issues with particularly bad feeds.

<img src="http://i.giphy.com/bhTJKZWkeKwiQ.gif">