### PR TITLE
Turbocharge validations

### DIFF
--- a/resources/migrations/20160929-01-add-parent-with-id-idx.down.sql
+++ b/resources/migrations/20160929-01-add-parent-with-id-idx.down.sql
@@ -1,0 +1,1 @@
+drop index if exists xml_parent_id_idx;

--- a/resources/migrations/20160929-01-add-parent-with-id-idx.up.sql
+++ b/resources/migrations/20160929-01-add-parent-with-id-idx.up.sql
@@ -1,0 +1,1 @@
+create index xml_parent_id_idx on xml_tree_values (results_id, parent_with_id);

--- a/resources/migrations/20160930-01-create-street-segment-overlaps-fn.down.sql
+++ b/resources/migrations/20160930-01-create-street-segment-overlaps-fn.down.sql
@@ -1,0 +1,1 @@
+drop function if exists street_segment_overlaps(rid int);

--- a/resources/migrations/20160930-01-create-street-segment-overlaps-fn.up.sql
+++ b/resources/migrations/20160930-01-create-street-segment-overlaps-fn.up.sql
@@ -1,0 +1,48 @@
+create or replace function street_segment_overlaps(rid int)
+returns table (path ltree, id text)
+as $$
+begin
+  create temp table sse on commit drop as
+  select ss.id,
+    ss.results_id,
+    ss.street_name,
+    ss.city,
+    ss.state,
+    ss.zip,
+    ss.odd_even_both,
+    ss.precinct_id,
+    ss.start_house_number,
+    ss.end_house_number,
+    coalesce(ss.address_direction, 'NULL_VALUE') as address_direction,
+    coalesce(ss.street_direction, 'NULL_VALUE') as street_direction,
+    coalesce(ss.street_suffix, 'NULL_VALUE') as street_suffix
+    from v5_1_street_segments ss
+  where ss.results_id = rid
+  order by ss.street_name, ss.city, ss.state, ss.zip;
+
+  create index street_segment_experiment_idx on sse (street_name, city, state, zip);
+
+  analyze sse;
+
+  return query SELECT subpath(xtv.path,0,4), ss2.id
+   FROM sse ss
+   INNER JOIN sse ss2
+           ON ss2.start_house_number >= ss.start_house_number AND
+              ss2.start_house_number <= ss.end_house_number AND
+              ss.street_name = ss2.street_name AND
+              ss.city = ss2.city AND
+              ss.state = ss2.state AND
+              ss.zip = ss2.zip AND
+              ss.address_direction = ss2.address_direction AND
+              ss.street_direction = ss2.street_direction AND
+              ss.street_suffix = ss2.street_suffix AND
+              ss.precinct_id != ss2.precinct_id AND
+              ss.id != ss2.id AND
+              (ss.odd_even_both = ss2.odd_even_both OR
+               ss.odd_even_both = 'both' OR
+               ss2.odd_even_both = 'both')
+   INNER JOIN xml_tree_values xtv
+           ON xtv.value = ss.id AND xtv.results_id = rid
+   WHERE xtv.simple_path = 'VipObject.StreetSegment.id';
+end;
+$$ language plpgsql;

--- a/src/vip/data_processor/validation/v5/id.clj
+++ b/src/vip/data_processor/validation/v5/id.clj
@@ -29,14 +29,12 @@
 (def validate-no-missing-ids
   (util/build-xml-tree-value-query-validator
    :fatal :id :missing :missing-id
-   "SELECT xtv.path
-    FROM (SELECT DISTINCT subltree(path, 0, 4) || 'id' AS path
-          FROM xml_tree_values WHERE results_id = ?
-          AND nlevel(subltree(path, 0, 4)) = 4) xtv
-    LEFT JOIN (SELECT path FROM xml_tree_values WHERE results_id = ?) xtv2
-    ON xtv.path = xtv2.path
-    WHERE xtv2.path IS NULL"
-   util/two-import-ids))
+   "select distinct subltree(path, 0, 4) || 'id' as path
+    from xml_tree_values
+    where results_id = ?
+      and nlevel(path) > 3
+      and parent_with_id is null"
+   (fn [{:keys [import-id]}] [import-id])))
 
 (defn validate-ids-with
   [{:keys [import-id] :as ctx} simple-path query]

--- a/src/vip/data_processor/validation/v5/street_segment.clj
+++ b/src/vip/data_processor/validation/v5/street_segment.clj
@@ -15,43 +15,17 @@
 (def validate-odd-even-both-value
   (util/validate-enum-elements :oeb-enum :errors))
 
-(def overlap-query
-  "SELECT subpath(xtv.path,0,4) AS path, ss2.id AS ss2_id
-   FROM v5_1_street_segments ss
-   INNER JOIN v5_1_street_segments ss2
-           ON ss2.start_house_number >= ss.start_house_number AND
-              ss2.start_house_number <= ss.end_house_number AND
-              ss.street_name = ss2.street_name AND
-              ss.city = ss2.city AND
-              ss.state = ss2.state AND
-              ss.zip = ss2.zip AND
-              COALESCE(ss.address_direction, 'NULL_VALUE') =
-                COALESCE(ss2.address_direction, 'NULL_VALUE') AND
-              COALESCE(ss.street_direction, 'NULL_VALUE') =
-                COALESCE(ss2.street_direction, 'NULL_VALUE') AND
-              COALESCE(ss.street_suffix, 'NULL_VALUE') =
-                COALESCE(ss2.street_suffix, 'NULL_VALUE') AND
-              ss.precinct_id != ss2.precinct_id AND
-              ss.id != ss2.id AND
-              ss.results_id = ss2.results_id AND
-              (ss.odd_even_both = ss2.odd_even_both OR
-               ss.odd_even_both = 'both' OR
-               ss2.odd_even_both = 'both')
-   INNER JOIN xml_tree_values xtv
-           ON xtv.value = ss.id
-   WHERE ss.results_id = ? AND xtv.simple_path = 'VipObject.StreetSegment.id';")
-
 (defn validate-no-street-segment-overlaps
   [{:keys [import-id] :as ctx}]
   (log/info "Validating street segment overlaps")
   (let [overlaps (korma/exec-raw
                   (:conn postgres/v5-1-street-segments)
-                  [overlap-query [import-id]]
+                  ["SELECT * from street_segment_overlaps(?);" [import-id]]
                   :results)]
     (reduce (fn [ctx overlap]
               (update-in ctx [:errors
                               :street-segment
                               (.getValue (:path overlap))
                               :overlaps]
-                         conj (:ss2_id overlap)))
+                         conj (:id overlap)))
             ctx overlaps)))


### PR DESCRIPTION
This has a couple tweaks, but the biggest thing is that street segment overlaps should be much faster.

The overlap query is basically the same, but instead of fighting indexes and filtering of the full set of street_segments, create a temporary table with only your chosen feed's street segments and apply an index that makes the `INNER JOIN` to a second copy of the street_segment really smooth.