### PR TITLE
Fix stats

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -3,7 +3,6 @@
             [clojure.core.async :as a]
             [clojure.tools.logging :as log]
             [clojure.pprint :as pprint]
-            [utility-works.async :as util-async]
             [vip.data-processor :as data-processor]
             [vip.data-processor.errors :as errors]
             [vip.data-processor.pipeline :as pipeline]
@@ -29,30 +28,11 @@
    psql/store-public-id
    psql/store-election-id
    data-processor/add-validations
-   errors/detach-errors-chan])
+   errors/close-errors-chan
+   errors/await-statistics])
 
 (defn -main [filename]
   (psql/initialize)
-  (util-async/batch-process
-   errors/v3-errors-chan
-   (fn [all-errors]
-     (doseq [[_ errors] (group-by #(get-in % [:ctx :import-id])
-                                  all-errors)]
-       (psql/bulk-import
-        (:ctx (first errors))
-        psql/validations
-        (map psql/validation-value errors))))
-   1000 100)
-  (util-async/batch-process
-   errors/v5-errors-chan
-   (fn [all-errors]
-     (doseq [[_ errors] (group-by #(get-in % [:ctx :import-id])
-                                  all-errors)]
-       (psql/bulk-import
-        (:ctx (first errors))
-        psql/xml-tree-validations
-        (map psql/xml-tree-validation-value errors))))
-   1000 100)
   (let [file (if (zip/xml-file? filename)
                (java.nio.file.Paths/get filename (into-array [""]))
                (java.io.File. filename))

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                                                               org.slf4j/slf4j-simple
                                                               org.slf4j/slf4j-api]]
                  [org.clojure/core.async "0.2.391"]
-                 [democracyworks/utility-works "0.1.1-SNAPSHOT"]
+                 [democracyworks/utility-works "0.1.1"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
                  [turbovote.resource-config "0.2.0"]
                  [joplin.jdbc "0.3.6"

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                                                               org.slf4j/slf4j-simple
                                                               org.slf4j/slf4j-api]]
                  [org.clojure/core.async "0.2.391"]
-                 [democracyworks/utility-works "0.1.0"]
+                 [democracyworks/utility-works "0.1.1-SNAPSHOT"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
                  [turbovote.resource-config "0.2.0"]
                  [joplin.jdbc "0.3.6"

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -44,12 +44,14 @@
           [tree-stats/store-tree-stats]))
 
 (defn add-validations
-  [{:keys [spec-version] :as ctx}]
-  (let [validations (condp = @spec-version
-                      "3.0" v3-validation-pipeline
-                      "5.1" v5-1-validation-pipeline
-                      nil)]
-    (update ctx :pipeline (partial concat validations))))
+  [{:keys [spec-version skip-validations?] :as ctx}]
+  (if skip-validations?
+    ctx
+    (let [validations (condp = spec-version
+                        "3.0" v3-validation-pipeline
+                        "5.1" v5-1-validation-pipeline
+                        nil)]
+      (update ctx :pipeline (partial concat validations)))))
 
 (def pipeline
   (concat download-pipeline

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -6,7 +6,6 @@
             [korma.db :as db]
             [korma.core :as korma]
             [turbovote.resource-config :refer [config]]
-            [vip.data-processor.db.statistics :as stats]
             [vip.data-processor.db.util :as db.util]
             [vip.data-processor.util :as util]
             [vip.data-processor.validation.data-spec :as data-spec]
@@ -296,11 +295,6 @@
                                 (data-spec/coerce-rows columns)))))
           ctx
           db.util/import-entity-names))
-
-(defn store-stats [{:keys [import-id] :as ctx}]
-  (korma/insert statistics
-                (korma/values (assoc (stats/stats-map ctx) :results_id import-id)))
-  ctx)
 
 (defn columns [table]
   (let [table-name (:table table)]

--- a/src/vip/data_processor/errors.clj
+++ b/src/vip/data_processor/errors.clj
@@ -1,22 +1,6 @@
 (ns vip.data-processor.errors
   (:require [clojure.core.async :as a]))
 
-(def v3-errors-chan (a/chan 1024))
-(def v3-errors-mix (a/mix v3-errors-chan))
-
-(def v5-errors-chan (a/chan 1024))
-(def v5-errors-mix (a/mix v5-errors-chan))
-
-(defn route-messages [errors-chan spec-version]
-  (case spec-version
-    "3.0" (a/admix v3-errors-mix errors-chan)
-    "5.1" (a/admix v5-errors-mix errors-chan)))
-
-(defn add-watch-fn [errors-chan]
-  (fn [key ref _ spec-version]
-    (route-messages errors-chan spec-version)
-    (remove-watch ref key)))
-
 (defrecord ValidationError [ctx severity scope
                             identifier error-type error-value])
 
@@ -29,8 +13,10 @@
 
   ctx)
 
-(defn detach-errors-chan [{:keys [errors-chan spec-version] :as ctx}]
-  (case @spec-version
-    "3.0" (a/unmix v3-errors-mix errors-chan)
-    "5.1" (a/unmix v5-errors-mix errors-chan))
+(defn close-errors-chan [{:keys [errors-chan] :as ctx}]
+  (a/close! errors-chan)
+  ctx)
+
+(defn await-statistics [ctx]
+  (a/<!! (:processing-chan ctx))
   ctx)

--- a/src/vip/data_processor/errors/process.clj
+++ b/src/vip/data_processor/errors/process.clj
@@ -1,0 +1,30 @@
+(ns vip.data-processor.errors.process
+  (:require [utility-works.async :as util-async]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.db.tree-statistics :as tree-stats]))
+
+(defn batch-process-fn [validations-table
+                        validations-transform
+                        stats-fn]
+  (fn [{:keys [errors-chan] :as ctx}]
+    (let [processing-chan (util-async/batch-process
+                           errors-chan
+                           (fn [errors]
+                             (psql/bulk-import
+                              ctx
+                              validations-table
+                              (map validations-transform errors)))
+                           500
+                           5000
+                           (partial stats-fn ctx))]
+      (assoc ctx :processing-chan processing-chan))))
+
+(def process-v3-validations
+  (batch-process-fn psql/validations
+                    psql/validation-value
+                    psql/store-stats))
+
+(def process-v5-validations
+  (batch-process-fn psql/xml-tree-validations
+                    psql/xml-tree-validation-value
+                    tree-stats/store-tree-stats))

--- a/src/vip/data_processor/errors/process.clj
+++ b/src/vip/data_processor/errors/process.clj
@@ -1,30 +1,31 @@
 (ns vip.data-processor.errors.process
   (:require [utility-works.async :as util-async]
             [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.db.statistics :as stats]
             [vip.data-processor.db.tree-statistics :as tree-stats]))
 
-(defn batch-process-fn [validations-table
-                        validations-transform
-                        stats-fn]
-  (fn [{:keys [errors-chan] :as ctx}]
-    (let [processing-chan (util-async/batch-process
-                           errors-chan
-                           (fn [errors]
-                             (psql/bulk-import
-                              ctx
-                              validations-table
-                              (map validations-transform errors)))
-                           500
-                           5000
-                           (partial stats-fn ctx))]
-      (assoc ctx :processing-chan processing-chan))))
+(defn process-v3-validations [{:keys [errors-chan] :as ctx}]
+  (let [processing-chan (util-async/batch-process
+                         errors-chan
+                         (fn [errors]
+                           (psql/bulk-import
+                            ctx
+                            psql/validations
+                            (map psql/validation-value errors)))
+                         500
+                         5000
+                         (partial stats/store-stats ctx))]
+    (assoc ctx :processing-chan processing-chan)))
 
-(def process-v3-validations
-  (batch-process-fn psql/validations
-                    psql/validation-value
-                    psql/store-stats))
-
-(def process-v5-validations
-  (batch-process-fn psql/xml-tree-validations
-                    psql/xml-tree-validation-value
-                    tree-stats/store-tree-stats))
+(defn process-v5-validations [{:keys [errors-chan] :as ctx}]
+  (let [processing-chan (util-async/batch-process
+                         errors-chan
+                         (fn [errors]
+                           (psql/bulk-import
+                            ctx
+                            psql/xml-tree-validations
+                            (map psql/xml-tree-validation-value errors)))
+                         500
+                         5000
+                         (partial tree-stats/store-tree-stats ctx))]
+    (assoc ctx :processing-chan processing-chan)))

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -2,8 +2,7 @@
   (:require [clojure.tools.logging :as log]
             [clojure.stacktrace :as stacktrace]
             [vip.data-processor.db.postgres :as psql]
-            [clojure.core.async :as a]
-            [vip.data-processor.errors :as errors]))
+            [clojure.core.async :as a]))
 
 (defn try-processing-fn
   "Attempt to run the processing function on the context. If the
@@ -42,19 +41,15 @@
   Runs the pipeline, returning the final context. An exception on the
   context will result in logging the exception."
   [pipeline initial-input]
-  (let [spec-version (atom nil)
-        errors-chan (a/chan 1024)
-        ctx {:input initial-input
+  (let [ctx {:input initial-input
              :skip-validations? false
              :warnings {}
              :errors {}
              :critical {}
              :fatal {}
-             :spec-version spec-version
-             :errors-chan errors-chan
+             :spec-version (atom nil)
+             :errors-chan (a/chan 1024)
              :pipeline pipeline}
-        _ (add-watch spec-version :route-errors
-                     (errors/add-watch-fn errors-chan))
         result (run-pipeline ctx)]
     (log/info (pr-str (select-keys result [:import-id :public-id :db :xml-output-file])))
     (log/debug (pr-str (select-keys result [:spec-version :fatal :critical])))

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -45,6 +45,7 @@
   (let [spec-version (atom nil)
         errors-chan (a/chan 1024)
         ctx {:input initial-input
+             :skip-validations? false
              :warnings {}
              :errors {}
              :critical {}

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -15,7 +15,8 @@
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.db.translations.transformer :as v5-1-transformers]
-            [vip.data-processor.errors :as errors]))
+            [vip.data-processor.errors :as errors]
+            [vip.data-processor.errors.process :as process]))
 
 (defn csv-filenames [data-specs]
   (set (map :filename data-specs)))
@@ -173,10 +174,12 @@
 
 (def version-pipelines
   {"3.0" [sqlite/attach-sqlite-db
+          process/process-v3-validations
           (csv-files/validate-dependencies csv-files/v3-0-file-dependencies)
           load-csvs]
    "5.1" (concat [(fn [ctx] (assoc ctx :tables postgres/v5-1-tables))
                   (fn [ctx] (assoc ctx :ltree-index 0))
+                  process/process-v5-validations
                   load-csvs]
                  v5-1-transformers/transformers
                  tree-xml/pipeline)})

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -8,7 +8,8 @@
             [vip.data-processor.errors :as errors]))
 
 (defn read-edn-sqs-message [ctx]
-  (assoc ctx :input (edn/read-string (get-in ctx [:input :body]))))
+  (let [message (edn/read-string (get-in ctx [:input :body]))]
+    (assoc ctx :input message :skip-validations? (get message :skip-validations false))))
 
 (defn assert-filename [ctx]
   (if-let [filename (get-in ctx [:input :filename])]

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -9,7 +9,8 @@
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.v5 :as v5-validations]
             [vip.data-processor.validation.xml.v5 :as xml.v5]
-            [vip.data-processor.errors :as errors]))
+            [vip.data-processor.errors :as errors]
+            [vip.data-processor.errors.process :as process]))
 
 (def address-elements
   #{"address"
@@ -253,8 +254,10 @@
 
 (def version-pipelines
   {"3.0" [sqlite/attach-sqlite-db
+          process/process-v3-validations
           load-xml]
-   "5.1" [load-xml-ltree
+   "5.1" [process/process-v5-validations
+          load-xml-ltree
           xml.v5/load-xml-street-segments
           set-input-as-xml-output-file]})
 

--- a/test/vip/data_processor/db/statistics_test.clj
+++ b/test/vip/data_processor/db/statistics_test.clj
@@ -2,19 +2,6 @@
   (:require [clojure.test :refer :all]
             [vip.data-processor.db.statistics :refer :all]))
 
-(deftest error-count-test
-  (testing "reports appropriate total numbers for our one error format"
-    (let [table-name :contests
-          ctx {:warnings {table-name {:global {:missing-header ["Header missing"]
-                                               :too-long ["Table seems way too long"]}}}
-               :errors {table-name {3 {:bad-names [{"Charleeee" "Too many E's"}
-                                                   {"" "Too short"}
-                                                   {"Christopher" "Already taken"}]}}}
-               :critical {table-name {4 {:just-some-more [1 2 3 4]}}}
-               :fatal {:this-one-doesnt-have-that-table
-                       {:global {:not-there ["So it will contribute 0 to the count"]}}}}]
-      (is (= 9 (error-count table-name ctx))))))
-
 (deftest complete-test
   (testing "rows less errors gives the success percentage"
     (let [rows 400 errors 24]

--- a/test/vip/data_processor/output/tree_xml_postgres_test.clj
+++ b/test/vip/data_processor/output/tree_xml_postgres_test.clj
@@ -8,6 +8,7 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
+(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres pipeline-test
   (let [import-id (-> postgres/results

--- a/test/vip/data_processor/test_helpers.clj
+++ b/test/vip/data_processor/test_helpers.clj
@@ -62,6 +62,7 @@
                                 psql/xml-tree-values
                                 psql/election_approvals
                                 psql/statistics
+                                psql/v5-statistics
                                 psql/validations
                                 psql/results]))
       (reset! setup-postgres-has-run true)))


### PR DESCRIPTION
The calculation of feed statistics was broken in two ways.

For 3.0 feeds, the code to calculate statistics was never updated after validation errors were no longer stored on the processing context. Now that they're placed in the database as processing occurs, the calculation needed to happen by counting rows in the database, not values in a map.

For _all_ feeds, it was possible that stats would be calculated _before_ validation errors were all inserted into the database. (Concurrency!) Now we wait on all validations to finish being inserted before calculating. We achieved this by running `batch-process` on the `errors-chan` for the processing context of each run (instead of mixing them in to a single channel which had `batch-process` taking care of it). Then we added a `wrapup-f` for those individual `batch-process`es to calculate the stats for that run. Since that won't get triggered until `errors-chan` is closed and all validations have been inserted, we won't miss any.

☘ This has been deployed to production already due to its urgency, but we can always update. ☘