### PR TITLE
Scope IDREFS query to current feed only

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                                                               org.slf4j/slf4j-simple
                                                               org.slf4j/slf4j-api]]
                  [org.clojure/core.async "0.2.391"]
-                 [democracyworks/utility-works "0.1.1"]
+                 [democracyworks/utility-works "0.1.2"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
                  [turbovote.resource-config "0.2.0"]
                  [joplin.jdbc "0.3.6"

--- a/src/vip/data_processor/validation/v5/id.clj
+++ b/src/vip/data_processor/validation/v5/id.clj
@@ -71,7 +71,8 @@
                   UNNEST(string_to_array(value, ' ')) AS value,
                   parent_with_id, simple_path
              FROM xml_tree_values
-            WHERE simple_path = ?)
+            WHERE simple_path = ?
+              and results_id = ?)
      SELECT referer.path, referer.value
        FROM referer
        LEFT JOIN (SELECT value
@@ -79,10 +80,8 @@
                    WHERE results_id = ?
                      AND simple_path ~ '*{2}.id') referent
               ON referer.value = referent.value
-           WHERE referer.results_id = ?
-             AND referer.simple_path = ?
-             AND referent.value IS NULL;"
-    [simple-path import-id import-id simple-path]]))
+           WHERE referent.value IS NULL;"
+    [simple-path import-id import-id]]))
 
 (defn validate-idref-references
   [{:keys [import-id spec-version] :as ctx}]


### PR DESCRIPTION
The more data you load, the more time it takes to validate ID references. This is easily resolved by limiting the size of the `referer` set  to that which we should _actually_ be checking against, instead of _everything_ in `xml_tree_values`.