### PR TITLE
Include the state's name as part of the filename

### DIFF
--- a/test/vip/data_processor/s3_test.clj
+++ b/test/vip/data_processor/s3_test.clj
@@ -4,13 +4,19 @@
 
 (deftest zip-filename*-test
   (testing "nicely formatted dates make nice filenames"
-    (is (= "vipfeed-51-2015-03-24.zip"
-           (zip-filename* "51" "2015-03-24"))))
+    (is (= "vipfeed-51-VA-2015-03-24.zip"
+           (zip-filename* "51" "VA" "2015-03-24"))))
 
   (testing "workably formatted dates make nice filenames"
-    (is (= "vipfeed-52-2015-03-27.zip"
-           (zip-filename* "52" "2015/03/27"))))
+    (is (= "vipfeed-52-FL-2015-03-27.zip"
+           (zip-filename* "52" "FL" "2015/03/27"))))
 
   (testing "poorly formatted dates use a workable filename"
-    (is (= "vipfeed-12345-.zip"
-           (zip-filename* "12345" nil)))))
+    (is (= "vipfeed-12345-North-Carolina-.zip"
+           (zip-filename* "12345" "North Carolina" nil))))
+
+  (testing "missing the fips and/or state doesn't break the world"
+    (is (= "vipfeed-12-YY-2016-11-08.zip"
+           (zip-filename* "12" nil  "2016-11-08")))
+    (is (= "vipfeed-XX-North-Carolina-2016-11-08.zip"
+           (zip-filename* nil " North Carolina " "2016-11-08")))))


### PR DESCRIPTION
The idea is that this should help catch state / fips code mismatches. Below, you see what ends up in the processed bucket when a Virginia feed decides to impersonate Florida (FIPS 12).

<img width="1274" alt="screen shot 2016-10-07 at 11 25 56 am" src="https://cloud.githubusercontent.com/assets/104658/19199395/15646a3a-8c81-11e6-93ea-7ad22bd3c5f3.png">
