### PR TITLE
Log reasons for stopping

### DIFF
--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -68,5 +68,4 @@
       (psql/fail-run import-id (with-out-str (stacktrace/print-throwable ex)))
       (log/error (with-out-str (stacktrace/print-stack-trace ex))))
 
-
     result))

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -55,11 +55,16 @@
              :pipeline pipeline}
         _ (add-watch spec-version :route-errors
                      (errors/add-watch-fn errors-chan))
-        result (run-pipeline ctx)]
+        result (run-pipeline ctx)
+        import-id (:import-id result)]
     (log/info (pr-str (select-keys result [:import-id :public-id :db :xml-output-file])))
-    (log/debug (pr-str (select-keys result [:spec-version :fatal :critical])))
+    (log/debug (pr-str (select-keys result [:spec-version :fatal :critical :stop])))
+
     (when-let [ex (:exception result)]
-      (psql/fail-run (:import-id result)
-                     (with-out-str (stacktrace/print-throwable ex)))
+      (psql/fail-run import-id (with-out-str (stacktrace/print-throwable ex)))
       (log/error (with-out-str (stacktrace/print-stack-trace ex))))
+
+    (when-let [stop (:stop result)]
+      (psql/fail-run import-id stop)
+      (log/error "Stopping run of" import-id "due to:" stop))
     result))

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -58,7 +58,6 @@
         result (run-pipeline ctx)
         import-id (:import-id result)]
     (log/info (pr-str (select-keys result [:import-id :public-id :db :xml-output-file])))
-    (log/debug (pr-str (select-keys result [:spec-version :fatal :critical :stop])))
 
     (when-let [stop (:stop result)]
       (psql/fail-run import-id nil)

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -60,11 +60,13 @@
     (log/info (pr-str (select-keys result [:import-id :public-id :db :xml-output-file])))
     (log/debug (pr-str (select-keys result [:spec-version :fatal :critical :stop])))
 
+    (when-let [stop (:stop result)]
+      (psql/fail-run import-id nil)
+      (log/error "Stopping run of" import-id "due to:" stop))
+
     (when-let [ex (:exception result)]
       (psql/fail-run import-id (with-out-str (stacktrace/print-throwable ex)))
       (log/error (with-out-str (stacktrace/print-stack-trace ex))))
 
-    (when-let [stop (:stop result)]
-      (psql/fail-run import-id stop)
-      (log/error "Stopping run of" import-id "due to:" stop))
+
     result))


### PR DESCRIPTION
There are (currently) four ways a pipeline can be stopped:
- no filename in the input
- an unsupported csv version
- an unsupported xml version
- an exception is thrown by some part of the pipeline

Previously when processing a feed and the pipeline was stopped, viewing the dashboard's feed list would make you think that the feed was still running. Now when we stop processing a feed, you'll see a message telling you processing has failed, which is much more meaningful than a misleading [throbber](https://en.wikipedia.org/wiki/Throbber).