### PR TITLE
Add `name` to polling locations CSV

### DIFF
--- a/resources/migrations/20161006-01-add-name-to-v5_1_polling_locations.down.sql
+++ b/resources/migrations/20161006-01-add-name-to-v5_1_polling_locations.down.sql
@@ -1,0 +1,1 @@
+alter table v5_1_polling_locations drop column if exists name;

--- a/resources/migrations/20161006-01-add-name-to-v5_1_polling_locations.up.sql
+++ b/resources/migrations/20161006-01-add-name-to-v5_1_polling_locations.up.sql
@@ -1,0 +1,1 @@
+alter table v5_1_polling_locations add column name text;

--- a/src/vip/data_processor/db/translations/v5_1/polling_locations.clj
+++ b/src/vip/data_processor/db/translations/v5_1/polling_locations.clj
@@ -20,11 +20,12 @@
              [(util/simple-value->ltree :address_line)
               (util/internationalized-text->ltree :directions)
               (util/internationalized-text->ltree :hours)
-              (util/simple-value->ltree :photo_uri)
               (util/simple-value->ltree :hours_open_id)
               (util/simple-value->ltree :is_drop_box)
               (util/simple-value->ltree :is_early_voting)
-              util/latlng->ltree])
+              util/latlng->ltree
+              (util/simple-value->ltree :name)
+              (util/simple-value->ltree :photo_uri)])
      {:path id-path
       :simple_path (util/path->simple-path id-path)
       :parent_with_id id-path

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -290,6 +290,7 @@
    {:filename "polling_location.txt"
     :table :polling-locations
     :columns [{:name "id"}
+              {:name "name"}
               {:name "address_line"}
               {:name "directions"}
               {:name "hours"}

--- a/test-resources/csv/5-1/full-good-run/polling_location.txt
+++ b/test-resources/csv/5-1/full-good-run/polling_location.txt
@@ -1,5 +1,5 @@
-address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source,id
-"ALBERMARLE HIGH SCHOOL 2775 Hydraulic Rd Charlottesville, VA 22901","Use back door",7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps,poll001
-Public Library Main St Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps,poll002
-Historic Society,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,,poll003
-Community Center,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,,poll004
+name,address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source,id
+"ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901","Use back door",7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps,poll001
+Public Library,10 W 14th Ave Pkwy Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps,poll002
+Historic Society,214 Preservation Ct,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,,poll003
+Community Center,1024 Town Sq,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,,poll004

--- a/test-resources/csv/5-1/polling_location.txt
+++ b/test-resources/csv/5-1/polling_location.txt
@@ -1,2 +1,2 @@
-address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source,id
-"ALBERMARLE HIGH SCHOOL 2775 Hydraulic Rd Charlottesville, VA 22901","Use back door",7am-8pm,www.picture.com,hours0001,false,true,38.0754627,78.5014875,Google Maps,pl81274
+name,address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source,id
+"ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901","Use back door",7am-8pm,www.picture.com,hours0001,false,true,38.0754627,78.5014875,Google Maps,pl81274

--- a/test/vip/data_processor/db/translations/v5_1/polling_locations_test.clj
+++ b/test/vip/data_processor/db/translations/v5_1/polling_locations_test.clj
@@ -26,15 +26,16 @@
       (are-xml-tree-values
        out-ctx
        "pl81274" "VipObject.0.PollingLocation.0.id"
-       "ALBERMARLE HIGH SCHOOL 2775 Hydraulic Rd Charlottesville, VA 22901" "VipObject.0.PollingLocation.0.AddressLine.0"
+       "2775 Hydraulic Rd Charlottesville, VA 22901" "VipObject.0.PollingLocation.0.AddressLine.0"
        "Use back door" "VipObject.0.PollingLocation.0.Directions.1.Text.0"
        "en" "VipObject.0.PollingLocation.0.Directions.1.Text.0.language"
        "7am-8pm" "VipObject.0.PollingLocation.0.Hours.2.Text.0"
        "en" "VipObject.0.PollingLocation.0.Hours.2.Text.0.language"
-       "www.picture.com" "VipObject.0.PollingLocation.0.PhotoUri.3"
-       "hours0001" "VipObject.0.PollingLocation.0.HoursOpenId.4"
-       "false" "VipObject.0.PollingLocation.0.IsDropBox.5"
-       "true" "VipObject.0.PollingLocation.0.IsEarlyVoting.6"
-       "38.0754627" "VipObject.0.PollingLocation.0.LatLng.7.Latitude.0"
-       "78.5014875" "VipObject.0.PollingLocation.0.LatLng.7.Longitude.1"
-       "Google Maps" "VipObject.0.PollingLocation.0.LatLng.7.Source.2"))))
+       "hours0001" "VipObject.0.PollingLocation.0.HoursOpenId.3"
+       "false" "VipObject.0.PollingLocation.0.IsDropBox.4"
+       "true" "VipObject.0.PollingLocation.0.IsEarlyVoting.5"
+       "38.0754627" "VipObject.0.PollingLocation.0.LatLng.6.Latitude.0"
+       "78.5014875" "VipObject.0.PollingLocation.0.LatLng.6.Longitude.1"
+       "Google Maps" "VipObject.0.PollingLocation.0.LatLng.6.Source.2"
+       "ALBERMARLE HIGH SCHOOL" "VipObject.0.PollingLocation.0.Name.7"
+       "www.picture.com" "VipObject.0.PollingLocation.0.PhotoUri.8"))))


### PR DESCRIPTION
`name` is an optional field as of v5.1.2 of the VIP specification. The
order of polling location elements is adjusted to match the order in the
XSD; this should make validations with `xmllint` a little smoother.