### PR TITLE
Catch another N{F,P}E possiblity

### DIFF
--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -39,14 +39,14 @@
 
 (defn format-fips [fips]
   (cond
-    (nil? fips) "XX"
+    (empty? fips) "XX"
     (< (count fips) 3) (format "%02d" (Integer/parseInt fips))
     (< (count fips) 5) (format "%05d" (Integer/parseInt fips))
     :else fips))
 
 (defn format-state
   [state]
-  (if (nil? state)
+  (if (empty? state)
     "YY"
     (clojure.string/replace (clojure.string/trim state) #"\s" "-")))
 

--- a/test/vip/data_processor/s3_test.clj
+++ b/test/vip/data_processor/s3_test.clj
@@ -17,6 +17,6 @@
 
   (testing "missing the fips and/or state doesn't break the world"
     (is (= "vipfeed-12-YY-2016-11-08.zip"
-           (zip-filename* "12" nil  "2016-11-08")))
+           (zip-filename* "12" nil "2016-11-08")))
     (is (= "vipfeed-XX-North-Carolina-2016-11-08.zip"
-           (zip-filename* nil " North Carolina " "2016-11-08")))))
+           (zip-filename* "" " North Carolina " "2016-11-08")))))


### PR DESCRIPTION
If a flat file contains an empty string for `vip_id`, it won't be null
in the database; it'll be an empty string. This covers both nil and empty
string cases.