### PR TITLE
Safer version without patch

### DIFF
--- a/src/vip/data_processor/util.clj
+++ b/src/vip/data_processor/util.clj
@@ -44,6 +44,9 @@
        (filter #(= filename (clojure.string/lower-case (.getName %))))
        first))
 
-(defn version-without-patch [version]
+(defn version-without-patch
+  "Strip the patch-level from `spec-version`. Assumes three or fewer version
+  numbers, e.g., \"5.1.2\" becomes \"5.1\"."
+  [version]
   (when-not (empty? version)
     (clojure.string/replace version #"^(\d+\.\d+)\.\d+$" "$1")))

--- a/src/vip/data_processor/util.clj
+++ b/src/vip/data_processor/util.clj
@@ -45,4 +45,5 @@
        first))
 
 (defn version-without-patch [version]
-  (clojure.string/replace version #"^(\d+\.\d+)\.\d+$" "$1"))
+  (when-not (empty? version)
+    (clojure.string/replace version #"^(\d+\.\d+)\.\d+$" "$1")))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -171,7 +171,7 @@
                        "source.txt is missing")))
 
 (defn unsupported-version [{:keys [spec-version] :as ctx}]
-  (assoc ctx :stop (str "Unsupported CSV version: " @spec-version)))
+  (assoc ctx :stop (str "Unsupported CSV version: " (pr-str @spec-version))))
 
 (def version-pipelines
   {"3.0" [sqlite/attach-sqlite-db

--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -246,7 +246,7 @@
                                     (util/version-without-patch version))))))))
 
 (defn unsupported-version [{:keys [spec-version] :as ctx}]
-  (assoc ctx :stop (str "Unsupported XML version: " @spec-version)))
+  (assoc ctx :stop (str "Unsupported XML version: " (pr-str @spec-version))))
 
 (defn set-input-as-xml-output-file
   [{:keys [input] :as ctx}]

--- a/test/vip/data_processor/util_test.clj
+++ b/test/vip/data_processor/util_test.clj
@@ -35,3 +35,17 @@
   (testing "when we run into a vector, that becomes part of the value"
     (is (= {[:to :flatten :or] [:not {:to "flatten"}]}
            (flatten-keys {:to {:flatten {:or [:not {:to "flatten"}]}}})))))
+
+(deftest version-without-patch-test
+  (testing "when there is no version, there is no patch level to remove"
+    (is (nil? (version-without-patch nil)))
+    (is (nil? (version-without-patch ""))))
+
+  (testing "with a two-part version number, we get our input back"
+    (is (= "5.1" (version-without-patch "5.1"))))
+
+  (testing "with a three-part version number, we strip the patch level"
+    (is (= "5.1" (version-without-patch "5.1.1"))))
+
+  (testing "going past three levels might surprise you"
+    (is (= "5.1.2.3" (version-without-patch "5.1.2.3")))))

--- a/test/vip/data_processor/util_test.clj
+++ b/test/vip/data_processor/util_test.clj
@@ -45,7 +45,4 @@
     (is (= "5.1" (version-without-patch "5.1"))))
 
   (testing "with a three-part version number, we strip the patch level"
-    (is (= "5.1" (version-without-patch "5.1.1"))))
-
-  (testing "going past three levels might surprise you"
-    (is (= "5.1.2.3" (version-without-patch "5.1.2.3")))))
+    (is (= "5.1" (version-without-patch "5.1.1")))))


### PR DESCRIPTION
Sometimes people make mistakes and a feed will be missing the spec-version. If that happens, we should stop processing because "no version" is an "unsupported version" instead of throwing an exception.