### PR TITLE
Bulk import ElectionAdministrations

### DIFF
--- a/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
+++ b/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
@@ -44,8 +44,7 @@
               import-id
               (election-administrations->ltree import-id idx-fn))]
     (if (seq rows)
-      (do
-        (-> ctx
+      (-> ctx
             (postgres/bulk-import postgres/xml-tree-values rows)
             (assoc :ltree-index (idx-fn)))
-        ctx))))
+      ctx)))

--- a/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
+++ b/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
@@ -40,12 +40,12 @@
 
 (defn transformer [{:keys [import-id ltree-index] :as ctx}]
   (let [idx-fn (util/index-generator ltree-index)
-        ltree-entries (util/prep-for-insertion
-                       import-id
-                       (election-administrations->ltree import-id idx-fn))]
-    (if (seq ltree-entries)
+        rows (util/prep-for-insertion
+              import-id
+              (election-administrations->ltree import-id idx-fn))]
+    (if (seq rows)
       (do
-        (korma/insert postgres/xml-tree-values
-          (korma/values ltree-entries))
-        (assoc ctx :ltree-index (idx-fn)))
-      ctx)))
+        (-> ctx
+            (postgres/bulk-import postgres/xml-tree-values rows)
+            (assoc :ltree-index (idx-fn)))
+        ctx))))


### PR DESCRIPTION
One feed had 10069 elements to insert using `korma.core/insert` and had
the connection close beneath it. This throws a lovely PGSQLException,
and processing halts. This fixes that, imitating our own
`db.translations.util/transformer` a bit more closely.