### PR TITLE
Consider city when checking street segment overlap

### DIFF
--- a/src/vip/data_processor/validation/db/v3_0/street_segment.clj
+++ b/src/vip/data_processor/validation/db/v3_0/street_segment.clj
@@ -21,6 +21,7 @@
                                            (korma/sqlfn ifnull :street_segments2.precinct_id "NULL_VALUE"))
                                      (not= (korma/sqlfn ifnull :street_segments.precinct_split_id "NULL_VALUE")
                                            (korma/sqlfn ifnull :street_segments2.precinct_split_id "NULL_VALUE")))
+                                 (= :street_segments.non_house_address_city :street_segments2.non_house_address_city)
                                  (= :street_segments.non_house_address_zip :street_segments2.non_house_address_zip)
                                  (or (= :street_segments.odd_even_both :street_segments2.odd_even_both)
                                      (= :street_segments.odd_even_both "both")

--- a/test-resources/csv/overlapping-street-segments/street_segment.txt
+++ b/test-resources/csv/overlapping-street-segments/street_segment.txt
@@ -17,3 +17,5 @@ id,start_house_number,end_house_number,odd_even_both,non_house_address_street_na
 26,150,250,even,SAME PRECINCT_ID IS OKAY,Beverly Hills,CA,90210,1
 27,100,200,even,IF ONE HAS NULL ODD_EVEN_BOTH,Beverly Hills,CA,90210,1
 28,140,140,,IF ONE HAS NULL ODD_EVEN_BOTH,Beverly Hills,CA,90210,2
+29,512,512,both,NON-OVERLAP DIFFERENT CITY,Beverly Hills,CA,90210,3
+30,512,512,both,NON-OVERLAP DIFFERENT CITY,Los Angeles,CA,90210,3

--- a/test/vip/data_processor/validation/db/v3_0/street_segment_test.clj
+++ b/test/vip/data_processor/validation/db/v3_0/street_segment_test.clj
@@ -32,7 +32,7 @@
       18 19
       20 21
       27 28)
-    (doseq [id [22 23 24 25 26]]
+    (doseq [id [22 23 24 25 26 29 30]]
       (is (nil? (contains-error?  errors
                                   {:severity :errors
                                    :scope :street-segments


### PR DESCRIPTION
We're already considering the city when checking for street segment overlaps in 5.1 feeds, but it didn't make into the 3.0 version of the validation. This fixes the bug described in [this Pivotal card]( https://www.pivotaltracker.com/story/show/131375753).