### PR TITLE
Add an index for Metis' 5.1 locality overview

### DIFF
--- a/resources/migrations/20161103-tighten-index-for-locality-overview.down.sql
+++ b/resources/migrations/20161103-tighten-index-for-locality-overview.down.sql
@@ -1,0 +1,1 @@
+drop index if exists xml_tree_values_results_value_simple_path_idx;

--- a/resources/migrations/20161103-tighten-index-for-locality-overview.up.sql
+++ b/resources/migrations/20161103-tighten-index-for-locality-overview.up.sql
@@ -1,0 +1,3 @@
+create index xml_tree_values_results_value_simple_path_idx
+on xml_tree_values (results_id, value, simple_path)
+where simple_path in ('VipObject.Precinct.LocalityId', 'VipObject.Locality.id', 'VipObject.Locality.Name');


### PR DESCRIPTION
Previously, we had an index like this`"xml_tree_values_result_simple_path_idx" btree (results_id, simple_path)`, but the [locality overview query](https://github.com/votinginfoproject/Metis/blob/master/pg/v5_1_queries.js#L6-L38) has a third join condition in `value`. This matches the join conditions and turns an index scan into an index _only_ scan; we saw query times drop from minutes to under 50ms.

(This won't replace `xml_tree_values_result_simple_path_idx` just yet, but I hope it does.)

```
                                                                                            QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=6487.60..6490.07 rows=990 width=72) (actual time=36.295..36.782 rows=496 loops=1)
   Sort Key: localities.name
   Sort Method: quicksort  Memory: 64kB
   CTE precincts
     ->  HashAggregate  (cost=6403.53..6403.66 rows=13 width=12) (actual time=11.569..12.106 rows=496 loops=1)
           Group Key: localities_1.value
           ->  Nested Loop Left Join  (cost=1.10..6383.28 rows=4051 width=12) (actual time=0.126..10.781 rows=496 loops=1)
                 ->  Nested Loop Left Join  (cost=0.68..2630.55 rows=599 width=10) (actual time=0.085..2.020 rows=496 loops=1)
                       ->  Index Scan using results_public_id_key on results r  (cost=0.27..8.29 rows=1 width=4) (actual time=0.016..0.017 rows=1 loops=1)
                             Index Cond: ((public_id)::text = '2016-11-08-federal-Maine-870'::text)
                       ->  Index Only Scan using xtv_results_value_simple_idx on xml_tree_values localities_1  (cost=0.41..2607.29 rows=1498 width=14) (actual time=0.057..0.998 rows=496 loops=1)
                             Index Cond: ((results_id = r.id) AND (simple_path = 'VipObject.Locality.id'::ltree))
                             Heap Fetches: 496
                 ->  Index Only Scan using xtv_results_value_simple_idx on xml_tree_values precincts_1  (cost=0.41..6.25 rows=1 width=14) (actual time=0.012..0.013 rows=1 loops=496)
                       Index Cond: ((results_id = r.id) AND (value = localities_1.value) AND (simple_path = 'VipObject.Precinct.LocalityId'::ltree))
                       Heap Fetches: 491
   CTE localities
     ->  Function Scan on crosstab ct  (cost=0.00..10.00 rows=995 width=96) (actual time=18.485..19.013 rows=496 loops=1)
           Filter: (id IS NOT NULL)
   ->  Hash Left Join  (cost=0.42..24.68 rows=990 width=72) (actual time=32.216..34.917 rows=496 loops=1)
         Hash Cond: (localities.id = precincts.locality_id)
         ->  CTE Scan on localities  (cost=0.00..19.90 rows=990 width=64) (actual time=18.490..20.118 rows=496 loops=1)
               Filter: (id IS NOT NULL)
         ->  Hash  (cost=0.26..0.26 rows=13 width=40) (actual time=13.715..13.715 rows=496 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 26kB
               ->  CTE Scan on precincts  (cost=0.00..0.26 rows=13 width=40) (actual time=11.572..13.180 rows=496 loops=1)
 Planning time: 5.486 ms
 Execution time: 37.705 ms
(28 rows)
```