### PR TITLE
Make the message key match the ctx key

### DIFF
--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -9,7 +9,7 @@
 
 (defn read-edn-sqs-message [ctx]
   (let [message (edn/read-string (get-in ctx [:input :body]))]
-    (assoc ctx :input message :skip-validations? (get message :skip-validations false))))
+    (assoc ctx :input message :skip-validations? (get message :skip-validations? false))))
 
 (defn assert-filename [ctx]
   (if-let [filename (get-in ctx [:input :filename])]


### PR DESCRIPTION
I got the names out of sync, but now they're the same.