### PR TITLE
Pre-election work

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -24,6 +24,7 @@
    zip/extracted-contents
    t/remove-invalid-extensions
    t/xml-csv-branch
+   psql/analyze-xtv
    psql/store-spec-version
    psql/store-public-id
    psql/store-election-id

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                                                               org.slf4j/slf4j-simple
                                                               org.slf4j/slf4j-api]]
                  [org.clojure/core.async "0.2.391"]
-                 [democracyworks/utility-works "0.1.2"]
+                 [democracyworks/utility-fns "0.2.0"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
                  [turbovote.resource-config "0.2.0"]
                  [joplin.jdbc "0.3.6"

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -57,6 +57,7 @@
   (concat download-pipeline
           [t/remove-invalid-extensions
            t/xml-csv-branch
+           psql/analyze-xtv
            psql/store-spec-version
            psql/store-public-id
            psql/store-election-id

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -4,7 +4,6 @@
             [com.climate.newrelic.trace :refer [defn-traced]]
             [squishy.core :as sqs]
             [turbovote.resource-config :refer [config]]
-            [utility-works.async :as util-async]
             [korma.core :as korma]
             [vip.data-processor.cleanup :as cleanup]
             [vip.data-processor.errors :as errors]

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -221,6 +221,13 @@
       (korma/where {:id import-id})))
   ctx)
 
+(defn analyze-xtv [ctx]
+  (log/info "Analyzing xml_tree_values")
+  (korma/exec-raw
+   (:conn xml-tree-values)
+   ["analyze xml_tree_values"])
+  ctx)
+
 (defn complete-run [ctx]
   (let [id (:import-id ctx)
         filename (:generated-xml-filename ctx)]

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -101,11 +101,20 @@
                     " ~ '" path "'"))))
 
 (defn find-value-for-simple-path [import-id simple-path]
-  (-> xml-tree-values
-      (korma/select
+  (-> (korma/select xml-tree-values
         (korma/fields :value)
         (korma/where {:results_id import-id
                       :simple_path (path->ltree simple-path)}))
+      first
+      :value))
+
+(defn find-single-xml-tree-value [results-id path]
+  (-> (korma/select xml-tree-values
+        (korma/fields :value)
+        (korma/where {:results_id results-id})
+        (korma/where (ltree-match xml-tree-values
+                                  :path
+                                  path)))
       first
       :value))
 
@@ -149,26 +158,16 @@
      :state state
      :import-id import-id}))
 
-(defn find-single-xml-tree-value [results-id path]
-  (-> (korma/select xml-tree-values
-        (korma/fields :value)
-        (korma/where {:results_id results-id})
-        (korma/where (ltree-match xml-tree-values
-                                  :path
-                                  path)))
-      first
-      :value))
-
 (defn get-xml-tree-public-id-data [{:keys [import-id] :as ctx}]
-  (let [state (find-single-xml-tree-value
+  (let [state (find-value-for-simple-path
                import-id
-               "VipObject.0.State.*{1}.Name.*{1}")
-        date (find-single-xml-tree-value
+               "VipObject.State.Name")
+        date (find-value-for-simple-path
               import-id
-              "VipObject.0.Election.*{1}.Date.*{1}")
-        election-type (find-single-xml-tree-value
+              "VipObject.Election.Date")
+        election-type (find-value-for-simple-path
                        import-id
-                       "VipObject.0.Election.*{1}.ElectionType.*{1}.Text.*{1}")]
+                       "VipObject.Election.ElectionType.Text")]
     {:date date
      :election-type election-type
      :state state

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -181,15 +181,18 @@
 
 (defn generate-public-id [ctx]
   (let [{:keys [date election-type state import-id]} (get-public-id-data ctx)]
+    (log/info "Building public id")
     (build-public-id date election-type state import-id)))
 
 (defn generate-election-id [ctx]
+  (log/info "Building election id")
   (let [{:keys [date election-type state]} (get-public-id-data ctx)]
     (build-election-id date election-type state)))
 
 (defn store-public-id [ctx]
   (let [id (:import-id ctx)
         public-id (generate-public-id ctx)]
+    (log/info "Storing public id")
     (korma/update results
                   (korma/set-fields {:public_id public-id})
                   (korma/where {:id id}))
@@ -206,6 +209,7 @@
 (defn store-election-id [ctx]
   (if-let [election-id (generate-election-id ctx)]
     (let [id (:import-id ctx)]
+      (log/info "Storing election id")
       (save-election-id! election-id)
       (korma/update results
                     (korma/set-fields {:election_id election-id})
@@ -215,6 +219,7 @@
 
 (defn store-spec-version [{:keys [spec-version import-id] :as ctx}]
   (when @spec-version
+    (log/info "Storing spec-verion," @spec-version)
     (korma/update results
       (korma/set-fields {:spec_version @spec-version})
       (korma/where {:id import-id})))

--- a/src/vip/data_processor/db/translations/v5_1/street_segments.clj
+++ b/src/vip/data_processor/db/translations/v5_1/street_segments.clj
@@ -1,11 +1,14 @@
 (ns vip.data-processor.db.translations.v5-1.street-segments
-  (:require [korma.core :as korma]
-            [vip.data-processor.db.postgres :as postgres]
+  (:require [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.db.translations.util :as util]))
 
-(defn row-fn [import-id]
-  (korma/select (postgres/v5-1-tables :street-segments)
-    (korma/where {:results_id import-id})))
+(def row-fn
+  (postgres/lazy-select-fn
+   10000
+   (fn [import-id]
+     (str "SELECT * FROM v5_1_street_segments"
+          " WHERE results_id = "
+          import-id))))
 
 (defn base-path [index]
   (str "VipObject.0.StreetSegment." index))

--- a/src/vip/data_processor/errors.clj
+++ b/src/vip/data_processor/errors.clj
@@ -1,5 +1,6 @@
 (ns vip.data-processor.errors
-  (:require [clojure.core.async :as a]))
+  (:require [clojure.core.async :as a]
+            [clojure.tools.logging :as log]))
 
 (defrecord ValidationError [ctx severity scope
                             identifier error-type error-value])
@@ -17,6 +18,17 @@
   (a/close! errors-chan)
   ctx)
 
-(defn await-statistics [ctx]
-  (a/<!! (:processing-chan ctx))
+(defn await-statistics
+  "The process validations functions use batch-process from
+  utility-fns.async and puts the resulting core.async channel on the
+  context at :processing-chan. Once the last validations have been
+  saved, the feed's statistics will be calculated on the thread that
+  coordinates the work. Thus, here we wait on the core.async channel
+  and we'll be sure the stats are done."
+  [ctx]
+  (log/info "Awaiting statistics")
+  (-> ctx
+      :processing-chan
+      a/<!!)
+  (log/info "Statistics complete")
   ctx)

--- a/src/vip/data_processor/errors/process.clj
+++ b/src/vip/data_processor/errors/process.clj
@@ -1,5 +1,5 @@
 (ns vip.data-processor.errors.process
-  (:require [utility-works.async :as util-async]
+  (:require [utility-fns.async :as util-async]
             [vip.data-processor.db.postgres :as psql]
             [vip.data-processor.db.statistics :as stats]
             [vip.data-processor.db.tree-statistics :as tree-stats]))
@@ -12,9 +12,10 @@
                             ctx
                             psql/validations
                             (map psql/validation-value errors)))
-                         500
-                         5000
-                         (partial stats/store-stats ctx))]
+                         {:batch-size 10000
+                          :timeout 5000
+                          :pool-size 30
+                          :wrapup-f (partial stats/store-stats ctx)})]
     (assoc ctx :processing-chan processing-chan)))
 
 (defn process-v5-validations [{:keys [errors-chan] :as ctx}]
@@ -25,7 +26,8 @@
                             ctx
                             psql/xml-tree-validations
                             (map psql/xml-tree-validation-value errors)))
-                         500
-                         5000
-                         (partial tree-stats/store-tree-stats ctx))]
+                         {:batch-size 10000
+                          :timeout 5000
+                          :pool-size 30
+                          :wrapup-f (partial tree-stats/store-tree-stats ctx)})]
     (assoc ctx :processing-chan processing-chan)))

--- a/src/vip/data_processor/output/tree_xml.clj
+++ b/src/vip/data_processor/output/tree_xml.clj
@@ -5,7 +5,8 @@
             [vip.data-processor.output.xml-helpers :refer [create-xml-file]]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.db.util :as db.util]
-            [clojure.tools.logging :as log])
+            [clojure.tools.logging :as log]
+            [vip.data-processor.db.postgres :as psql])
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [org.apache.commons.lang StringEscapeUtils]))
@@ -96,10 +97,7 @@
           inside-open-tag (atom false)
           values-written (atom 0)]
       (doseq [{:keys [path value simple_path] :as row}
-              (db.util/lazy-select 100000
-                                   postgres/xml-tree-values
-                                   (korma/where {:results_id import-id})
-                                   (korma/order :insert_counter :ASC))]
+              (psql/lazy-select-xml-tree-values 100000 import-id)]
         (swap! values-written inc)
         (when (= (mod @values-written 100000) 0)
           (log/info "Wrote" @values-written "values"))

--- a/src/vip/data_processor/pipeline.clj
+++ b/src/vip/data_processor/pipeline.clj
@@ -43,10 +43,6 @@
   [pipeline initial-input]
   (let [ctx {:input initial-input
              :skip-validations? false
-             :warnings {}
-             :errors {}
-             :critical {}
-             :fatal {}
              :spec-version (atom nil)
              :errors-chan (a/chan 1024)
              :pipeline pipeline}

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -9,7 +9,7 @@
 
 (defn read-edn-sqs-message [ctx]
   (let [message (edn/read-string (get-in ctx [:input :body]))]
-    (assoc ctx :input message :skip-validations? (get message :skip-validations false))))
+    (assoc ctx :input message :skip-validations? (get message :skip-validations? false))))
 
 (defn assert-filename [ctx]
   (if-let [filename (get-in ctx [:input :filename])]

--- a/test/vip/data_processor/output/tree_xml_postgres_test.clj
+++ b/test/vip/data_processor/output/tree_xml_postgres_test.clj
@@ -8,7 +8,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres pipeline-test
   (let [import-id (-> postgres/results

--- a/test/vip/data_processor/test_helpers.clj
+++ b/test/vip/data_processor/test_helpers.clj
@@ -68,13 +68,6 @@
       (reset! setup-postgres-has-run true)))
   (f))
 
-(defn with-clean-postgres
-  "An :each test fixture to clear out tables in the test database. "
-  [f]
-  (doseq [table psql-tables]
-    (korma/delete table))
-  (f))
-
 (defmacro are-xml-tree-values
   [out-ctx & args]
   `(are [value# path#] (= value#

--- a/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-types-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/candidate_test.clj
+++ b/test/vip/data_processor/validation/v5/candidate_test.clj
@@ -8,7 +8,6 @@
              [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-pre-election-statuses-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/district_type_test.clj
+++ b/test/vip/data_processor/validation/v5/district_type_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-test
   (testing "Locality elements"

--- a/test/vip/data_processor/validation/v5/election_administration_test.clj
+++ b/test/vip/data_processor/validation/v5/election_administration_test.clj
@@ -8,7 +8,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-departments-test
   (testing "missing Department element is an error"

--- a/test/vip/data_processor/validation/v5/election_test.clj
+++ b/test/vip/data_processor/validation/v5/election_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-one-election-test
   (testing "more than one Election element is a fatal error"

--- a/test/vip/data_processor/validation/v5/electoral_district_test.clj
+++ b/test/vip/data_processor/validation/v5/electoral_district_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
   (testing "missing Name is an error"

--- a/test/vip/data_processor/validation/v5/external_identifiers_test.clj
+++ b/test/vip/data_processor/validation/v5/external_identifiers_test.clj
@@ -8,7 +8,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-types-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/hours_open_test.clj
+++ b/test/vip/data_processor/validation/v5/hours_open_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-times-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/id_test.clj
+++ b/test/vip/data_processor/validation/v5/id_test.clj
@@ -8,7 +8,6 @@
              [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres id-uniqueness-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/internationalized_text_test.clj
+++ b/test/vip/data_processor/validation/v5/internationalized_text_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-texts-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/locality_test.clj
+++ b/test/vip/data_processor/validation/v5/locality_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/office_test.clj
+++ b/test/vip/data_processor/validation/v5/office_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/ordered_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ordered_contest_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-contest-ids-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/party_selection_test.clj
+++ b/test/vip/data_processor/validation/v5/party_selection_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-party-ids-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/party_test.clj
+++ b/test/vip/data_processor/validation/v5/party_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-colors-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/polling_location_test.clj
+++ b/test/vip/data_processor/validation/v5/polling_location_test.clj
@@ -7,7 +7,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-address-lines-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/precinct_test.clj
+++ b/test/vip/data_processor/validation/v5/precinct_test.clj
@@ -8,7 +8,6 @@
              [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/retention_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/retention_contest_test.clj
@@ -8,7 +8,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-candidate-ids-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/source_test.clj
+++ b/test/vip/data_processor/validation/v5/source_test.clj
@@ -8,7 +8,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-one-source-test
   (testing "more than one Source element is a fatal error"

--- a/test/vip/data_processor/validation/v5/state_test.clj
+++ b/test/vip/data_processor/validation/v5/state_test.clj
@@ -8,7 +8,6 @@
              [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-names-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5/street_segment_test.clj
+++ b/test/vip/data_processor/validation/v5/street_segment_test.clj
@@ -8,7 +8,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres validate-no-missing-odd-even-both
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/v5_test.clj
+++ b/test/vip/data_processor/validation/v5_test.clj
@@ -10,7 +10,6 @@
              [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres full-good-v5-test
   (let [errors-chan (a/chan 100)

--- a/test/vip/data_processor/validation/xml_with_postgres_test.clj
+++ b/test/vip/data_processor/validation/xml_with_postgres_test.clj
@@ -10,7 +10,6 @@
             [clojure.core.async :as a]))
 
 (use-fixtures :once setup-postgres)
-(use-fixtures :each with-clean-postgres)
 
 (deftest ^:postgres load-xml-ltree-test
   (testing "imports xml values into postgres"


### PR DESCRIPTION
This represents the work done between `origin/master` and what's currently deployed in staging and production (modulo a couple things, noted below). The commits here have been slightly reworked for clarity.

Differences: With the approval and release of 0.2.0 of utility-fns (née utility-works), data-processor has been updated to use that instead of the old utility-works 0.1.3-SNAPSHOT. The warnings/errors/critical/failure keys have been removed from the initial context. A couple of unused requires have been excised.