### PR TITLE
5 1 source and election

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -30,7 +30,8 @@
    psql/store-election-id
    data-processor/add-validations
    errors/close-errors-chan
-   errors/await-statistics])
+   errors/await-statistics
+   psql/refresh-materialized-views])
 
 (defn -main [filename]
   (psql/initialize)

--- a/resources/migrations/20161130-01-create-dashboard-schema.down.sql
+++ b/resources/migrations/20161130-01-create-dashboard-schema.down.sql
@@ -1,0 +1,1 @@
+drop schema dashboard;

--- a/resources/migrations/20161130-01-create-dashboard-schema.down.sql
+++ b/resources/migrations/20161130-01-create-dashboard-schema.down.sql
@@ -1,1 +1,1 @@
-drop schema dashboard;
+drop schema v5_dashboard;

--- a/resources/migrations/20161130-01-create-dashboard-schema.up.sql
+++ b/resources/migrations/20161130-01-create-dashboard-schema.up.sql
@@ -1,1 +1,1 @@
-create schema dashboard;
+create schema v5_dashboard;

--- a/resources/migrations/20161130-01-create-dashboard-schema.up.sql
+++ b/resources/migrations/20161130-01-create-dashboard-schema.up.sql
@@ -1,0 +1,1 @@
+create schema dashboard;

--- a/resources/migrations/20161130-02-dashboard-i18n.down.sql
+++ b/resources/migrations/20161130-02-dashboard-i18n.down.sql
@@ -1,0 +1,3 @@
+drop materialized view dashboard.i18n;
+drop index xtv_i18n_paths_idx;
+drop index xtv_i18n_text_idx;

--- a/resources/migrations/20161130-02-dashboard-i18n.down.sql
+++ b/resources/migrations/20161130-02-dashboard-i18n.down.sql
@@ -1,3 +1,3 @@
-drop materialized view dashboard.i18n;
+drop materialized view v5_dashboard.i18n;
 drop index xtv_i18n_paths_idx;
 drop index xtv_i18n_text_idx;

--- a/resources/migrations/20161130-02-dashboard-i18n.up.sql
+++ b/resources/migrations/20161130-02-dashboard-i18n.up.sql
@@ -1,0 +1,24 @@
+create index xtv_i18n_paths_idx
+on xml_tree_values (results_id, path)
+where simple_path ~ 'VipObject.*.Text.language'
+  and value = 'en';
+
+create index xtv_i18n_text_idx
+on xml_tree_values (results_id, path, value)
+where simple_path ~ 'VipObject.*.Text';
+
+create materialized view dashboard.i18n (results_id, simple_path, value) as
+with i18n as
+  (select results_id, subpath(path, 0, nlevel(path) - 1) as path
+   from xml_tree_values
+   where simple_path ~ 'VipObject.*.Text.language'
+     and value = 'en'
+   order by 1)
+select
+  distinct on (xtv.results_id, xtv.simple_path)
+  xtv.results_id, xtv.simple_path, xtv.value
+from i18n
+left join xml_tree_values xtv
+       on i18n.results_id = xtv.results_id
+      and xtv.simple_path ~ '*.Text'
+      and  i18n.path <@ xtv.path;

--- a/resources/migrations/20161130-02-dashboard-i18n.up.sql
+++ b/resources/migrations/20161130-02-dashboard-i18n.up.sql
@@ -7,7 +7,7 @@ create index xtv_i18n_text_idx
 on xml_tree_values (results_id, path, value)
 where simple_path ~ 'VipObject.*.Text';
 
-create materialized view dashboard.i18n (results_id, simple_path, value) as
+create materialized view v5_dashboard.i18n (results_id, simple_path, value) as
 with i18n as
   (select results_id, subpath(path, 0, nlevel(path) - 1) as path
    from xml_tree_values

--- a/resources/migrations/20161130-03-dashboard-sources.down.sql
+++ b/resources/migrations/20161130-03-dashboard-sources.down.sql
@@ -1,1 +1,1 @@
-drop materialized view dashboard.sources;
+drop materialized view v5_dashboard.sources;

--- a/resources/migrations/20161130-03-dashboard-sources.down.sql
+++ b/resources/migrations/20161130-03-dashboard-sources.down.sql
@@ -1,0 +1,1 @@
+drop materialized view dashboard.sources;

--- a/resources/migrations/20161130-03-dashboard-sources.up.sql
+++ b/resources/migrations/20161130-03-dashboard-sources.up.sql
@@ -1,4 +1,4 @@
-create materialized view dashboard.sources
+create materialized view v5_dashboard.sources
 (results_id, id, vip_id, name, datetime,
  description, organization_uri, terms_of_use_uri)
 as

--- a/resources/migrations/20161130-03-dashboard-sources.up.sql
+++ b/resources/migrations/20161130-03-dashboard-sources.up.sql
@@ -6,7 +6,7 @@ with
   texts as (
     select *
     from crosstab('select results_id, element_type(simple_path) as element, value
-                  from i18n_text t
+                  from v5_dashboard.i18n t
                   where t.simple_path ~
                       ''VipObject.Source.Description.Text''
                   order by 1',

--- a/resources/migrations/20161130-03-dashboard-sources.up.sql
+++ b/resources/migrations/20161130-03-dashboard-sources.up.sql
@@ -1,0 +1,37 @@
+create materialized view dashboard.sources
+(results_id, id, vip_id, name, datetime,
+ description, organization_uri, terms_of_use_uri)
+as
+with
+  texts as (
+    select *
+    from crosstab('select results_id, element_type(simple_path) as element, value
+                  from i18n_text t
+                  where t.simple_path ~
+                      ''VipObject.Source.Description.Text''
+                  order by 1',
+                  'select ''Description''')
+    as ct(results_id int, description text)),
+
+  source as (
+    select *
+    from crosstab('select
+                     results_id,
+                     element_type(simple_path) as element,
+                     value
+                   from xml_tree_values
+                   where simple_path ~ ''VipObject.Source.!Text''
+                   order by 1',
+                  'select unnest(ARRAY[''Name'',
+                                       ''DateTime'',
+                                       ''OrganizationUri'',
+                                       ''TermsOfUseUri'',
+                                       ''VipId'',
+                                       ''id''])')
+    as ct(results_id int, name text, datetime text, organization_uri text,
+          terms_of_use_uri text, vip_id text, id text))
+select
+  s.results_id, s.id, s.vip_id, s.name, s.datetime,
+  t.description, s.organization_uri, s.terms_of_use_uri
+from source s
+left join texts t on t.results_id = s.results_id;

--- a/resources/migrations/20161130-04-dashboard-election.down.sql
+++ b/resources/migrations/20161130-04-dashboard-election.down.sql
@@ -1,0 +1,1 @@
+drop materialized view dashboard.elections;

--- a/resources/migrations/20161130-04-dashboard-election.down.sql
+++ b/resources/migrations/20161130-04-dashboard-election.down.sql
@@ -1,1 +1,1 @@
-drop materialized view dashboard.elections;
+drop materialized view v5_dashboard.elections;

--- a/resources/migrations/20161130-04-dashboard-election.up.sql
+++ b/resources/migrations/20161130-04-dashboard-election.up.sql
@@ -1,0 +1,49 @@
+create materialized view dashboard.elections
+  (results_id, id, date, election_type, is_statewide, name, registration_info,
+   absentee_ballot_info, results_uri, polling_hours, hours_open_id,
+   has_election_day_registration, registration_deadline, absentee_request_deadline)
+as
+with
+  texts as (
+    select *
+    from crosstab('select results_id, element_type(simple_path) as element, value
+                  from i18n_text
+                  where i18n_text.simple_path ~
+                      ''VipObject.Election.AbsenteeBallotInfo|ElectionType|Name|RegistrationInfo.Text''
+                  order by 1',
+                  'select unnest(ARRAY[''AbsenteeBallotInfo'',
+                                       ''ElectionType'',
+                                       ''Name'',
+                                       ''RegistrationInfo''])')
+    as ct(results_id int, absentee_ballot_info text, election_type text,
+          name text, registration_info text)),
+  election as (
+    select *
+    from crosstab('select
+                     xtv.results_id,
+                     element_type(xtv.simple_path) as element,
+                     xtv.value as value
+                   from xml_tree_values xtv
+                   where xtv.simple_path ~ ''VipObject.Election.*''
+                   order by 1',
+                  'select unnest(ARRAY[''AbsenteeRequestDeadline'',
+                                       ''Date'',
+                                       ''HasElectionDayRegistration'',
+                                       ''IsStatewide'',
+                                       ''PollingHours'',
+                                       ''HoursOpenId'',
+                                       ''RegistrationDeadline'',
+                                       ''ResultsUri'',
+                                       ''StateId'',
+                                       ''id''])')
+    as ct(results_id int, absentee_request_deadline text, date text,
+          has_election_day_registration text, is_statewide text,
+          polling_hours text, hours_open_id text, registration_deadline text,
+          results_uri text, state_id text, id text))
+select
+  e.results_id, e.id, e.date, t.election_type, e.is_statewide, t.name,
+  t.registration_info, t.absentee_ballot_info, e.results_uri, e.polling_hours,
+  e.hours_open_id, e.has_election_day_registration, e.registration_deadline,
+  e.absentee_request_deadline
+from election e
+left join texts t on t.results_id = e.results_id;

--- a/resources/migrations/20161130-04-dashboard-election.up.sql
+++ b/resources/migrations/20161130-04-dashboard-election.up.sql
@@ -8,7 +8,7 @@ with
     select *
     from crosstab('select results_id, element_type(simple_path) as element, value
                   from v5_dashboard.i18n
-                  where i18n_text.simple_path ~
+                  where simple_path ~
                       ''VipObject.Election.AbsenteeBallotInfo|ElectionType|Name|RegistrationInfo.Text''
                   order by 1',
                   'select unnest(ARRAY[''AbsenteeBallotInfo'',

--- a/resources/migrations/20161130-04-dashboard-election.up.sql
+++ b/resources/migrations/20161130-04-dashboard-election.up.sql
@@ -7,7 +7,7 @@ with
   texts as (
     select *
     from crosstab('select results_id, element_type(simple_path) as element, value
-                  from i18n_text
+                  from v5_dashboard.i18n
                   where i18n_text.simple_path ~
                       ''VipObject.Election.AbsenteeBallotInfo|ElectionType|Name|RegistrationInfo.Text''
                   order by 1',

--- a/resources/migrations/20161130-04-dashboard-election.up.sql
+++ b/resources/migrations/20161130-04-dashboard-election.up.sql
@@ -1,4 +1,4 @@
-create materialized view dashboard.elections
+create materialized view v5_dashboard.elections
   (results_id, id, date, election_type, is_statewide, name, registration_info,
    absentee_ballot_info, results_uri, polling_hours, hours_open_id,
    has_election_day_registration, registration_deadline, absentee_request_deadline)

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -64,6 +64,7 @@
            add-validations
            errors/close-errors-chan
            errors/await-statistics
+           psql/refresh-materialized-views
            s3/upload-to-s3
            cleanup/cleanup]))
 

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -235,7 +235,7 @@
 (defn refresh-materialized-views
   [ctx]
   (log/info "Refreshing materialized views")
-  (doseq [view ["dashboard.sources" "dashboard.elections"]]
+  (doseq [view ["v5_dashboard.sources" "v5_dashboard.elections"]]
     (korma/exec-raw
      (:conn xml-tree-values)
      [(str "refresh materialized view " view)]))

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -232,6 +232,15 @@
    ["analyze xml_tree_values"])
   ctx)
 
+(defn refresh-materialized-views
+  [ctx]
+  (log/info "Refreshing materialized views")
+  (doseq [view ["dashboard.sources" "dashboard.elections"]]
+    (korma/exec-raw
+     (:conn xml-tree-values)
+     [(str "refresh materialized view " view)]))
+  ctx)
+
 (defn complete-run [ctx]
   (let [id (:import-id ctx)
         filename (:generated-xml-filename ctx)]


### PR DESCRIPTION
In [this Pivotal card](https://www.pivotaltracker.com/story/show/128176637), we build a page that shows up the interesting parts of Source and Election elements. It doesn't feel right that working on the UI should require knowing how the intermediate representations of the data are formed, so this PR sets up a nice view to make things easier.

This creates a new schema, `v5_dashboard` that has a set of materialized views that will be refreshed once all validations have finished. Once we have the dashboard's queries pointing somewhere other than `xml_tree_values`, we can entertain aggressively dropping intermediate data (street segments, at least).

This is related to and blocks a [Metis PR](https://github.com/votinginfoproject/Metis/pull/345).
