### PR TITLE
Rename `parent_id` to something more useful

### DIFF
--- a/resources/migrations/20161222-rename-parent-id.down.sql
+++ b/resources/migrations/20161222-rename-parent-id.down.sql
@@ -1,0 +1,2 @@
+alter table v5_1_departments rename column election_administration_id to parent_id;
+alter table v5_1_voter_services rename column department_id to parent_id;

--- a/resources/migrations/20161222-rename-parent-id.up.sql
+++ b/resources/migrations/20161222-rename-parent-id.up.sql
@@ -1,0 +1,2 @@
+alter table v5_1_departments rename column parent_id to election_administration_id;
+alter table v5_1_voter_services rename column parent_id to department_id;

--- a/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
+++ b/src/vip/data_processor/db/translations/v5_1/election_administrations.clj
@@ -15,8 +15,8 @@
 
 (defn election-administrations->ltree [import-id idx-fn]
   (let [election-administrations (row-fn import-id)
-        departments (group-by :parent_id (ds/row-fn import-id))
-        voter-services (group-by :parent_id (vs/row-fn import-id))]
+        departments (group-by :election_administration_id (ds/row-fn import-id))
+        voter-services (group-by :department_id (vs/row-fn import-id))]
     (mapcat (fn [ea]
               (let [ds (get departments (:id ea))
                     path (base-path (idx-fn))

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -43,7 +43,7 @@
     :columns [{:name "id"}
               {:name "description"}
               {:name "election_official_person_id"}
-              {:name "parent_id"}
+              {:name "department_id"}
               {:name "type"}
               {:name "other_type"}]}
    {:filename "ballot_measure_contest.txt"
@@ -175,7 +175,7 @@
     :table :departments
     :columns [{:name "id"}
               {:name "election_official_person_id"}
-              {:name "parent_id"}]}
+              {:name "election_administration_id"}]}
    {:filename "election.txt"
     :table :elections
     :columns [{:name "id"}

--- a/test-resources/csv/5-1/department.txt
+++ b/test-resources/csv/5-1/department.txt
@@ -1,4 +1,4 @@
-election_official_person_id,parent_id,id
+election_official_person_id,election_administration_id,id
 eloff01,ea123,dep01
 eloff02,ea345,dep02
 eloff03,ea625,dep03

--- a/test-resources/csv/5-1/full-good-run/department.txt
+++ b/test-resources/csv/5-1/full-good-run/department.txt
@@ -1,4 +1,4 @@
-election_official_person_id,parent_id,id
+election_official_person_id,election_administration_id,id
 per50002,ea123,dep01
 per50002,ea345,dep02
 per50002,ea625,dep03

--- a/test-resources/csv/5-1/full-good-run/voter_service.txt
+++ b/test-resources/csv/5-1/full-good-run/voter_service.txt
@@ -1,4 +1,4 @@
-description,election_official_person_id,type,other_type,parent_id,id
+description,election_official_person_id,type,other_type,department_id,id
 A service we provide,per50002,overseas-voting,,dep01,vs01
 Abstainance-only voting,per50002,voter-registration,,dep02,vs00
 Pencil sharpening,per50002,other,office-help,dep03,vs02

--- a/test-resources/csv/5-1/voter_service.txt
+++ b/test-resources/csv/5-1/voter_service.txt
@@ -1,4 +1,4 @@
-description,election_official_person_id,type,other_type,parent_id,id
+description,election_official_person_id,type,other_type,department_id,id
 A service we provide,eloff02,overseas-voting,,dep01,vs01
 Abstainance-only voting,eloff01,voter-registration,,dep02,vs00
 Pencil sharpening,eloff03,other,office-help,dep03,vs02


### PR DESCRIPTION
For the CSV version of VIP's 5.1 spec, each element is described by a single file. When elements contain sub-elements, we need some kind of "_foreign key_" to combine it with another file. We've seen some confusion when telling folks that a department is connected to an election administration by `parent_id` (where's the file `parent.txt`?); calling it `election_administration_id` seems to be more clear. Similarly, a voter service would be connected to a department by it's `department_id`.

[Pivotal story](https://www.pivotaltracker.com/story/show/129056229)
