### PR TITLE
Add election info to results

### DIFF
--- a/resources/migrations/20161228-add-election-info-to-results.down.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.down.sql
@@ -1,0 +1,8 @@
+begin;
+alter table results
+  drop column state;
+alter table results
+  drop column election_type;
+alter table results
+  drop column election_date;
+commit;

--- a/resources/migrations/20161228-add-election-info-to-results.down.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.down.sql
@@ -5,4 +5,6 @@ alter table results
   drop column election_type;
 alter table results
   drop column election_date;
+alter table results
+  drop column vip_id;
 commit;

--- a/resources/migrations/20161228-add-election-info-to-results.up.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.up.sql
@@ -1,35 +1,26 @@
 begin;
 alter table results add column state text, add column election_type text, add column election_date text, add column vip_id text;
 
-with type as
-(select
-   r.id as results_id,
-   coalesce(e3.election_type, xtv.value, 'UNKNOWN') as type
-   from results r
-   left join v3_0_elections e3 on e3.results_id = r.id
-   left join xml_tree_values xtv on xtv.results_id = r.id and xtv.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0'
-),
 
-state_date as
+with results_values as
 (select r.id as results_id,
- coalesce(s3.name, xtv_state.value, 'UNKNOWN') as state,
- case when e3.date is not null then date(e3.date)
-      when xtv_date.value is not null then date(xtv_date.value) end as date,
- case when length(trim(both from t.type, ' ')) = 0 then 'UNKNOWN' else t.type end as election_type,
- coalesce(source3.vip_id, xtv_vip_id.value) as vip_id
+    coalesce(e3.election_type, xtv.value) as type,
+    coalesce(s3.name, xtv_state.value) as state,
+    case when e3.date is not null then date(e3.date)
+         when xtv_date.value is not null then date(xtv_date.value) end as date,
+    coalesce(source3.vip_id, xtv_vip_id.value) as vip_id
 from results r
 left join v3_0_states s3 on s3.results_id = r.id
 left join xml_tree_values xtv_state on xtv_state.results_id = r.id and xtv_state.simple_path = 'VipObject.State.Name'
 left join v3_0_elections e3 on e3.results_id = r.id
 left join xml_tree_values xtv_date on xtv_date.results_id = r.id and xtv_date.simple_path = 'VipObject.Election.Date'
-left join type t on r.id = t.results_id
 left join v3_0_sources source3 on source3.results_id = r.id
 left join xml_tree_values xtv_vip_id on xtv_vip_id.results_id = r.id and xtv_vip_id.simple_path = 'VipObject.Source.VipId'
-)
+left join xml_tree_values xtv on xtv.results_id = r.id and xtv.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0')
 
 update results
-set state = s.state, election_type = s.election_type, election_date = s.date, vip_id = s.vip_id
-from state_date as s
-where id = s.results_id;
+set state = v.state, election_type = v.type, election_date = v.date, vip_id = v.vip_id
+from results_values v
+where id = v.results_id;
 
 commit;

--- a/resources/migrations/20161228-add-election-info-to-results.up.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.up.sql
@@ -1,5 +1,5 @@
 begin;
-alter table results add column state text, add column election_type text, add column election_date text;
+alter table results add column state text, add column election_type text, add column election_date text, add column vip_id text;
 
 with type as
 (select
@@ -15,17 +15,20 @@ state_date as
  coalesce(s3.name, xtv_state.value, 'UNKNOWN') as state,
  case when e3.date is not null then date(e3.date)
       when xtv_date.value is not null then date(xtv_date.value) end as date,
- case when length(trim(both from t.type, ' ')) = 0 then 'UNKNOWN' else t.type end as election_type
+ case when length(trim(both from t.type, ' ')) = 0 then 'UNKNOWN' else t.type end as election_type,
+ coalesce(source3.vip_id, xtv_vip_id.value) as vip_id
 from results r
 left join v3_0_states s3 on s3.results_id = r.id
 left join xml_tree_values xtv_state on xtv_state.results_id = r.id and xtv_state.simple_path = 'VipObject.State.Name'
 left join v3_0_elections e3 on e3.results_id = r.id
 left join xml_tree_values xtv_date on xtv_date.results_id = r.id and xtv_date.simple_path = 'VipObject.Election.Date'
 left join type t on r.id = t.results_id
+left join v3_0_sources source3 on source3.results_id = r.id
+left join xml_tree_values xtv_vip_id on xtv_vip_id.results_id = r.id and xtv_vip_id.simple_path = 'VipObject.Source.VipId'
 )
 
 update results
-set state = s.state, election_type = s.election_type, election_date = s.date
+set state = s.state, election_type = s.election_type, election_date = s.date, vip_id = s.vip_id
 from state_date as s
 where id = s.results_id;
 

--- a/resources/migrations/20161228-add-election-info-to-results.up.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.up.sql
@@ -1,23 +1,68 @@
 begin;
 alter table results add column state text, add column election_type text, add column election_date text;
 
-with new_values
-  as (select r.id as results_id,
-        coalesce(s3.name, xtv_state.value, 'UNKNOWN') as state,
-        coalesce(e3.election_type, xtv_type.value, 'UNKNOWN') as election_type,
-        case when e3.date is not null then date(e3.date)
-             when xtv_date.value is not null then date(xtv_date.value) end
-             as election_date
-      from results r
-      left join v3_0_states s3 on s3.results_id = r.id
-      left join xml_tree_values xtv_state on xtv_state.results_id = r.id and xtv_state.simple_path = 'VipObject.State.Name'
-      left join v3_0_elections e3 on e3.results_id = r.id
-      left join xml_tree_values xtv_type on xtv_type.results_id = r.id and xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0'
-      left join xml_tree_values xtv_date on xtv_date.results_id = r.id and xtv_date.simple_path = 'VipObject.Election.Date'
-      )
+with t as
+(select
+   r.id as results_id,
+   coalesce(e3.election_type, xtv.value, 'UNKNOWN') as type
+   from results r
+   left join v3_0_elections e3 on e3.results_id = r.id
+   left join xml_tree_values xtv on xtv.results_id = r.id and xtv.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0'
+),
+
+s as
+(select r.id as results_id,
+ coalesce(s3.name, xtv_state.value, 'UNKNOWN') as state
+from results r
+left join v3_0_states s3 on s3.results_id = r.id
+left join xml_tree_values xtv_state on xtv_state.results_id = r.id and xtv_state.simple_path = 'VipObject.State.Name'
+),
+
+d as
+(select
+   r.id as results_id,
+   case when e3.date is not null then date(e3.date)
+        when xtv_date.value is not null then date(xtv_date.value)
+   end as date
+ from results r
+ left join v3_0_elections e3 on e3.results_id = r.id
+ left join xml_tree_values xtv_date on xtv_date.results_id = r.id and xtv_date.simple_path = 'VipObject.Election.Date'),
+
+v as
+(select
+  t.results_id,
+   case when length(trim(both from t.type, ' ')) = 0 then 'UNKNOWN' else t.type end as election_type,
+   s.state as state,
+   d.date as date
+ from t
+ left join s on s.results_id = t.results_id
+ left join d on d.results_id = t.results_id)
 update results
-set state = new_values.state, election_type = new_values.election_type, election_date = new_values.election_date
-from new_values
-where id = new_values.results_id;
+set state = v.state, election_type = v.election_type, election_date = v.date
+from v
+where id = v.results_id;
 
 commit;
+--
+--
+--
+-- "SELECT DISTINCT ON (r.id) \
+--                  r.public_id, r.start_time, date(r.end_time) AS end_time, \
+--                  CASE WHEN r.end_time IS NOT NULL \
+--                       THEN r.end_time - r.start_time END AS duration, \
+--                  r.spec_version, r.complete, COALESCE(s3.name, xtv_state.value) AS state, \
+--                  COALESCE(e3.election_type, xtv_type.value) AS election_type, \
+--                  CASE WHEN e3.date IS NOT NULL THEN DATE(e3.date) \
+--                       WHEN xtv_date.value IS NOT NULL THEN DATE(xtv_date.value) END \
+--                       AS election_date \
+--           FROM results r \
+--           LEFT JOIN v3_0_states s3 ON s3.results_id = r.id \
+--           LEFT JOIN v3_0_elections e3 ON e3.results_id = r.id \
+--           LEFT JOIN xml_tree_values xtv_state ON xtv_state.results_id = r.id \
+--                                              AND xtv_state.simple_path = 'VipObject.State.Name' \
+--           LEFT JOIN xml_tree_values xtv_type ON xtv_type.results_id = r.id \
+--                                             AND xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0' \
+--           LEFT JOIN xml_tree_values xtv_date ON xtv_date.results_id = r.id \
+--                                             AND xtv_date.simple_path = 'VipObject.Election.Date' \
+--           ORDER BY r.id DESC \
+--           LIMIT 20 OFFSET ($1 * 20);",

--- a/resources/migrations/20161228-add-election-info-to-results.up.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.up.sql
@@ -1,0 +1,8 @@
+begin;
+alter table results
+  add column state text;
+alter table results
+  add column election_type text;
+alter table results
+  add column election_date text;
+commit;

--- a/resources/migrations/20161228-add-election-info-to-results.up.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.up.sql
@@ -1,8 +1,23 @@
 begin;
-alter table results
-  add column state text;
-alter table results
-  add column election_type text;
-alter table results
-  add column election_date text;
+alter table results add column state text, add column election_type text, add column election_date text;
+
+with new_values
+  as (select r.id as results_id,
+        coalesce(s3.name, xtv_state.value, 'UNKNOWN') as state,
+        coalesce(e3.election_type, xtv_type.value, 'UNKNOWN') as election_type,
+        case when e3.date is not null then date(e3.date)
+             when xtv_date.value is not null then date(xtv_date.value) end
+             as election_date
+      from results r
+      left join v3_0_states s3 on s3.results_id = r.id
+      left join xml_tree_values xtv_state on xtv_state.results_id = r.id and xtv_state.simple_path = 'VipObject.State.Name'
+      left join v3_0_elections e3 on e3.results_id = r.id
+      left join xml_tree_values xtv_type on xtv_type.results_id = r.id and xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0'
+      left join xml_tree_values xtv_date on xtv_date.results_id = r.id and xtv_date.simple_path = 'VipObject.Election.Date'
+      )
+update results
+set state = new_values.state, election_type = new_values.election_type, election_date = new_values.election_date
+from new_values
+where id = new_values.results_id;
+
 commit;

--- a/resources/migrations/20161228-add-election-info-to-results.up.sql
+++ b/resources/migrations/20161228-add-election-info-to-results.up.sql
@@ -1,7 +1,7 @@
 begin;
 alter table results add column state text, add column election_type text, add column election_date text;
 
-with t as
+with type as
 (select
    r.id as results_id,
    coalesce(e3.election_type, xtv.value, 'UNKNOWN') as type
@@ -10,59 +10,23 @@ with t as
    left join xml_tree_values xtv on xtv.results_id = r.id and xtv.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0'
 ),
 
-s as
+state_date as
 (select r.id as results_id,
- coalesce(s3.name, xtv_state.value, 'UNKNOWN') as state
+ coalesce(s3.name, xtv_state.value, 'UNKNOWN') as state,
+ case when e3.date is not null then date(e3.date)
+      when xtv_date.value is not null then date(xtv_date.value) end as date,
+ case when length(trim(both from t.type, ' ')) = 0 then 'UNKNOWN' else t.type end as election_type
 from results r
 left join v3_0_states s3 on s3.results_id = r.id
 left join xml_tree_values xtv_state on xtv_state.results_id = r.id and xtv_state.simple_path = 'VipObject.State.Name'
-),
+left join v3_0_elections e3 on e3.results_id = r.id
+left join xml_tree_values xtv_date on xtv_date.results_id = r.id and xtv_date.simple_path = 'VipObject.Election.Date'
+left join type t on r.id = t.results_id
+)
 
-d as
-(select
-   r.id as results_id,
-   case when e3.date is not null then date(e3.date)
-        when xtv_date.value is not null then date(xtv_date.value)
-   end as date
- from results r
- left join v3_0_elections e3 on e3.results_id = r.id
- left join xml_tree_values xtv_date on xtv_date.results_id = r.id and xtv_date.simple_path = 'VipObject.Election.Date'),
-
-v as
-(select
-  t.results_id,
-   case when length(trim(both from t.type, ' ')) = 0 then 'UNKNOWN' else t.type end as election_type,
-   s.state as state,
-   d.date as date
- from t
- left join s on s.results_id = t.results_id
- left join d on d.results_id = t.results_id)
 update results
-set state = v.state, election_type = v.election_type, election_date = v.date
-from v
-where id = v.results_id;
+set state = s.state, election_type = s.election_type, election_date = s.date
+from state_date as s
+where id = s.results_id;
 
 commit;
---
---
---
--- "SELECT DISTINCT ON (r.id) \
---                  r.public_id, r.start_time, date(r.end_time) AS end_time, \
---                  CASE WHEN r.end_time IS NOT NULL \
---                       THEN r.end_time - r.start_time END AS duration, \
---                  r.spec_version, r.complete, COALESCE(s3.name, xtv_state.value) AS state, \
---                  COALESCE(e3.election_type, xtv_type.value) AS election_type, \
---                  CASE WHEN e3.date IS NOT NULL THEN DATE(e3.date) \
---                       WHEN xtv_date.value IS NOT NULL THEN DATE(xtv_date.value) END \
---                       AS election_date \
---           FROM results r \
---           LEFT JOIN v3_0_states s3 ON s3.results_id = r.id \
---           LEFT JOIN v3_0_elections e3 ON e3.results_id = r.id \
---           LEFT JOIN xml_tree_values xtv_state ON xtv_state.results_id = r.id \
---                                              AND xtv_state.simple_path = 'VipObject.State.Name' \
---           LEFT JOIN xml_tree_values xtv_type ON xtv_type.results_id = r.id \
---                                             AND xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0' \
---           LEFT JOIN xml_tree_values xtv_date ON xtv_date.results_id = r.id \
---                                             AND xtv_date.simple_path = 'VipObject.Election.Date' \
---           ORDER BY r.id DESC \
---           LIMIT 20 OFFSET ($1 * 20);",

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -152,10 +152,18 @@
         {:keys [date election_type]} (-> ctx
                                          (get-in [:tables :elections])
                                          (korma/select (korma/fields :date :election_type))
-                                         first)]
+                                         first)
+        vip-id (-> ctx
+                   (get-in [:tables :sources])
+                   (korma/select (korma/fields :vip_id))
+                   first
+                   :vip_id)]
+
+
     {:date date
      :election-type election_type
      :state state
+     :vip-id vip-id
      :import-id import-id}))
 
 (defn get-xml-tree-public-id-data [{:keys [import-id] :as ctx}]
@@ -167,11 +175,15 @@
               "VipObject.Election.Date")
         election-type (find-value-for-simple-path
                        import-id
-                       "VipObject.Election.ElectionType.Text")]
+                       "VipObject.Election.ElectionType.Text")
+        vip-id (find-value-for-simple-path
+                import-id
+                "VipObject.Source.VipId")]
     {:date date
      :election-type election-type
      :state state
-     :import-id import-id}))
+     :import-id import-id
+     :vip-id vip-id}))
 
 (defn get-public-id-data [{:keys [spec-version] :as ctx}]
   (condp = (util/version-without-patch @spec-version)
@@ -198,7 +210,8 @@
                   (korma/set-fields {:public_id public-id
                                      :state (:state public-id-data)
                                      :election_type (:election-type public-id-data)
-                                     :election_date (:date public-id-data)})
+                                     :election_date (:date public-id-data)
+                                     :vip_id (:vip-id public-id-data)})
                   (korma/where {:id id}))
     (assoc ctx :public-id public-id)))
 

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -191,10 +191,14 @@
 
 (defn store-public-id [ctx]
   (let [id (:import-id ctx)
-        public-id (generate-public-id ctx)]
+        public-id (generate-public-id ctx)
+        public-id-data (get-public-id-data ctx)]
     (log/info "Storing public id")
     (korma/update results
-                  (korma/set-fields {:public_id public-id})
+                  (korma/set-fields {:public_id public-id
+                                     :state (:state public-id-data)
+                                     :election_type (:election-type public-id-data)
+                                     :election_date (:date public-id-data)})
                   (korma/where {:id id}))
     (assoc ctx :public-id public-id)))
 

--- a/test/vip/data_processor/validation/v5_test.clj
+++ b/test/vip/data_processor/validation/v5_test.clj
@@ -46,18 +46,20 @@
     (assert-no-problems errors {})
 
     (testing "the election state, type, and date are saved to the results table"
-      (let [results_values (-> (korma/select psql/results
-                                (korma/fields :id :start_time :public_id :state :election_type :election_date)
+      (let [results-values (-> (korma/select psql/results
+                                (korma/fields :id :start_time :public_id :state :election_type :election_date :vip_id)
                                 (korma/where {:id (:import-id out-ctx)}))
                             first)]
-        (is (= (:election_date results_values) "10/08/2016"))
-        (is (= (:election_type results_values) "Edible"))
-        (is (= (:state results_values) "Virginia"))))
+        (is (= (:election_date results-values) "10/08/2016"))
+        (is (= (:election_type results-values) "Edible"))
+        (is (= (:state results-values) "Virginia"))
+        (is (= (:vip_id results-values) "51"))))
 
     (testing "the data for building a public_id is correctly fetched"
       (is (= {:date "10/08/2016"
               :election-type "Edible"
-              :state "Virginia"}
+              :state "Virginia"
+              :vip-id "51"}
              (dissoc
               (psql/get-xml-tree-public-id-data out-ctx)
               :import-id))))))


### PR DESCRIPTION
For this [pivotal story](https://www.pivotaltracker.com/story/show/135535245) this adds `election_type`, `election_date`, `state`, and `vip_id` to the `results` table to speed up the query that populates the feeds table when you log in to the dashboard.  This adds those as columns to the table and also populates them in the pipeline as new feeds are processed.  Corresponds with [this](https://github.com/votinginfoproject/Metis/pull/349) on the dashboard.