### PR TITLE
Build the public id with warm, safe, US-ASCII

### DIFF
--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -138,8 +138,7 @@
                         (map #(str/trim %))
                         (map #(Normalizer/normalize % java.text.Normalizer$Form/NFKD))
                         (map #(str/replace % #"\p{Space}" "-"))
-                        (map #(str/replace % #"[\p{Punct}&&[^-]]" "%"))
-                        (map #(str/replace % #"[\P{ASCII}%]" "")))]
+                        (map #(str/replace % #"[\p{Punct}\P{ASCII}&&[^-]]" "")))]
     (if (empty? good-parts)
       (str "invalid-" import-id)
       (str/join "-" (concat good-parts [import-id])))))

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -21,9 +21,14 @@
     (is (= "2015-06-18-federal-Ohio-4" (build-public-id "6/18/2015" "federal" "Ohio" 4)))
     (is (= "federal-Ohio-4" (build-public-id "//////" "federal" "Ohio" 4)))
     (is (= "federal-Ohio-4" (build-public-id "" "federal " "Ohio " 4))))
+
   (testing "gives an 'invalid' named id if all of date, election-type and state are nil"
     (is (= "invalid-4" (build-public-id nil nil nil 4)))
-    (is (= "invalid-4" (build-public-id "" nil "" 4)))))
+    (is (= "invalid-4" (build-public-id "" nil "" 4))))
+
+  (testing "most punctuation and any non-ascii characters are stripped"
+    (is (= "1969-06-20-a-space-race-pal-11" (build-public-id "6/20/1969" "a space" "race, pal!" 11)))
+    (is (= "2017-01-05-jalapenos-42" (build-public-id "1/5/2017" "jalapeños" nil 42)))))
 
 (deftest coerce-identifier-test
   (testing "coerces valid identifiers"


### PR DESCRIPTION
We build a `public_id` value to use in our URLs, but it's coming from user supplied data, which sometimes might contain characters that break routing in the dashboard. It seemed like percent encoding the string would be the best solution, but
something in the dashboard isn't properly handling those encoded strings, so
the next best solution seems to be removing things that would cause it
to break.

[Story A](https://www.pivotaltracker.com/story/show/132265201), [story B](https://www.pivotaltracker.com/story/show/132272105)