### PR TITLE
Locality error reports

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -31,7 +31,8 @@
    data-processor/add-validations
    errors/close-errors-chan
    errors/await-statistics
-   psql/refresh-materialized-views])
+   psql/refresh-materialized-views
+   psql/populate-locality-table])
 
 (defn -main [filename]
   (psql/initialize)

--- a/resources/migrations/20170109-00-fix-precincts-by-locality.down.sql
+++ b/resources/migrations/20170109-00-fix-precincts-by-locality.down.sql
@@ -1,0 +1,9 @@
+create or replace function v5_dashboard.precincts_by_locality(rid integer, locality_id text)
+returns ltree[] as $$
+
+select array_agg(xtv.parent_with_id)
+  from xml_tree_values xtv
+  where xtv.results_id = rid
+    and xtv.simple_path = 'VipObject.Precinct.LocalityId'
+    and xtv.value = locality_id;
+$$ language sql;

--- a/resources/migrations/20170109-00-fix-precincts-by-locality.up.sql
+++ b/resources/migrations/20170109-00-fix-precincts-by-locality.up.sql
@@ -1,0 +1,10 @@
+create or replace function v5_dashboard.precincts_by_locality(rid integer, locality_id text)
+returns ltree[] as $$
+
+select array_agg(xtv.parent_with_id)
+  from xml_tree_values xtv
+  where xtv.results_id = rid
+    and xtv.simple_path = 'VipObject.Precinct.LocalityId'
+    and xtv.value = locality_id
+    and xtv.parent_with_id is not null;
+$$ language sql;

--- a/resources/migrations/20170117-00-create-paths-by-locality.down.sql
+++ b/resources/migrations/20170117-00-create-paths-by-locality.down.sql
@@ -1,0 +1,1 @@
+drop table v5_dashboard.paths_by_locality;

--- a/resources/migrations/20170117-00-create-paths-by-locality.up.sql
+++ b/resources/migrations/20170117-00-create-paths-by-locality.up.sql
@@ -1,0 +1,4 @@
+create table v5_dashboard.paths_by_locality (
+    results_id integer references results (id) not null,
+    locality_id text,
+    paths ltree[] not null);

--- a/resources/migrations/20170117-01-populate-locality-table.down.sql
+++ b/resources/migrations/20170117-01-populate-locality-table.down.sql
@@ -1,0 +1,1 @@
+drop function if exists v5_dashboard.populate_locality_table(integer);

--- a/resources/migrations/20170117-01-populate-locality-table.up.sql
+++ b/resources/migrations/20170117-01-populate-locality-table.up.sql
@@ -1,0 +1,130 @@
+create or replace function v5_dashboard.populate_locality_table(rid integer)
+returns void as $$
+declare
+  localities record;
+  precincts ltree[];
+  precincts_values text[];
+  polling_locations ltree[];
+  hours_open ltree[];
+  street_segments ltree[];
+  electoral_districts ltree[];
+  contests ltree[];
+  locality_paths ltree[];
+  election_administrations ltree[];
+  temp_table text;
+begin
+  delete from v5_dashboard.paths_by_locality where results_id = rid;
+  temp_table := 'locality_stuff_' || rid;
+
+  execute 'create temp table ' || temp_table || ' on commit drop as
+     select path, simple_path, value, parent_with_id
+     from xml_tree_values
+     where results_id = ' || rid || '
+     and path ~ ''VipObject.0.HoursOpen|Locality|ElectionAdministration|ElectoralDistrict|Precinct|PollingLocation|StreetSegment|Contest|BallotMeasureContest|CandidateContest|OrderedContest|RetentionContest|PartyContest.*'''
+  using rid;
+
+  execute 'create index '|| temp_table::regclass || '_ss_idx
+           on ' || temp_table::regclass ||
+          ' (simple_path, value)
+          where simple_path = ''VipObject.StreetSegment.PrecinctId''';
+
+  execute 'create index ' || temp_table::regclass ||'_other_idx
+           on ' || temp_table::regclass ||
+          ' (simple_path, path, value, parent_with_id)
+          where simple_path = ''VipObject.Precinct.id''
+             or simple_path = ''VipObject.Precinct.PollingLocationIds''
+             or simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+             or simple_path = ''VipObject.PollingLocation.id''
+             or simple_path = ''VipObject.PollingLocation.HoursOpenId''
+             or simple_path = ''VipObject.HoursOpen.id''';
+
+  execute 'analyze ' || temp_table;
+
+  for localities in
+    execute 'select value as id, array_agg(parent_with_id) as precincts
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.Precinct.LocalityId''
+               and parent_with_id is not null
+               group by value
+               order by value'
+  loop
+    execute 'with precincts as (
+               select array_agg(value) as v
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.id''
+                 and path <@ $1)
+             select array_agg(subpath(parent_with_id, 0, 4))
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.StreetSegment.PrecinctId''
+               and value in (select unnest(precincts.v) from precincts)'
+    into street_segments
+    using localities.precincts;
+
+    execute 'with polling_locations as (
+               select string_to_array(string_agg(value, '' ''), '' '') as ids
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.PollingLocationIds''
+                 and parent_with_id <@ $1)
+             select array_agg(subpath(parent_with_id, 0, 4))
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.PollingLocation.id''
+               and value in (select unnest(ids) from polling_locations)'
+    into polling_locations
+    using localities.precincts;
+
+    execute 'with districts
+             as (select string_to_array(string_agg(value, '' ''), '' '') as ids
+                 from ' || temp_table::regclass || '
+                 where simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+                   and path <@ $1)
+             select array_agg(parent_with_id)
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.ElectoralDistrict.id''
+               and value in (select unnest(districts.ids) from districts)'
+    into electoral_districts
+    using localities.precincts;
+
+    execute 'with districts as (
+               select string_to_array(string_agg(value, '' ''), '' '') as ids
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+                 and path <@ $1)
+             select array_agg(parent_with_id)
+             from ' || temp_table::regclass || '
+             where simple_path ~ ''VipObject.Contest|BallotMeasureContest|CandidateContest|OrderedContest|RetentionContest|PartyContest.*''
+               and value in (select unnest(districts.ids) from districts)'
+    into contests
+    using localities.precincts;
+
+    execute 'select array_agg(path)
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.HoursOpen.id''
+               and value in (select value
+                             from ' || temp_table::regclass || '
+                             where simple_path = ''VipObject.PollingLocation.HoursOpenId''
+                               and parent_with_id <@ $1)'
+    into hours_open
+    using polling_locations;
+
+    execute
+      'with locality as
+        (select * from ' || temp_table::regclass || '
+            where simple_path = ''VipObject.Locality.id''
+            and value = $1),
+      election_admin as
+        (select t.* from ' || temp_table::regclass || ' t
+            join locality on locality.parent_with_id = t.parent_with_id
+            where t.simple_path = ''VipObject.Locality.ElectionAdministrationId''),
+      path as (
+          select t.parent_with_id from ' || temp_table::regclass || ' t
+          join election_admin on election_admin.value = t.value
+          and t.simple_path = ''VipObject.ElectionAdministration.id'')
+      select array_agg(t.path) from '|| temp_table::regclass ||' t join path on t.parent_with_id = path.parent_with_id'
+    into election_administrations
+    using localities.id;
+
+    locality_paths :=  localities.precincts || polling_locations || hours_open || street_segments || electoral_districts || contests || election_administrations;
+    insert into v5_dashboard.paths_by_locality values(rid, localities.id, locality_paths);
+  end loop;
+end;
+$$ language plpgsql;

--- a/resources/migrations/20170117-01-populate-locality-table.up.sql
+++ b/resources/migrations/20170117-01-populate-locality-table.up.sql
@@ -128,3 +128,11 @@ begin
   end loop;
 end;
 $$ language plpgsql;
+
+do $$declare r record;
+begin
+  for r in select id from results where spec_version like '5.1%'
+  loop
+    perform v5_dashboard.populate_locality_table(r.id);
+  end loop;
+end$$

--- a/resources/migrations/20170117-02-locality-error-report.down.sql
+++ b/resources/migrations/20170117-02-locality-error-report.down.sql
@@ -1,0 +1,1 @@
+drop function if exists v5_dashboard.locality_error_report(text, text);

--- a/resources/migrations/20170117-02-locality-error-report.up.sql
+++ b/resources/migrations/20170117-02-locality-error-report.up.sql
@@ -1,0 +1,16 @@
+create or replace function v5_dashboard.locality_error_report(pid text, given_locality_id text)
+returns table (results_id bigint, path text, severity varchar, scope varchar, identifier text, error_type varchar, error_data text)
+as $$
+declare results_id_from_pid int;
+begin
+  select id into results_id_from_pid from results where results.public_id = pid;
+  return query
+  select xtv.results_id, ltree2text(xtv.path), xtv.severity, xtv.scope, x.value AS identifier, xtv.error_type, xtv.error_data
+  from xml_tree_validations xtv
+  left join xml_tree_values x
+         on x.path = subpath(xtv.path,0,4) || 'id' and x.results_id = xtv.results_id
+  inner join results r on r.id = xtv.results_id
+  where r.public_id = pid
+    and xtv.path <@ (select paths from v5_dashboard.paths_by_locality pbl where pbl.locality_id = given_locality_id and pbl.results_id = results_id_from_pid);
+  end
+$$ language plpgsql;

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -65,6 +65,7 @@
            errors/close-errors-chan
            errors/await-statistics
            psql/refresh-materialized-views
+           psql/populate-locality-table
            s3/upload-to-s3
            cleanup/cleanup]))
 

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -55,6 +55,8 @@
     (korma/database results-db))
   (korma/defentity v5-1-street-segments
     (korma/table "v5_1_street_segments"))
+  (korma/defentity v5-dashboard-paths-by-locality
+    (korma/table "v5_dashboard.paths_by_locality"))
   (def v5-1-tables
     (db.util/make-entities "5.1" results-db [:offices
                                              :voter-services
@@ -233,6 +235,14 @@
   (korma/exec-raw
    (:conn xml-tree-values)
    ["analyze xml_tree_values"])
+  ctx)
+
+(defn populate-locality-table
+  [ctx]
+  (let [id (:import-id ctx)]
+    (korma/exec-raw
+     (:conn xml-tree-values)
+     ["select v5_dashboard.populate_locality_table(?)" [id]]))
   ctx)
 
 (defn refresh-materialized-views

--- a/test-resources/xml/v5-locality-summaries.xml
+++ b/test-resources/xml/v5-locality-summaries.xml
@@ -25,6 +25,50 @@
     <StateId>st08</StateId>
   </Election>
 
+  <ElectoralDistrict id="ed01">
+    <Name>Chaffee</Name>
+    <Number>1</Number>
+    <Type>county</Type>
+  </ElectoralDistrict>
+
+  <ElectoralDistrict id="ed02">
+    <Name>Colorado Fifth Congressional District</Name>
+    <Number>5</Number>
+    <Type>congressional</Type>
+  </ElectoralDistrict>
+
+  <ElectoralDistrict id="ed03">
+    <Name>Buena Vista</Name>
+    <Type>township</Type>
+  </ElectoralDistrict>
+
+  <Contest id="con01">
+    <BallotTitle>
+      <Text lang="en">Best Tacos in the County</Text>
+    </BallotTitle>
+    <ElectoralDistrictId>ed01</ElectoralDistrictId>
+    <Name>Taco Contest</Name>
+  </Contest>
+
+  <Contest id="con02">
+    <BallotTitle>
+      <Text lang="en">US Senate Stuff</Text>
+    </BallotTitle>
+    <ElectoralDistrictId>ed02</ElectoralDistrictId>
+    <Name>A Quality Congressperson</Name>
+  </Contest>
+
+  <Contest id="con03">
+    <BallotSubTitle>
+      For those dogs that chase too many trucks
+    </BallotSubTitle>
+    <BallotTitle>
+      <Text lang="en">Finding Fussy Fidos</Text>
+    </BallotTitle>
+    <ElectoralDistrictId>ed03</ElectoralDistrictId>
+    <Name>Town Dogcatcher</Name>
+  </Contest>
+
   <State id="st08"></State>
 
   <!-- Buena Vista -->
@@ -47,6 +91,7 @@
     <Name>BV Precinct 1</Name>
     <Number>1</Number>
     <PollingLocationIds>pl10 pl11</PollingLocationIds>
+    <ElectoralDistrictIds>ed01 ed02 ed03</ElectoralDistrictIds>
   </Precinct>
 
   <Precinct id="pre11">
@@ -161,6 +206,7 @@
     <Name>Nathrop Area</Name>
     <Number>2</Number>
     <PollingLocationIds>pl2</PollingLocationIds>
+    <ElectoralDistrictIds>ed01 ed02 ed03</ElectoralDistrictIds>
   </Precinct>
 
   <PollingLocation id="pl2">


### PR DESCRIPTION
This is a pr for [this story](https://www.pivotaltracker.com/story/show/136705881) about generating locality-specific error reports.  It has a corresponding [dashboard pr](https://github.com/votinginfoproject/Metis/pull/350).  We made it possible to generate the locality error report by creating and populating a new table to hold all of the localities for a feed and their corresponding paths, and then using those to filter the xml_tree_validations table at the time of report generation.  The `v5_dashboard.populate_locality_table` function has also been added to the pipeline to populate the table each time a new feed is processed and `v5_dashboard.locality_error_report` is what gets called to actually create the report.