### PR TITLE
Don't force apartment numbers to be integers

### DIFF
--- a/resources/specs/vip_spec_v3.0.xsd
+++ b/resources/specs/vip_spec_v3.0.xsd
@@ -268,8 +268,8 @@
               <xs:element name="start_house_number" type="xs:integer" />
               <xs:element name="end_house_number" type="xs:integer" />
               <xs:element name="odd_even_both" type="oebEnum" />
-              <xs:element minOccurs="0" name="start_apartment_number" type="xs:integer" />
-              <xs:element minOccurs="0" name="end_apartment_number" type="xs:integer" />
+              <xs:element minOccurs="0" name="start_apartment_number" type="xs:string" />
+              <xs:element minOccurs="0" name="end_apartment_number" type="xs:string" />
               <xs:element name="non_house_address" type="detailAddressType" />
               <xs:element name="precinct_id" type="xs:integer" />
               <xs:element minOccurs="0" name="precinct_split_id" type="xs:integer" />

--- a/resources/specs/vip_spec_v3.0.xsd
+++ b/resources/specs/vip_spec_v3.0.xsd
@@ -314,36 +314,36 @@
     </xs:complexType>
   </xs:element>
 
-  
+
 
 
 <xs:complexType name="detailAddressType">
     <xs:all>
-        <xs:element minOccurs="0" name="house_number" type="xs:integer"/> 
-        <xs:element minOccurs="0" name="house_number_prefix" type="xs:string"/> 
-        <xs:element minOccurs="0" name="house_number_suffix" type="xs:string"/> 
-        <xs:element minOccurs="0" name="street_direction" type="xs:string"/> 
-        <xs:element name="street_name" type="xs:string"/> 
-        <xs:element minOccurs="0" name="street_suffix" type="xs:string"/> 
-        <xs:element minOccurs="0" name="address_direction" type="xs:string"/> 
+        <xs:element minOccurs="0" name="house_number" type="xs:integer"/>
+        <xs:element minOccurs="0" name="house_number_prefix" type="xs:string"/>
+        <xs:element minOccurs="0" name="house_number_suffix" type="xs:string"/>
+        <xs:element minOccurs="0" name="street_direction" type="xs:string"/>
+        <xs:element name="street_name" type="xs:string"/>
+        <xs:element minOccurs="0" name="street_suffix" type="xs:string"/>
+        <xs:element minOccurs="0" name="address_direction" type="xs:string"/>
         <xs:element minOccurs="0" name="apartment" type="xs:string"/>
         <xs:element name="city" type="xs:string"/>
         <xs:element name="state" type="xs:string"/>
         <xs:element name="zip" type="xs:string"/>
-    </xs:all> 
-</xs:complexType> 
-  
+    </xs:all>
+</xs:complexType>
+
 <xs:complexType name="simpleAddressType">
     <xs:all>
-        <xs:element minOccurs="0" name="location_name" type="xs:string"/> 
+        <xs:element minOccurs="0" name="location_name" type="xs:string"/>
         <xs:element name="line1" type="xs:string"/>
         <xs:element minOccurs="0" name="line2" type="xs:string"/>
         <xs:element minOccurs="0" name="line3" type="xs:string"/>
         <xs:element name="city" type="xs:string"/>
         <xs:element name="state" type="xs:string"/>
         <xs:element name="zip" type="xs:string"/>
-    </xs:all> 
-</xs:complexType> 
+    </xs:all>
+</xs:complexType>
 
 <xs:complexType name="votesWithCertification">
   <xs:simpleContent>
@@ -364,7 +364,7 @@
       <xs:enumeration value="Unofficial_Complete"/>
       <xs:enumeration value="Certified"/>
     </xs:restriction>
-  </xs:simpleType> 
+  </xs:simpleType>
 
   <xs:simpleType name="yesNoEnum">
     <xs:restriction base="xs:string">
@@ -375,7 +375,7 @@
       <xs:enumeration value="YES"/>
       <xs:enumeration value="NO"/>
     </xs:restriction>
-  </xs:simpleType> 
+  </xs:simpleType>
 
   <xs:simpleType name="oebEnum">
     <xs:restriction base="xs:string">
@@ -389,6 +389,6 @@
       <xs:enumeration value="EVEN"/>
       <xs:enumeration value="BOTH"/>
     </xs:restriction>
-  </xs:simpleType> 
+  </xs:simpleType>
 
 </xs:schema>

--- a/src/vip/data_processor/validation/data_spec/v3_0.clj
+++ b/src/vip/data_processor/validation/data_spec/v3_0.clj
@@ -313,8 +313,8 @@
               {:name "start_house_number" :required :critical :format format/all-digits :coerce coerce/coerce-integer}
               {:name "end_house_number" :required :critical :format format/all-digits :coerce coerce/coerce-integer}
               {:name "odd_even_both" :format format/odd-even-both}
-              {:name "start_apartment_number" :format format/all-digits :coerce coerce/coerce-integer}
-              {:name "end_apartment_number" :format format/all-digits :coerce coerce/coerce-integer}
+              {:name "start_apartment_number"}
+              {:name "end_apartment_number"}
               {:name "non_house_address_house_number" :format format/all-digits :coerce coerce/coerce-integer}
               {:name "non_house_address_house_number_prefix"}
               {:name "non_house_address_house_number_suffix"}

--- a/test-resources/csv/full-good-run/street_segment.txt
+++ b/test-resources/csv/full-good-run/street_segment.txt
@@ -1,7 +1,7 @@
 start_house_number,end_house_number,odd_even_both,start_apartment_number,end_apartment_number,non_house_address_house_number,non_house_address_house_number_prefix,non_house_address_house_number_suffix,non_house_address_street_direction,non_house_address_street_name,non_house_address_street_suffix,non_house_address_address_direction,non_house_address_apartment,non_house_address_city,non_house_address_state,non_house_address_zip,precinct_id,precinct_split_id,id
 1,1,odd,,,,,,,BON SECOURS,WAY,,,PORTSMOUTH,VA,23703,90000,100041,2000000
 1,1,odd,,,,,,,CRAWFORD,CT,,,PORTSMOUTH,VA,23704,90013,100019,2000001
-1,10,both,,,,,,,BRENT,CRES,,,PORTSMOUTH,VA,23703,90028,100034,2000002
+1,10,both,1a,2b,,,,,BRENT,CRES,,,PORTSMOUTH,VA,23703,90028,100034,2000002
 1,10,both,,,,,,,CRABTREE,CT,,,PORTSMOUTH,VA,23703,90040,100001,2000003
 1,10,both,,,,,,,Keswick,CT,,,Portsmouth,VA,23703,90015,100025,2000004
 1,10,both,,,,,,,Neptune,CT,,,Portsmouth,VA,23703,90015,100025,2000005

--- a/test/vip/data_processor/output/xml_test.clj
+++ b/test/vip/data_processor/output/xml_test.clj
@@ -5,6 +5,7 @@
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.pipeline :as pipeline]
             [vip.data-processor.validation.csv :as csv]
+            [vip.data-processor.validation.csv.file-set :as csv-files]
             [vip.data-processor.validation.data-spec :as data-spec]
             [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
             [vip.data-processor.validation.transforms :as transforms]
@@ -27,8 +28,14 @@
                       :spec-version (atom "3.0")
                       :errors-chan errors-chan
                       :pipeline (concat [(data-spec/add-data-specs
-                                          v3-0/data-specs)]
-                                        transforms/csv-validations
+                                          v3-0/data-specs)
+                                         csv/error-on-missing-files
+                                         csv/determine-spec-version
+                                         csv/remove-bad-filenames
+                                         sqlite/attach-sqlite-db
+                                         (csv-files/validate-dependencies
+                                          csv-files/v3-0-file-dependencies)
+                                         csv/load-csvs]
                                         pipeline)} db)
           results-ctx (pipeline/run-pipeline ctx)
           xml-doc (-> results-ctx


### PR DESCRIPTION
In [this story](https://www.pivotaltracker.com/story/show/137898631), we thought it would be trivial to remove a validation on apartment numbers. However, when writing XML for a 3.0 feed, we validate it against the spec, so we'd need to change the XSD as well if strings are going to be allowed (ok, it's a little less trivial). Also, I noticed the pipeline used in `xml_test/write-xml-test` was letting errors sneak through with passing tests (see [this chore](https://www.pivotaltracker.com/story/show/135355555))

So, here is a little PR that introduces `3.0.1`, for your perusal. I'll make an issue / PR for [vip-specification](https://github.com/votinginfoproject/vip-specification), but for now, how does this approach feel? Is there a better way?