### PR TITLE
V3 remove refresh materialized views

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -31,8 +31,7 @@
    data-processor/add-validations
    errors/close-errors-chan
    errors/await-statistics
-   psql/refresh-materialized-views
-   psql/populate-locality-table])
+   psql/v5-summary-branch])
 
 (defn -main [filename]
   (psql/initialize)

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -64,8 +64,7 @@
            add-validations
            errors/close-errors-chan
            errors/await-statistics
-           psql/refresh-materialized-views
-           psql/populate-locality-table
+           psql/v5-summary-branch
            s3/upload-to-s3
            cleanup/cleanup]))
 

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -275,6 +275,13 @@
      [(str "refresh materialized view " view)]))
   ctx)
 
+
+(defn v5-summary-branch
+  [{:keys [spec-version] :as ctx}]
+  (if (= @spec-version "5.1")
+    (update ctx :pipeline (partial concat [populate-locality-table refresh-materialized-views]))
+    ctx))
+
 (defn complete-run [ctx]
   (let [id (:import-id ctx)
         filename (:generated-xml-filename ctx)]

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -55,7 +55,7 @@
                  :spec-version (atom "3.0")}
         v5-ctx {:pipeline []
                 :spec-version (atom "5.1")}
-        v3-out-ctx (v5-summary-branch-2 v3-ctx)
-        v5-out-ctx (v5-summary-branch-2 v5-ctx)]
+        v3-out-ctx (v5-summary-branch v3-ctx)
+        v5-out-ctx (v5-summary-branch v5-ctx)]
     (is (= (count (v3-out-ctx :pipeline)) 0))
     (is (= (count (v5-out-ctx :pipeline)) 2))))

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -49,3 +49,13 @@
           (build-election-id "2015-10-10" "LOUISIANA   " "GENERAL")))
    (is (nil? (build-election-id "2015-10-10" "LOUISIANA" nil)))
    (is (nil? (build-election-id "2015-10-10" "" "GENERAL")))))
+
+(deftest v5-summary-branch-test
+  (let [v3-ctx {:pipeline []
+                 :spec-version (atom "3.0")}
+        v5-ctx {:pipeline []
+                :spec-version (atom "5.1")}
+        v3-out-ctx (v5-summary-branch-2 v3-ctx)
+        v5-out-ctx (v5-summary-branch-2 v5-ctx)]
+    (is (= (count (v3-out-ctx :pipeline)) 0))
+    (is (= (count (v5-out-ctx :pipeline)) 2))))


### PR DESCRIPTION
For [this story](https://www.pivotaltracker.com/story/show/141260295) our initial attempt is to remove the `refreshing-materialized-views` and `populate-locality-table` steps from the 3.0 pipeline; in local testing this step contributes significantly to the time required to run a feed and is not necessary for 3.0 feeds.