### PR TITLE
Apartment numbers are text

### DIFF
--- a/resources/migrations/20170316-00-v3-apartment-number-strings.down.sql
+++ b/resources/migrations/20170316-00-v3-apartment-number-strings.down.sql
@@ -1,2 +1,21 @@
-alter table v3_0_street_segments alter column start_apartment_number set data type integer using start_apartment_number::integer;
-alter table v3_0_street_segments alter column end_apartment_number set data type integer using end_apartment_number::integer;
+/*update v3_0_street_segments set start_apartment_number = null where start_apartment_number = '';*/
+/*update v3_0_street_segments set end_apartment_number = null where end_apartment_number = '';*/
+
+create or replace function convert_to_integer(apt_number_txt text)
+returns integer as $$
+declare apt_number_int integer default null;
+begin
+    begin
+        apt_number_int := apt_number_txt::integer;
+    exception when others then
+        return null;
+    end;
+return apt_number_int;
+end;
+$$ language plpgsql;
+
+
+alter table v3_0_street_segments alter column start_apartment_number set data type integer using convert_to_integer(start_apartment_number);
+alter table v3_0_street_segments alter column end_apartment_number set data type integer using convert_to_integer(end_apartment_number);
+
+drop function convert_to_integer(text);

--- a/resources/migrations/20170316-00-v3-apartment-number-strings.down.sql
+++ b/resources/migrations/20170316-00-v3-apartment-number-strings.down.sql
@@ -1,0 +1,2 @@
+alter table v3_0_street_segments alter column start_apartment_number set data type integer using start_apartment_number::integer;
+alter table v3_0_street_segments alter column end_apartment_number set data type integer using end_apartment_number::integer;

--- a/resources/migrations/20170316-00-v3-apartment-number-strings.down.sql
+++ b/resources/migrations/20170316-00-v3-apartment-number-strings.down.sql
@@ -1,6 +1,3 @@
-/*update v3_0_street_segments set start_apartment_number = null where start_apartment_number = '';*/
-/*update v3_0_street_segments set end_apartment_number = null where end_apartment_number = '';*/
-
 create or replace function convert_to_integer(apt_number_txt text)
 returns integer as $$
 declare apt_number_int integer default null;

--- a/resources/migrations/20170316-00-v3-apartment-number-strings.up.sql
+++ b/resources/migrations/20170316-00-v3-apartment-number-strings.up.sql
@@ -1,0 +1,2 @@
+alter table v3_0_street_segments alter column start_apartment_number set data type text;
+alter table v3_0_street_segments alter column end_apartment_number set data type text;


### PR DESCRIPTION
Related to [this story](https://www.pivotaltracker.com/story/show/137898631)--we changed the spec to allow `start_apartment_number` and `end_apartment_number` but didn't change the `v3_0_street_segments` table to store those columns as text.  This PR includes an up migration that alters the table schema to have those columns be text and an slightly more complicated down migration that checks if it can cast those columns as integers before changing the columns back to being integers.