### PR TITLE
Psql updates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,6 +37,7 @@
   :test-selectors {:default (complement :postgres)
                    :postgres :postgres
                    :all (constantly true)}
+  :repl-options {:init (set! *print-length* 50)}
   :java-agents [[com.newrelic.agent.java/newrelic-agent "3.25.0"]]
   :jar-copier {:java-agents true
                :destination "resources/jars"}

--- a/project.clj
+++ b/project.clj
@@ -20,13 +20,13 @@
                  [democracyworks/utility-fns "0.2.0"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
                  [turbovote.resource-config "0.2.0"]
-                 [joplin.jdbc "0.3.6"
+                 [joplin.jdbc "0.3.10"
                   :exclusions [ragtime/ragtime.jdbc]]
-                 [ragtime/ragtime.jdbc "0.5.3"]
-                 [korma "0.4.2"]
-                 [org.clojure/java.jdbc "0.5.0"]
-                 [org.postgresql/postgresql "9.4.1208" :exclusions [org.slf4j/slf4j-simple
-                                                                    org.slf4j/slf4j-api]]
+                 [ragtime/ragtime.jdbc "0.6.4"]
+                 [korma "0.4.3"]
+                 [org.clojure/java.jdbc "0.6.1"]
+                 [org.postgresql/postgresql "42.0.0" :exclusions [org.slf4j/slf4j-simple
+                                                                  org.slf4j/slf4j-api]]
                  [org.xerial/sqlite-jdbc "3.8.11.2"]]
   :plugins [[com.pupeno/jar-copier "0.4.0"]]
   :profiles {:test {:resource-paths ["test-resources"]

--- a/src/vip/data_processor/cleanup.clj
+++ b/src/vip/data_processor/cleanup.clj
@@ -7,5 +7,6 @@
                  (.toFile file)
                  file)]
       (when (.exists file)
+        (log/info "Removing" (.toString file))
         (.delete file))))
   ctx)

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -32,7 +32,8 @@
   (migrate)
   (let [opts (-> [:postgres]
                  config
-                 (assoc :db (config [:postgres :database])))]
+                 (assoc :db (config [:postgres :database]))
+                 (merge {:initial-pool-size 1, :minimum-pool-size 1, :maximum-pool-size 1}))]
     (db/defdb results-db (db/postgres opts)))
   (korma/defentity results
     (korma/database results-db))
@@ -359,42 +360,41 @@
   (map :column_name (columns table)))
 
 (defn lazy-select-xml-tree-values [chunk-size import-id]
-  (binding [db/*current-conn* (db/get-connection (:db xml-tree-values))]
-    (let [cursor-name (str (gensym "xtv_cursor"))
-          done? (atom false)
-          close-attempts (atom 0)]
-      (korma/exec-raw
-                      [(str "DECLARE " cursor-name " NO SCROLL CURSOR "
-                            "WITH HOLD FOR "
-                            "SELECT * FROM xml_tree_values "
-                            "WHERE results_id=" import-id " "
-                            "ORDER BY insert_counter ASC;")])
-      (letfn [(chunked-rows []
-                (when @done?
-                  (swap! close-attempts inc))
-                (try
-                  (do
-                    (let [this-chunk (korma/exec-raw
-                                      [(str "FETCH " chunk-size
-                                            " FROM " cursor-name)]
-                                      :results)]
-                      (if (seq this-chunk)
-                        (do
-                          (lazy-cat
-                           this-chunk
-                           (trampoline chunked-rows)))
-                        (do
-                          (reset! done? true)
-                          (korma/exec-raw
-                           [(str "CLOSE " cursor-name)])
-                          nil))))
-                  (catch java.sql.SQLException e
-                    (if (> @close-attempts 30)
+  (let [cursor-name (str (gensym "xtv_cursor"))
+        done? (atom false)
+        close-attempts (atom 0)]
+    (korma/exec-raw
+     [(str "DECLARE " cursor-name " NO SCROLL CURSOR "
+           "WITH HOLD FOR "
+           "SELECT * FROM xml_tree_values "
+           "WHERE results_id=" import-id " "
+           "ORDER BY insert_counter ASC;")])
+    (letfn [(chunked-rows []
+              (when @done?
+                (swap! close-attempts inc))
+              (try
+                (do
+                  (let [this-chunk (korma/exec-raw
+                                    [(str "FETCH " chunk-size
+                                          " FROM " cursor-name)]
+                                    :results)]
+                    (if (seq this-chunk)
                       (do
-                        (log/error "Tried to close cursor" cursor-name "too many times")
-                        nil)
-                      chunked-rows))))]
-        (trampoline chunked-rows)))))
+                        (lazy-cat
+                         this-chunk
+                         (trampoline chunked-rows)))
+                      (do
+                        (reset! done? true)
+                        (korma/exec-raw
+                         [(str "CLOSE " cursor-name)])
+                        nil))))
+                (catch java.sql.SQLException e
+                  (if (> @close-attempts 30)
+                    (do
+                      (log/error "Tried to close cursor" cursor-name "too many times")
+                      nil)
+                    chunked-rows))))]
+      (trampoline chunked-rows))))
 
 (defn lazy-select-fn [chunk-size query-fn]
   (fn [& args]

--- a/test/vip/data_processor/test_helpers.clj
+++ b/test/vip/data_processor/test_helpers.clj
@@ -50,8 +50,8 @@
                        :user (config [:postgres :user])
                        :password (config [:postgres :password])}]
 
-      (jdbc/execute! jdbc-config [(str "DROP DATABASE IF EXISTS " database-name)] :transaction? false)
-      (jdbc/execute! jdbc-config [(str "CREATE DATABASE " database-name)] :transaction? false)
+      (jdbc/execute! jdbc-config [(str "DROP DATABASE IF EXISTS " database-name)] {:transaction? false})
+      (jdbc/execute! jdbc-config [(str "CREATE DATABASE " database-name)] {:transaction? false})
 
       (psql/initialize)
       ;; these vars will be unbound until after psql/initialize, so

--- a/test/vip/data_processor/test_helpers.clj
+++ b/test/vip/data_processor/test_helpers.clj
@@ -10,8 +10,6 @@
             [vip.data-processor.util :as util]
             [clojure.core.async :as a]))
 
-(set! *print-length* 10)
-
 (def problem-types [:warnings :errors :critical :fatal])
 
 (defn csv-inputs [file-names]

--- a/test/vip/data_processor/validation/v5/boolean_test.clj
+++ b/test/vip/data_processor/validation/v5/boolean_test.clj
@@ -9,8 +9,6 @@
 
 (use-fixtures :once setup-postgres)
 
-(set! *print-length* 100)
-
 (deftest ^:postgres boolean-incorrect-test
   (let [errors-chan (a/chan 100)
         ctx {:input (xml-input "v5-incorrect-booleans.xml")

--- a/test/vip/data_processor/validation/v5/locality_test.clj
+++ b/test/vip/data_processor/validation/v5/locality_test.clj
@@ -113,16 +113,17 @@
          report (-> (korma/exec-raw
                      [(str "select * from v5_dashboard.locality_error_report('" public-id "', 'loc3')")]
                      :results)
-                   first)]
-        (is (= {:results_id results-id
-                :path "VipObject.0.StreetSegment.31.Zip"
-                :severity "errors"
-                :scope "street-segment"
-                :identifier "ss33"
-                :error_type "missing"
-                :error_data ":missing-zip"}
-               report))))))
-
+                    set)]
+        (is (= 3 (count report)))
+        (is (contains?
+             report
+             {:results_id results-id
+              :path "VipObject.0.StreetSegment.31.Zip"
+              :severity "errors"
+              :scope "street-segment"
+              :identifier "ss33"
+              :error_type "missing"
+              :error_data ":missing-zip"}))))))
 
 (deftest ^:postgres locality-summary-test
   (let [errors-chan (a/chan 100)


### PR DESCRIPTION
Pending edits...

Months ago we found that writing a very large feed's XML was slow after roughly 15 million rows were read; no matter how we indexed the table, PostgreSQL switched from doing index scans to doing sequential scans. By using a cursor, we could prevent a sequential scan from occurring, but [using a cursor with a connection pool can cause tests to deadlock](https://www.pivotaltracker.com/story/show/134808839), and [the implementation of cursors in PostgreSQL]() requires that each `fetch` be done on the same connection where the cursor was created.

We're using [Korma]() as a DSL to write SQL, and Korma uses [c3p0](). c3p0 [keeps its connections indefinitely](), so by making the pool only one connection (initially, and at most), we'll always be in the right place.

Only having one connection could raise problems if we're trying to multithread the app, though.