### PR TITLE
updated function to use precinct split polling locations

### DIFF
--- a/resources/migrations/20170331-00-polling-locations-include-precincts-splits.down.sql
+++ b/resources/migrations/20170331-00-polling-locations-include-precincts-splits.down.sql
@@ -1,0 +1,28 @@
+create or replace function v3_dashboard.polling_location_readable_report(pid text)
+returns table(locality_name text, precinct_name text, address_location_name text, address_line1 text, address_line2 text, address_line3 text, address_city text, address_state text, address_zip text, polling_location_id bigint)
+as $$
+begin
+return query
+select distinct on (v.identifier)
+       l.name, p.name, pl.address_location_name, pl.address_line1,
+       pl.address_line2, pl.address_line3, pl.address_city,
+       pl.address_state, pl.address_zip, v.identifier
+    from results r
+    join validations v on r.id = v.results_id
+    join v3_0_polling_locations pl
+      on v.identifier = pl.id
+      and pl.results_id = r.id
+    join v3_0_precinct_polling_locations ppl
+      on v.identifier = ppl.polling_location_id
+      and v.results_id = ppl.results_id
+    join v3_0_precincts p
+      on ppl.precinct_id = p.id
+      and p.results_id = r.id
+    join v3_0_localities l
+      on l.id = p.locality_id
+      and l.results_id = r.id
+    where r.public_id = pid
+    and v.scope = 'polling-locations'
+    and v.error_type like 'address%';
+end
+$$ language plpgsql;

--- a/resources/migrations/20170331-00-polling-locations-include-precincts-splits.up.sql
+++ b/resources/migrations/20170331-00-polling-locations-include-precincts-splits.up.sql
@@ -4,7 +4,7 @@ as $$
 begin
 return query
 select distinct on (v.identifier)
-       l1.name, p1.name, pl.address_location_name, pl.address_line1,
+       coalesce(l.name, l0.name), coalesce(p.name, p0.name), pl.address_location_name, pl.address_line1,
        pl.address_line2, pl.address_line3, pl.address_city,
        pl.address_state, pl.address_zip, v.identifier
     from results r
@@ -24,15 +24,15 @@ select distinct on (v.identifier)
     left join v3_0_precinct_splits ps
       on pspl.precinct_split_id = ps.id
       and ps.results_id = r.id
-    left join v3_0_precincts p1
-      on ps.precinct_id = p1.id
-      and p1.results_id = r.id
+    left join v3_0_precincts p0
+      on ps.precinct_id = p0.id
+      and p0.results_id = r.id
     left join v3_0_localities l
       on l.id = p.locality_id
       and l.results_id = r.id
-    left join v3_0_localities l1
-      on l1.id = p1.locality_id
-      and l1.results_id = r.id
+    left join v3_0_localities l0
+      on l0.id = p0.locality_id
+      and l0.results_id = r.id
     where r.public_id = pid
     and v.scope = 'polling-locations'
     and v.error_type like 'address%';

--- a/resources/migrations/20170331-00-polling-locations-include-precincts-splits.up.sql
+++ b/resources/migrations/20170331-00-polling-locations-include-precincts-splits.up.sql
@@ -1,0 +1,40 @@
+create or replace function v3_dashboard.polling_location_readable_report(pid text)
+returns table(locality_name text, precinct_name text, address_location_name text, address_line1 text, address_line2 text, address_line3 text, address_city text, address_state text, address_zip text, polling_location_id bigint)
+as $$
+begin
+return query
+select distinct on (v.identifier)
+       l1.name, p1.name, pl.address_location_name, pl.address_line1,
+       pl.address_line2, pl.address_line3, pl.address_city,
+       pl.address_state, pl.address_zip, v.identifier
+    from results r
+    join validations v on r.id = v.results_id
+    join v3_0_polling_locations pl
+      on v.identifier = pl.id
+      and pl.results_id = r.id
+    left join v3_0_precinct_polling_locations ppl
+      on v.identifier = ppl.polling_location_id
+      and v.results_id = ppl.results_id
+    left join v3_0_precinct_split_polling_locations pspl
+      on v.identifier = pspl.polling_location_id
+      and v.results_id = pspl.results_id
+    left join v3_0_precincts p
+      on ppl.precinct_id = p.id
+      and p.results_id = r.id
+    left join v3_0_precinct_splits ps
+      on pspl.precinct_split_id = ps.id
+      and ps.results_id = r.id
+    left join v3_0_precincts p1
+      on ps.precinct_id = p1.id
+      and p1.results_id = r.id
+    left join v3_0_localities l
+      on l.id = p.locality_id
+      and l.results_id = r.id
+    left join v3_0_localities l1
+      on l1.id = p1.locality_id
+      and l1.results_id = r.id
+    where r.public_id = pid
+    and v.scope = 'polling-locations'
+    and v.error_type like 'address%';
+end
+$$ language plpgsql;


### PR DESCRIPTION
This is a PR for [this bug](https://www.pivotaltracker.com/story/show/142810681).  The AR feed included data on the `v3_0_precinct_split_polling_locations` table rather than the `v3_0_precinct_polling_locations` table (which is totally valid).  The function that generates the polling location address error report was only using `v3_0_precinct_split_polling_locations`, so no data was generated for this AR feed.  

We updated the `v3_dashboard.polling_location_readable_report` function to use left joins and include joins to `v3_0_precinct_split_polling_locations` and `v3_0_precinct_splits` and then use those tables to join to `v3_0_precincts` and `v3_0_localities` (so you'll see that we join to each those two tables twice in the function, but using different source tables in each case).  Making them all left joins is necessary to work regardless of whether `v3_0_precinct_polling_locations` or `v3_0_precinct_split_polling_locations` is populated.