### PR TITLE
Load ltree XML in parallel

### DIFF
--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -238,13 +238,14 @@
   (let [xml-file (first (:input ctx))
         import-id (:import-id ctx)]
     (with-open [reader (util/bom-safe-reader xml-file)]
-      (doall (pmap insert
-                   (->> reader
-                        xml/parse
-                        path-and-values
-                        (partition 5000 5000 '())
-                        (map (fn [chunk]
-                               (map (partial paths->ltree import-id) chunk)))))))
+      (dorun
+       (pmap insert
+             (->> reader
+                  xml/parse
+                  path-and-values
+                  (partition 5000 5000 '())
+                  (map (fn [chunk]
+                         (map (partial paths->ltree import-id) chunk)))))))
     ctx))
 
 (defn determine-spec-version [ctx]


### PR DESCRIPTION
When we're loading XML for a 5.1 feed, we turn each tag into a map in `path-and-values`. Since each of these maps exists in isolation, we can insert chunks in parallel! For a large feed, this cuts the runtime of this step in the pipeline by about 1/3; our large XML files were taking 30-45 minutes, but this brings them down to a slightly more reasonable 10-15 minutes. The cost of doing inserts in parallel is CPU load as the connection pool jumps to 15 simultaneous connections.

Credit goes to @tank157 for this suggestion.