### PR TITLE
new migrations to fix crosstab

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -28,10 +28,10 @@
    psql/store-spec-version
    psql/store-public-id
    psql/store-election-id
+   psql/v5-summary-branch
    data-processor/add-validations
    errors/close-errors-chan
-   errors/await-statistics
-   psql/v5-summary-branch])
+   errors/await-statistics])
 
 (defn -main [filename]
   (psql/initialize)

--- a/resources/migrations/20170411-00-fix-locality-stats-crosstab.down.sql
+++ b/resources/migrations/20170411-00-fix-locality-stats-crosstab.down.sql
@@ -1,0 +1,198 @@
+drop function v5_dashboard.locality_stats(integer, text);
+
+create function v5_dashboard.locality_stats(rid int, locality_id text)
+returns table(results_id int, id text, name text, type text, error_count int,
+              precinct_errors int, precinct_count int, precinct_completion int,
+              polling_location_errors int, polling_location_count int, polling_location_completion int,
+              street_segment_errors int, street_segment_count int, street_segment_completion int,
+              hours_open_errors int, hours_open_count int, hours_open_completion int,
+              election_administration_errors int, election_administration_count int, election_administration_completion int,
+              department_errors int, department_count int, department_completion int,
+              voter_service_errors int, voter_service_count int, voter_service_completion int)
+as $$
+  declare
+    locality record;
+    pbl ltree[];
+    precinct_polling_location_ids text[];
+    precinct_polling_locations ltree[];
+    locality_ea ltree[];
+    precincts text[];
+    street_segments ltree[];
+    precinct_errors int;
+    precinct_completion int;
+    street_segment_errors int;
+    street_segment_count int;
+    street_segment_completion int;
+    polling_location_errors int;
+    polling_location_count int;
+    polling_location_completion int;
+    hours_open_errors int;
+    hours_open_count int;
+    hours_open_completion int;
+    election_administration_errors int;
+    election_administration_count int;
+    election_administration_completion int;
+    department_count int;
+    error_count int;
+  begin
+    select ct.parent_with_id, ct.name, ct.type, ct.id
+    into locality
+    from crosstab('select xtv.parent_with_id, subpath(xtv.simple_path, -1) as element, xtv.value
+                   from xml_tree_values xtv
+                   where xtv.results_id = ''' || rid || '''
+                   and xtv.simple_path in (''VipObject.Locality.id'',
+                   ''VipObject.Locality.Name'',
+                   ''VipObject.Locality.Type'')
+                   and xtv.path <@ (select subpath(xtv.parent_with_id, 0, 4)
+                                    from xml_tree_values xtv
+                                    where xtv.results_id = ''' || rid || '''
+                                      and xtv.simple_path = ''VipObject.Locality.id''
+                                      and xtv.value = ''' || locality_id || ''')
+                                    order by parent_with_id, element')
+    as ct(parent_with_id ltree, name text, type text, id text);
+    pbl := v5_dashboard.precincts_by_locality(rid, locality_id);
+
+    select string_to_array(string_agg(precincts.value, ' '), ' ')
+    into precinct_polling_location_ids
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.PollingLocationIds'
+      and precincts.parent_with_id <@ pbl;
+
+    select array_agg(subpath(polling_locations.parent_with_id, 0, 4))
+    into precinct_polling_locations
+    from xml_tree_values polling_locations
+    where polling_locations.results_id = rid
+    and polling_locations.simple_path = 'VipObject.PollingLocation.id'
+    and polling_locations.value in (select unnest(precinct_polling_location_ids));
+
+    select count(subpath(errors.path, 0, 4)) as precincts
+    into precinct_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+      and errors.path ~ '*.Precinct.*'
+      and errors.path <@ pbl
+      or errors.error_data = '"' || locality_id || '"';
+
+    select array_agg(precincts.value)
+    into precincts
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.id'
+      and precincts.path <@ pbl;
+
+    precinct_completion := v5_dashboard.completion_rate(cardinality(precincts), precinct_errors);
+
+    select array_agg(subpath(xtv.parent_with_id, 0, 4))
+    into street_segments
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and xtv.simple_path = 'VipObject.StreetSegment.PrecinctId'
+      and xtv.value in (select unnest(precincts));
+
+    select count(subpath(polling_location_errors.path, 0, 4))
+    into polling_location_errors
+    from xml_tree_validations polling_location_errors
+    where polling_location_errors.results_id = rid
+      and polling_location_errors.path ~ '*.PollingLocation.*'
+      and polling_location_errors.path <@ precinct_polling_locations;
+
+    polling_location_count := cardinality(precinct_polling_locations);
+    polling_location_completion := v5_dashboard.completion_rate(polling_location_count, polling_location_errors);
+
+    select count(subpath(errors.path, 0, 4))
+    into street_segment_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+      and errors.path <@ street_segments
+      and errors.path ~ '*.StreetSegment.*';
+
+    street_segment_completion := v5_dashboard.completion_rate(cardinality(street_segments), street_segment_errors);
+
+    select count(subpath(errors.path, 0, 4))
+    into hours_open_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+    and errors.path ~ '*.HoursOpen.*'
+    and errors.path <@ (select array_agg(hours_open.parent_with_id)
+                        from xml_tree_values hours_open
+                        where hours_open.results_id = rid
+                        and hours_open.simple_path = 'VipObject.HoursOpen.id'
+                        and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                        (select polling_location.value as hours_open_id
+                         from xml_tree_values polling_location
+                         where polling_location.results_id = rid
+                         and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                         and polling_location.parent_with_id <@ precinct_polling_locations));
+
+    select count(hours_open.value) as hours_open
+    into hours_open_count
+    from xml_tree_values hours_open
+    where hours_open.results_id = rid
+      and hours_open.simple_path = 'VipObject.HoursOpen.id'
+      and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                           (select polling_location.value as hours_open_id
+                           from xml_tree_values polling_location
+                           where polling_location.results_id = rid
+                             and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                             and polling_location.parent_with_id <@ precinct_polling_locations);
+    hours_open_completion := v5_dashboard.completion_rate(hours_open_count, hours_open_errors);
+
+    locality_ea := v5_dashboard.locality_election_administration(rid, locality_id);
+
+    select count(errors.path)
+      into election_administration_errors
+      from xml_tree_validations errors
+      where errors.results_id = rid
+        and element_type(errors.path) = 'ElectionAdministration'
+      and errors.path <@ locality_ea;
+
+    election_administration_completion := v5_dashboard.completion_rate(cardinality(locality_ea), election_administration_errors);
+
+    select count(xtv.path)
+    into department_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and xtv.path ~ '*.Department.*{1}'
+      and xtv.path <@ locality_ea;
+
+    select count(xtv.path)
+    into department_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'Department'
+      and xtv.parent_with_id <@ locality_ea;
+
+    department_completion := v5_dashboard.completion_rate(department_count, department_errors);
+
+    select count(xtv.path)
+    into voter_service_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.path <@ locality_ea;
+
+    select count(distinct subpath(xtv.path, 0, 6))
+    into voter_service_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.parent_with_id <@ locality_ea;
+
+    voter_service_completion := v5_dashboard.completion_rate(voter_service_count, voter_service_errors);
+
+    error_count := precinct_errors + polling_location_errors + street_segment_errors +
+                   hours_open_errors + election_administration_errors + department_errors +
+                   voter_service_errors;
+    return query
+    select
+      rid, locality.id, locality.name, locality.type, error_count,
+      precinct_errors, cardinality(precincts), precinct_completion,
+      polling_location_errors, polling_location_count, polling_location_completion,
+      street_segment_errors, cardinality(street_segments), street_segment_completion,
+      hours_open_errors, hours_open_count, hours_open_completion,
+      election_administration_errors, cardinality(locality_ea), election_administration_completion,
+      department_errors, department_count, department_completion,
+      voter_service_errors, voter_service_count, voter_service_completion;
+  end;
+$$ language plpgsql;

--- a/resources/migrations/20170411-00-fix-locality-stats-crosstab.up.sql
+++ b/resources/migrations/20170411-00-fix-locality-stats-crosstab.up.sql
@@ -1,0 +1,206 @@
+drop function v5_dashboard.locality_stats (integer, text);
+
+create index xtv_paths on xml_tree_validations using gist (path);
+
+create function v5_dashboard.locality_stats(rid int, lid text)
+returns table(results_id int, id text, name text, type text, error_count int,
+              precinct_errors int, precinct_count int, precinct_completion int,
+              polling_location_errors int, polling_location_count int, polling_location_completion int,
+              street_segment_errors int, street_segment_count int, street_segment_completion int,
+              hours_open_errors int, hours_open_count int, hours_open_completion int,
+              election_administration_errors int, election_administration_count int, election_administration_completion int,
+              department_errors int, department_count int, department_completion int,
+              voter_service_errors int, voter_service_count int, voter_service_completion int)
+as $$
+  declare
+    locality record;
+    pbl ltree[];
+    precinct_polling_location_ids text[];
+    precinct_polling_locations ltree[];
+    locality_ea ltree[];
+    precincts text[];
+    street_segments ltree[];
+    precinct_errors int;
+    precinct_completion int;
+    street_segment_errors int;
+    street_segment_count int;
+    street_segment_completion int;
+    polling_location_errors int;
+    polling_location_count int;
+    polling_location_completion int;
+    hours_open_errors int;
+    hours_open_count int;
+    hours_open_completion int;
+    election_administration_errors int;
+    election_administration_count int;
+    election_administration_completion int;
+    department_count int;
+    error_count int;
+  begin
+    select ct.parent_with_id, ct.name, ct.type, ct.id
+    into locality
+    from crosstab('select xtv.parent_with_id, subpath(xtv.simple_path, -1) as element, xtv.value
+                   from xml_tree_values xtv
+                   where xtv.results_id = ''' || rid || '''
+                   and xtv.simple_path in (''VipObject.Locality.id'',
+                   ''VipObject.Locality.Name'',
+                   ''VipObject.Locality.Type'')
+                   and xtv.path <@ (select subpath(xtv.parent_with_id, 0, 4)
+                                    from xml_tree_values xtv
+                                    where xtv.results_id = ''' || rid || '''
+                                      and xtv.simple_path = ''VipObject.Locality.id''
+                                      and xtv.value = ''' || lid || ''')
+                                    order by parent_with_id, element',
+                    'select unnest(ARRAY[''Name'', ''Type'', ''id''])' )
+    as ct(parent_with_id ltree, name text, type text, id text);
+    pbl := v5_dashboard.precincts_by_locality(rid, lid);
+
+    select string_to_array(string_agg(precincts.value, ' '), ' ')
+    into precinct_polling_location_ids
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.PollingLocationIds'
+      and precincts.parent_with_id <@ pbl;
+
+    select array_agg(subpath(polling_locations.parent_with_id, 0, 4))
+    into precinct_polling_locations
+    from xml_tree_values polling_locations
+    where polling_locations.results_id = rid
+    and polling_locations.simple_path = 'VipObject.PollingLocation.id'
+    and polling_locations.value in (select unnest(precinct_polling_location_ids));
+
+    select count(subpath(errors.path, 0, 4)) as precincts
+    into precinct_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+      and errors.path ~ 'VipObject.*{1}.Precinct.*'
+      and errors.path <@ pbl
+      or errors.error_data = '"' || lid || '"';
+
+    select array_agg(precincts.value)
+    into precincts
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.id'
+      and precincts.path <@ pbl;
+
+    precinct_completion := v5_dashboard.completion_rate(cardinality(precincts), precinct_errors);
+
+    select array_agg(subpath(xtv.parent_with_id, 0, 4))
+    into street_segments
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and xtv.simple_path = 'VipObject.StreetSegment.PrecinctId'
+      and xtv.value in (select unnest(precincts));
+
+    select count(subpath(polling_location_errors.path, 0, 4))
+    into polling_location_errors
+    from xml_tree_validations polling_location_errors
+    where polling_location_errors.results_id = rid
+      and polling_location_errors.path ~ 'VipObject.0.PollingLocation.*'
+      and polling_location_errors.path <@ precinct_polling_locations;
+
+    polling_location_count := cardinality(precinct_polling_locations);
+    polling_location_completion := v5_dashboard.completion_rate(polling_location_count, polling_location_errors);
+
+    with paths as (
+      select unnest (paths) as path
+      from v5_dashboard.paths_by_locality pbl
+      where pbl.results_id = rid
+        and pbl.locality_id = lid)
+    select count (v.path)
+    into street_segment_errors
+    from paths p, xml_tree_validations v
+    where v.results_id = rid
+      and v.path ~ 'VipObject.0.StreetSegment.*'
+      and v.path <@ p.path;
+
+    street_segment_completion := v5_dashboard.completion_rate(cardinality(street_segments), street_segment_errors);
+
+    select count(subpath(errors.path, 0, 4))
+    into hours_open_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+    and errors.path ~ 'VipObject.0.HoursOpen.*'
+    and errors.path <@ (select array_agg(hours_open.parent_with_id)
+                        from xml_tree_values hours_open
+                        where hours_open.results_id = rid
+                        and hours_open.simple_path = 'VipObject.HoursOpen.id'
+                        and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                        (select polling_location.value as hours_open_id
+                         from xml_tree_values polling_location
+                         where polling_location.results_id = rid
+                         and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                         and polling_location.parent_with_id <@ precinct_polling_locations));
+
+    select count(hours_open.value) as hours_open
+    into hours_open_count
+    from xml_tree_values hours_open
+    where hours_open.results_id = rid
+      and hours_open.simple_path = 'VipObject.HoursOpen.id'
+      and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                           (select polling_location.value as hours_open_id
+                           from xml_tree_values polling_location
+                           where polling_location.results_id = rid
+                             and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                             and polling_location.parent_with_id <@ precinct_polling_locations);
+    hours_open_completion := v5_dashboard.completion_rate(hours_open_count, hours_open_errors);
+
+    locality_ea := v5_dashboard.locality_election_administration(rid, lid);
+
+    select count(errors.path)
+      into election_administration_errors
+      from xml_tree_validations errors
+      where errors.results_id = rid
+        and element_type(errors.path) = 'ElectionAdministration'
+      and errors.path <@ locality_ea;
+
+    election_administration_completion := v5_dashboard.completion_rate(cardinality(locality_ea), election_administration_errors);
+
+    select count(xtv.path)
+    into department_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and xtv.path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*{1}'
+      and xtv.path <@ locality_ea;
+
+    select count(xtv.path)
+    into department_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'Department'
+      and xtv.parent_with_id <@ locality_ea;
+
+    department_completion := v5_dashboard.completion_rate(department_count, department_errors);
+
+    select count(xtv.path)
+    into voter_service_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.path <@ locality_ea;
+
+    select count(distinct subpath(xtv.path, 0, 6))
+    into voter_service_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.parent_with_id <@ locality_ea;
+
+    voter_service_completion := v5_dashboard.completion_rate(voter_service_count, voter_service_errors);
+
+    error_count := precinct_errors + polling_location_errors + street_segment_errors +
+                   hours_open_errors + election_administration_errors + department_errors +
+                   voter_service_errors;
+    return query
+    select
+      rid, locality.id, locality.name, locality.type, error_count,
+      precinct_errors, cardinality(precincts), precinct_completion,
+      polling_location_errors, polling_location_count, polling_location_completion,
+      street_segment_errors, cardinality(street_segments), street_segment_completion,
+      hours_open_errors, hours_open_count, hours_open_completion,
+      election_administration_errors, cardinality(locality_ea), election_administration_completion,
+      department_errors, department_count, department_completion,
+      voter_service_errors, voter_service_count, voter_service_completion;
+  end;
+$$ language plpgsql;

--- a/resources/migrations/20170418-00-adjust-temp-table-indices.down.sql
+++ b/resources/migrations/20170418-00-adjust-temp-table-indices.down.sql
@@ -1,0 +1,130 @@
+create or replace function v5_dashboard.populate_locality_table(rid integer)
+returns void as $$
+declare
+  localities record;
+  precincts ltree[];
+  precincts_values text[];
+  polling_locations ltree[];
+  hours_open ltree[];
+  street_segments ltree[];
+  electoral_districts ltree[];
+  contests ltree[];
+  locality_paths ltree[];
+  election_administrations ltree[];
+  temp_table text;
+begin
+  delete from v5_dashboard.paths_by_locality where results_id = rid;
+  temp_table := 'locality_stuff_' || rid;
+
+  execute 'create temp table ' || temp_table || ' on commit drop as
+     select path, simple_path, value, parent_with_id
+     from xml_tree_values
+     where results_id = ' || rid || '
+     and path ~ ''VipObject.0.HoursOpen|Locality|ElectionAdministration|ElectoralDistrict|Precinct|PollingLocation|StreetSegment|Contest|BallotMeasureContest|CandidateContest|OrderedContest|RetentionContest|PartyContest.*'''
+  using rid;
+
+  execute 'create index '|| temp_table::regclass || '_ss_idx
+           on ' || temp_table::regclass ||
+          ' (simple_path, value)
+          where simple_path = ''VipObject.StreetSegment.PrecinctId''';
+
+  execute 'create index ' || temp_table::regclass ||'_other_idx
+           on ' || temp_table::regclass ||
+          ' (simple_path, path, value, parent_with_id)
+          where simple_path = ''VipObject.Precinct.id''
+             or simple_path = ''VipObject.Precinct.PollingLocationIds''
+             or simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+             or simple_path = ''VipObject.PollingLocation.id''
+             or simple_path = ''VipObject.PollingLocation.HoursOpenId''
+             or simple_path = ''VipObject.HoursOpen.id''';
+
+  execute 'analyze ' || temp_table;
+
+  for localities in
+    execute 'select value as id, array_agg(parent_with_id) as precincts
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.Precinct.LocalityId''
+               and parent_with_id is not null
+               group by value
+               order by value'
+  loop
+    execute 'with precincts as (
+               select array_agg(value) as v
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.id''
+                 and path <@ $1)
+             select array_agg(subpath(parent_with_id, 0, 4))
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.StreetSegment.PrecinctId''
+               and value in (select unnest(precincts.v) from precincts)'
+    into street_segments
+    using localities.precincts;
+
+    execute 'with polling_locations as (
+               select string_to_array(string_agg(value, '' ''), '' '') as ids
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.PollingLocationIds''
+                 and parent_with_id <@ $1)
+             select array_agg(subpath(parent_with_id, 0, 4))
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.PollingLocation.id''
+               and value in (select unnest(ids) from polling_locations)'
+    into polling_locations
+    using localities.precincts;
+
+    execute 'with districts
+             as (select string_to_array(string_agg(value, '' ''), '' '') as ids
+                 from ' || temp_table::regclass || '
+                 where simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+                   and path <@ $1)
+             select array_agg(parent_with_id)
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.ElectoralDistrict.id''
+               and value in (select unnest(districts.ids) from districts)'
+    into electoral_districts
+    using localities.precincts;
+
+    execute 'with districts as (
+               select string_to_array(string_agg(value, '' ''), '' '') as ids
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+                 and path <@ $1)
+             select array_agg(parent_with_id)
+             from ' || temp_table::regclass || '
+             where simple_path ~ ''VipObject.Contest|BallotMeasureContest|CandidateContest|OrderedContest|RetentionContest|PartyContest.*''
+               and value in (select unnest(districts.ids) from districts)'
+    into contests
+    using localities.precincts;
+
+    execute 'select array_agg(path)
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.HoursOpen.id''
+               and value in (select value
+                             from ' || temp_table::regclass || '
+                             where simple_path = ''VipObject.PollingLocation.HoursOpenId''
+                               and parent_with_id <@ $1)'
+    into hours_open
+    using polling_locations;
+
+    execute
+      'with locality as
+        (select * from ' || temp_table::regclass || '
+            where simple_path = ''VipObject.Locality.id''
+            and value = $1),
+      election_admin as
+        (select t.* from ' || temp_table::regclass || ' t
+            join locality on locality.parent_with_id = t.parent_with_id
+            where t.simple_path = ''VipObject.Locality.ElectionAdministrationId''),
+      path as (
+          select t.parent_with_id from ' || temp_table::regclass || ' t
+          join election_admin on election_admin.value = t.value
+          and t.simple_path = ''VipObject.ElectionAdministration.id'')
+      select array_agg(t.path) from '|| temp_table::regclass ||' t join path on t.parent_with_id = path.parent_with_id'
+    into election_administrations
+    using localities.id;
+
+    locality_paths :=  localities.precincts || polling_locations || hours_open || street_segments || electoral_districts || contests || election_administrations;
+    insert into v5_dashboard.paths_by_locality values(rid, localities.id, locality_paths);
+  end loop;
+end;
+$$ language plpgsql;

--- a/resources/migrations/20170418-00-adjust-temp-table-indices.up.sql
+++ b/resources/migrations/20170418-00-adjust-temp-table-indices.up.sql
@@ -1,0 +1,141 @@
+create or replace function v5_dashboard.populate_locality_table(rid integer)
+returns void as $$
+declare
+  localities record;
+  precincts ltree[];
+  precincts_values text[];
+  polling_locations ltree[];
+  hours_open ltree[];
+  street_segments ltree[];
+  electoral_districts ltree[];
+  contests ltree[];
+  locality_paths ltree[];
+  election_administrations ltree[];
+  temp_table text;
+begin
+  delete from v5_dashboard.paths_by_locality where results_id = rid;
+  temp_table := 'locality_stuff_' || rid;
+  raise notice '% building temp table...', clock_timestamp();
+  execute 'create temp table ' || temp_table || ' on commit drop as
+     select path, simple_path, value, parent_with_id
+     from xml_tree_values
+     where results_id = ' || rid || '
+     and path ~ ''VipObject.0.HoursOpen|Locality|ElectionAdministration|ElectoralDistrict|Precinct|PollingLocation|StreetSegment|Contest|BallotMeasureContest|CandidateContest|OrderedContest|RetentionContest|PartyContest.*'''
+  using rid;
+
+  raise notice '% building index 1/2...', clock_timestamp();
+  execute 'create index '|| temp_table::regclass || '_ss_idx
+           on ' || temp_table::regclass ||
+          ' (simple_path, value)
+          where simple_path = ''VipObject.StreetSegment.PrecinctId''';
+  raise notice '% building index 2/2...', clock_timestamp();
+  execute 'create index ' || temp_table::regclass ||'_other_idx
+           on ' || temp_table::regclass ||
+          ' (simple_path, path, value, parent_with_id)
+          where simple_path = ''VipObject.Precinct.id''
+             or simple_path = ''VipObject.Precinct.PollingLocationIds''
+             or simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+             or simple_path = ''VipObject.ElectoralDistrict.id''
+             or simple_path = ''VipObject.Precinct.LocalityId''
+             or simple_path = ''VipObject.PollingLocation.id''
+             or simple_path = ''VipObject.PollingLocation.HoursOpenId''
+             or simple_path = ''VipObject.Locality.id''
+             or simple_path = ''VipObject.Locality.ElectionAdministrationId''
+             or simple_path = ''VipObject.ElectionAdministration.id''
+             or simple_path ~ ''VipObject.Contest|BallotMeasureContest|CandidateContest|OrderedContest|RetentionContest|PartyContest.*''
+             or simple_path = ''VipObject.HoursOpen.id''';
+
+  execute 'analyze ' || temp_table;
+  raise notice '% about to loop...', clock_timestamp();
+  for localities in
+    execute 'select value as id, array_agg(parent_with_id) as precincts
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.Precinct.LocalityId''
+               and parent_with_id is not null
+               group by value
+               order by value'
+  loop
+    raise notice '% beginning loop, doing street segments...', clock_timestamp();
+    execute 'with precincts as (
+               select array_agg(value) as v
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.id''
+                 and path <@ $1)
+             select array_agg(subpath(parent_with_id, 0, 4))
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.StreetSegment.PrecinctId''
+               and value in (select unnest(precincts.v) from precincts)'
+    into street_segments
+    using localities.precincts;
+    raise notice '% doing polling locations...', clock_timestamp();
+    execute 'with polling_locations as (
+               select string_to_array(string_agg(value, '' ''), '' '') as ids
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.PollingLocationIds''
+                 and parent_with_id <@ $1)
+             select array_agg(subpath(parent_with_id, 0, 4))
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.PollingLocation.id''
+               and value in (select unnest(ids) from polling_locations)'
+    into polling_locations
+    using localities.precincts;
+    raise notice '% doing electoral districts...', clock_timestamp();
+    execute 'with districts
+             as (select string_to_array(string_agg(value, '' ''), '' '') as ids
+                 from ' || temp_table::regclass || '
+                 where simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+                   and path <@ $1)
+             select array_agg(parent_with_id)
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.ElectoralDistrict.id''
+               and value in (select unnest(districts.ids) from districts)'
+    into electoral_districts
+    using localities.precincts;
+    raise notice '% doing contests...', clock_timestamp();
+    execute 'with districts as (
+               select string_to_array(string_agg(value, '' ''), '' '') as ids
+               from ' || temp_table::regclass || '
+               where simple_path = ''VipObject.Precinct.ElectoralDistrictIds''
+                 and path <@ $1)
+             select array_agg(parent_with_id)
+             from ' || temp_table::regclass || '
+             where simple_path ~ ''VipObject.Contest|BallotMeasureContest|CandidateContest|OrderedContest|RetentionContest|PartyContest.*''
+               and value in (select unnest(districts.ids) from districts)'
+    into contests
+    using localities.precincts;
+    raise notice '% doing hours open...', clock_timestamp();
+    execute 'select array_agg(path)
+             from ' || temp_table::regclass || '
+             where simple_path = ''VipObject.HoursOpen.id''
+               and value in (select value
+                             from ' || temp_table::regclass || '
+                             where simple_path = ''VipObject.PollingLocation.HoursOpenId''
+                               and parent_with_id <@ $1)'
+    into hours_open
+    using polling_locations;
+
+    raise notice '% doing election administration...', clock_timestamp();
+    execute
+      'with locality as
+        (select * from ' || temp_table::regclass || '
+            where simple_path = ''VipObject.Locality.id''
+            and value = $1),
+      election_admin as
+        (select t.* from ' || temp_table::regclass || ' t
+            join locality on locality.parent_with_id = t.parent_with_id
+            where t.simple_path = ''VipObject.Locality.ElectionAdministrationId''),
+      path as (
+          select t.parent_with_id from ' || temp_table::regclass || ' t
+          join election_admin on election_admin.value = t.value
+          and t.simple_path = ''VipObject.ElectionAdministration.id'')
+      select array_agg(t.path) from '|| temp_table::regclass ||' t join path on t.parent_with_id = path.parent_with_id'
+    into election_administrations
+    using localities.id;
+
+    raise notice '% finishing up...', clock_timestamp();
+
+    locality_paths :=  localities.precincts || polling_locations || hours_open || street_segments || electoral_districts || contests || election_administrations;
+    insert into v5_dashboard.paths_by_locality values(rid, localities.id, locality_paths);
+  end loop;
+end;
+$$ language plpgsql;

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -61,10 +61,10 @@
            psql/store-spec-version
            psql/store-public-id
            psql/store-election-id
+           psql/v5-summary-branch
            add-validations
            errors/close-errors-chan
            errors/await-statistics
-           psql/v5-summary-branch
            s3/upload-to-s3
            cleanup/cleanup]))
 

--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -271,6 +271,7 @@
 (defn populate-locality-table
   [ctx]
   (let [id (:import-id ctx)]
+    (log/info "Populating v5_dashboard.paths_by_locality")
     (korma/exec-raw
      (:conn xml-tree-values)
      ["select v5_dashboard.populate_locality_table(?)" [id]]))
@@ -303,7 +304,8 @@
 
 (defn v5-summary-branch
   [{:keys [spec-version] :as ctx}]
-  (if (= @spec-version "5.1")
+  (log/info "In v5-summary-branch")
+  (if (= (util/version-without-patch @spec-version) "5.1")
     (update ctx :pipeline (partial concat [populate-locality-table
                                            populate-i18n-table
                                            populate-sources-table

--- a/test/vip/data_processor/validation/v5/locality_test.clj
+++ b/test/vip/data_processor/validation/v5/locality_test.clj
@@ -129,6 +129,7 @@
   (let [errors-chan (a/chan 100)
         pipeline [psql/start-run
                   t/xml-csv-branch
+                  psql/v5-summary-branch
                   data-processor/add-validations
                   errors/close-errors-chan
                   errors/await-statistics]


### PR DESCRIPTION
For [this card](https://www.pivotaltracker.com/n/projects/1106394/stories/143593837) a fix to the `v5_dashboard.locality_stats` function to deal with instances where data requested for the crosstab is unavailable.  Previously ,a missing  `Name` or `Type` would push the `id` out from the column where it's meant to be and we would not only lose that data on the locality table on the main feed page but then also lose the link to get more information about a specific locality.  This migration will properly align the data in the `locality` table on the main feed page so we don't lose that connection to the locality report.