### PR TITLE
Source & Election are required elements; verify their presence

### DIFF
--- a/src/vip/data_processor/validation/v5/election.clj
+++ b/src/vip/data_processor/validation/v5/election.clj
@@ -17,10 +17,14 @@
         election-count (-> result
                            first
                            :election_count)]
-    (if (> election-count 1)
-      (errors/add-errors ctx :fatal :election "VipObject.0.Election" :count
-                         :more-than-one)
-      ctx)))
+    (cond
+      (zero? election-count) (errors/add-errors
+                              ctx :fatal :election "VipObject.0.Election"
+                              :count :missing-election)
+      (> election-count 1) (errors/add-errors
+                            ctx :fatal :election "VipObject.0.Election"
+                            :count :more-than-one))
+    ctx))
 
 (def validate-date
   (util/build-xml-tree-value-query-validator

--- a/src/vip/data_processor/validation/v5/source.clj
+++ b/src/vip/data_processor/validation/v5/source.clj
@@ -18,10 +18,14 @@
         source-count (-> result
                          first
                          :source_count)]
-    (if (> source-count 1)
-      (errors/add-errors ctx :fatal :source "VipObject.0.Source" :count
-                         :more-than-one)
-      ctx)))
+    (cond
+      (zero? source-count) (errors/add-errors
+                              ctx :fatal :source "VipObject.0.Source"
+                              :count :missing-source)
+      (> source-count 1) (errors/add-errors
+                            ctx :fatal :source "VipObject.0.Source"
+                            :count :more-than-one))
+    ctx))
 
 (def validate-name
   (util/build-xml-tree-value-query-validator

--- a/test/vip/data_processor/validation/v5/election_test.clj
+++ b/test/vip/data_processor/validation/v5/election_test.clj
@@ -33,7 +33,23 @@
                       xml/load-xml-ltree
                       v5.election/validate-one-election)
           errors (all-errors errors-chan)]
-      (assert-no-problems errors {}))))
+      (assert-no-problems errors {})))
+
+  (testing "having no Election is a problem"
+    (let [errors-chan (a/chan 100)
+          ctx {:input (xml-input "v5-one-source.xml")
+               :pipeline []
+               :errors-chan errors-chan}
+          out-ctx (-> ctx
+                      psql/start-run
+                      xml/load-xml-ltree
+                      v5.election/validate-one-election)
+          errors (all-errors errors-chan)]
+      (is (contains-error? errors
+                           {:severity :fatal
+                            :scope :election
+                            :identifier "VipObject.0.Election"
+                            :error-type :count})))))
 
 (deftest ^:postgres validate-date-test
   (testing "Date element missing is a fatal error"


### PR DESCRIPTION
Franklin noticed that we're [not validating the presence](https://www.pivotaltracker.com/story/show/144223187) of `Source` or `Election` elements, which should probably be fatal errors (my guess, since not knowing which election, on which date, a set of polling locations is for seems tricky). The 5.1 spec says [there must be one and only one](https://github.com/votinginfoproject/data-processor/blob/master/resources/specs/vip_spec_v5.1.2.xsd#L631), so that seems to fit with this being a fatal error.

This PR updates the validations to check for their presence. A feed missing both of these elements would have these two new errors shown on the dashboard like this:

![screen shot 2017-04-24 at 4 10 44 pm](https://cloud.githubusercontent.com/assets/104658/25360996/f849662e-2908-11e7-8d06-fecf22135df2.png)
