### PR TITLE
Replace any return char with \n in 5.1 text blocks

### DIFF
--- a/src/vip/data_processor/validation/data_spec/translate.clj
+++ b/src/vip/data_processor/validation/data_spec/translate.clj
@@ -1,0 +1,6 @@
+(ns vip.data-processor.validation.data-spec.translate
+  (:require [clojure.string :as str])
+  (:import [java.text Normalizer]))
+
+(defn clean-text [v]
+  (str/replace v #"\R" "\n"))

--- a/src/vip/data_processor/validation/data_spec/v3_0.clj
+++ b/src/vip/data_processor/validation/data_spec/v3_0.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.data-spec.v3-0
   (:require [vip.data-processor.validation.data-spec.value-format :as format]
-            [vip.data-processor.validation.data-spec.coerce :as coerce]))
+            [vip.data-processor.validation.data-spec.coerce :as coerce]
+            [vip.data-processor.validation.data-spec.translate :as translate]))
 
 (def data-specs
   [{:filename "ballot.txt"
@@ -39,7 +40,7 @@
     :tag-name :ballot_response
     :stats true
     :columns [{:name "id" :required :critical :format format/all-digits :coerce coerce/coerce-integer}
-              {:name "text" :required :critical}
+              {:name "text" :required :critical :translate translate/clean-text}
               {:name "sort_order" :format format/all-digits :coerce coerce/coerce-integer}]}
    {:filename "candidate.txt"
     :table :candidates
@@ -291,7 +292,7 @@
               {:name "title" :required :critical}
               {:name "subtitle"}
               {:name "brief"}
-              {:name "text" :required :critical}
+              {:name "text" :required :critical :translate translate/clean-text}
               {:name "pro_statement"}
               {:name "con_statement"}
               {:name "passage_threshold"}

--- a/src/vip/data_processor/validation/data_spec/v5_1.clj
+++ b/src/vip/data_processor/validation/data_spec/v5_1.clj
@@ -1,6 +1,7 @@
 (ns vip.data-processor.validation.data-spec.v5-1
   (:require [vip.data-processor.validation.data-spec.value-format :as format]
-            [vip.data-processor.validation.data-spec.coerce :as coerce]))
+            [vip.data-processor.validation.data-spec.coerce :as coerce]
+            [vip.data-processor.validation.data-spec.translate :as translate]))
 
 (def street-segments
   {:columns [{:name "id"}
@@ -65,11 +66,11 @@
               {:name "id"}
               {:name "con_statement"}
               {:name "effect_of_abstain"}
-              {:name "full_text"}
+              {:name "full_text" :translate translate/clean-text}
               {:name "info_uri"}
               {:name "passage_threshold"}
               {:name "pro_statement"}
-              {:name "summary_text"}
+              {:name "summary_text" :translate translate/clean-text}
               {:name "type"}
               {:name "other_type"}]}
    {:filename "ballot_measure_selection.txt"
@@ -82,7 +83,7 @@
     :columns [{:name "id"}
               {:name "ballot_measure_contest_ids"}
               {:name "ballot_measure_contest_selection_ids"}
-              {:name "text"}
+              {:name "text" :translate translate/clean-text}
               {:name "candidate_id"}
               {:name "endorsement_party_id"}
               {:name "is_write_in"}
@@ -335,11 +336,11 @@
               {:name "other_vote_variation"}
               {:name "con_statement"}
               {:name "effect_of_abstain"}
-              {:name "full_text"}
+              {:name "full_text" :translate translate/clean-text}
               {:name "info_uri"}
               {:name "passage_threshold"}
               {:name "pro_statement"}
-              {:name "summary_text"}
+              {:name "summary_text" :translate translate/clean-text}
               {:name "type"}
               {:name "other_type"}
               {:name "candidate_id"}

--- a/test/vip/data_processor/validation/data_spec/translate_test.clj
+++ b/test/vip/data_processor/validation/data_spec/translate_test.clj
@@ -1,0 +1,9 @@
+(ns vip.data-processor.validation.data-spec.translate-test
+  (:require [clojure.test :refer :all]
+            [vip.data-processor.validation.data-spec.translate :refer :all]))
+
+(deftest clean-text-test
+  (testing "replaces formfeed with newline"
+    (let [bad-text "Hello\fWorld!"
+          good-text "Hello\nWorld!"]
+      (is (= good-text (clean-text bad-text))))))


### PR DESCRIPTION
Fixes the formfeed issue identified in [this bug](https://www.pivotaltracker.com/story/show/144406851). Verified that before this fix the provided CSV feed fails to run in `xmllint` with an invalid char. After, the feed still fails to be valid according to `xmllint`, but for issues of structure (missing `<Name>` elements for one).

I applied the `clean-text` function to any 5.1 data-spec fields that seemed like they could be larger blocks of text where newlines are likely to appear.