### PR TITLE
added function to get early vote site address error report

### DIFF
--- a/resources/migrations/20170609-00-early_vote_address_report.down.sql
+++ b/resources/migrations/20170609-00-early_vote_address_report.down.sql
@@ -1,0 +1,1 @@
+drop function v3_dashboard.early_vote_location_address_report(text);

--- a/resources/migrations/20170609-00-early_vote_address_report.up.sql
+++ b/resources/migrations/20170609-00-early_vote_address_report.up.sql
@@ -1,0 +1,19 @@
+create or replace function v3_dashboard.early_vote_location_address_report(pid text)
+returns table(early_vote_site_name text, address_location_name text, address_line1 text, address_line2 text, address_line3 text, address_city text, address_state text, address_zip text, polling_location_id bigint)
+as $$
+begin
+return query
+select distinct on (v.identifier)
+       ev.name, ev.address_location_name, ev.address_line1,
+       ev.address_line2, ev.address_line3, ev.address_city,
+       ev.address_state, ev.address_zip, v.identifier
+    from results r
+    join validations v on r.id = v.results_id
+    join v3_0_early_vote_sites ev
+      on v.identifier = ev.id
+      and ev.results_id = r.id
+    where r.public_id = pid
+    and v.scope = 'early-vote-sites'
+    and v.error_type like 'address%';
+end
+$$ language plpgsql;

--- a/resources/migrations/20170609-00-early_vote_address_report.up.sql
+++ b/resources/migrations/20170609-00-early_vote_address_report.up.sql
@@ -1,10 +1,10 @@
 create or replace function v3_dashboard.early_vote_location_address_report(pid text)
-returns table(early_vote_site_name text, address_location_name text, address_line1 text, address_line2 text, address_line3 text, address_city text, address_state text, address_zip text, polling_location_id bigint)
+returns table(locality_name text, early_vote_site_name text, address_location_name text, address_line1 text, address_line2 text, address_line3 text, address_city text, address_state text, address_zip text, polling_location_id bigint)
 as $$
 begin
 return query
 select distinct on (v.identifier)
-       ev.name, ev.address_location_name, ev.address_line1,
+       l.name, ev.name, ev.address_location_name, ev.address_line1,
        ev.address_line2, ev.address_line3, ev.address_city,
        ev.address_state, ev.address_zip, v.identifier
     from results r
@@ -12,6 +12,10 @@ select distinct on (v.identifier)
     join v3_0_early_vote_sites ev
       on v.identifier = ev.id
       and ev.results_id = r.id
+    join v3_0_locality_early_vote_sites lev
+      on ev.id = lev.early_vote_site_id
+    join v3_0_localities l
+      on l.id = lev.locality_id
     where r.public_id = pid
     and v.scope = 'early-vote-sites'
     and v.error_type like 'address%';


### PR DESCRIPTION
For [this card](https://www.pivotaltracker.com/story/show/145550577) and related to [this PR](https://github.com/votinginfoproject/Metis/pull/370)--a database function to generate an address-specific error report for Early Vote Sites.  It grabs all early vote sites with an address-related error and groups them together i.e. if your Early Vote Site is missing both a zip and a state, that site will have it's own line with those two pieces missing.