### PR TITLE
fix 5.1 output file name

### DIFF
--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -65,8 +65,8 @@
            add-validations
            errors/close-errors-chan
            errors/await-statistics
-           psql/delete-from-xml-tree-values
            s3/upload-to-s3
+           psql/delete-from-xml-tree-values
            cleanup/cleanup]))
 
 (defn-traced process-message [message]


### PR DESCRIPTION
We figured out that 5.1 feeds rely on the `xml_tree_values` table to generate the name for the output file it saves to s3.  By deleting from `xml_tree_values` before the output is saved to s3 all 5.1 feeds were being named `vipfeed-XX-YY-.zip` instead of getting their intended value.  Moving the delete step to after the file is uploaded to s3 should fix this.