### PR TITLE
Upgrade squishy

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,9 +10,10 @@
                  [clj-time "0.12.2"]
                  [clj-aws-s3 "0.3.10" :exclusions [joda-time]]
                  [com.climate/clj-newrelic "0.2.1"]
-                 [democracyworks/squishy "2.0.0" :exclusions [joda-time
-                                                              org.slf4j/slf4j-simple
-                                                              org.slf4j/slf4j-api]]
+                 [democracyworks/squishy "3.0.1"
+                    :exclusions [joda-time
+                                 org.slf4j/slf4j-simple
+                                 org.slf4j/slf4j-api]]
                  [org.clojure/core.async "0.2.391"]
                  [democracyworks/utility-fns "0.2.0"]
                  [net.lingala.zip4j/zip4j "1.3.2"]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -4,7 +4,8 @@
             :processed-bucket #resource-config/env "VIP_DP_S3_PROCESSED_BUCKET"}
        :sqs {:region #aws/region #resource-config/env "VIP_DP_SQS_REGION"
              :queue #resource-config/env "VIP_DP_SQS_QUEUE"
-             :fail-queue #resource-config/env "VIP_DP_SQS_FAIL_QUEUE"}}
+             :fail-queue #resource-config/env "VIP_DP_SQS_FAIL_QUEUE"
+             :visibility-timeout 43200}}
  :postgres {:host #resource-config/env "DB_PORT_5432_TCP_ADDR"
             :port #resource-config/env "DB_PORT_5432_TCP_PORT"
             :user #resource-config/env "DB_ENV_POSTGRES_USER"

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -101,10 +101,10 @@
     (q/initialize)
     (psql/initialize)
     (q/publish {:id id :event "starting"} "qa-engine.status")
-    (let [consumer (consume)]
+    (let [consumer-id (consume)]
       (.addShutdownHook (Runtime/getRuntime)
                         (Thread. (fn []
                                    (log/info "VIP Data Processor shutting down...")
                                    (q/publish {:id id :event "stopping"} "qa-engine.status")
-                                   (future-cancel consumer))))
+                                   (sqs/stop-consumer consumer-id))))
       @consumer)))

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -89,11 +89,14 @@
 
 (defn consume []
   (let [{:keys [access-key secret-key]} (config [:aws :creds])
-        {:keys [region queue fail-queue]} (config [:aws :sqs])
+        {:keys [region queue fail-queue
+                visibility-timeout]} (config [:aws :sqs])
         creds {:access-key access-key
                :access-secret secret-key
-               :region region}]
-    (sqs/consume-messages creds queue fail-queue process-message)))
+               :region region}
+        opts (when visibility-timeout
+               {:visibility-timeout visibility-timeout})]
+    (sqs/consume-messages creds queue fail-queue opts process-message)))
 
 (defn -main [& args]
   (let [id (java.util.UUID/randomUUID)]
@@ -107,4 +110,4 @@
                                    (log/info "VIP Data Processor shutting down...")
                                    (q/publish {:id id :event "stopping"} "qa-engine.status")
                                    (sqs/stop-consumer consumer-id))))
-      @consumer)))
+      @consumer-id)))


### PR DESCRIPTION
Reviving this older branch so we can take advantage of the visibility-timeout feature to prevent any super long running feeds from effectively DOSing the data-processor nodes.

Setting the timeout to 12 hours initially to match the current setting on the queues.