### PR TITLE
Duplicate polling place warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ The message you send on the SQS queue must look like the following:
 It is an EDN map, with the key `:filename`, whose value is the name of
 a file in the `VIP_DP_S3_UNPROCESSED_BUCKET` S3 bucket.
 
+## Testing
+
+### Non-Postgres tests
+
+`lein test`
+
+### Postgres tests
+
+There are two ways you can do this.
+
+#### Local DB
+
+Using a locally running postgres db
+`lein test :postgres`
+
+#### Docker
+
+Will create a DB as part of the docker-compose stack
+`script/postgres-tests`
+
 ## Developing
 
 The processing pipeline is defined as a sequence of functions that

--- a/resources/migrations/20170919-00-add-polling-locations-ids-idx.down.sql
+++ b/resources/migrations/20170919-00-add-polling-locations-ids-idx.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS xtv_localities_polling_locations_ids_idx;
+DROP INDEX IF EXISTS xtv_precincts_polling_locations_ids_idx;

--- a/resources/migrations/20170919-00-add-polling-locations-ids-idx.up.sql
+++ b/resources/migrations/20170919-00-add-polling-locations-ids-idx.up.sql
@@ -1,0 +1,12 @@
+DROP INDEX IF EXISTS xtv_localities_polling_locations_ids_idx;
+
+CREATE INDEX xtv_localities_polling_locations_ids_idx
+ON xml_tree_values (results_id, path, value)
+WHERE path ~ 'VipObject.*.Locality.*.PollingLocationIds.*';
+
+DROP INDEX IF EXISTS xtv_precincts_polling_locations_ids_idx;
+
+CREATE INDEX xtv_precincts_polling_locations_ids_idx
+ON xml_tree_values (results_id, path, value)
+WHERE path ~ 'VipObject.*.Precinct.*.PollingLocationIds.*';
+

--- a/src/vip/data_processor/errors.clj
+++ b/src/vip/data_processor/errors.clj
@@ -5,9 +5,16 @@
 (defrecord ValidationError [ctx severity scope
                             identifier error-type error-value])
 
-(defn add-errors [{:keys [errors-chan] :as ctx}
-                  severity scope identifier error-type
-                  & error-data]
+(defn add-errors
+  "Adds an error to the validations.
+  severity: keyword, one of :fatal, :critical, :errors, :warnings
+  scope: keyword, roughly the location of the error (:precinct, :id, :import, :global)
+  identifier: If it's a specific type like Precinct, the ID of the Precinct
+  error-type: keyword, specific subclass of error (:duplicate, :missing-data)
+  error-data: one or more value that caused the error (ie bad zip code)."
+  [{:keys [errors-chan] :as ctx}
+   severity scope identifier error-type
+   & error-data]
   (doseq [error-value error-data]
     (a/>!! errors-chan
            (->ValidationError ctx severity scope identifier error-type error-value)))
@@ -17,9 +24,13 @@
 (defrecord V5ValidationError [ctx severity scope
                                 identifier error-type error-value parent-element-id])
 
-(defn add-v5-errors [{:keys [errors-chan] :as ctx}
-                     severity scope identifier error-type parent-element-id
-                     & error-data]
+(defn add-v5-errors
+  "Same error options as add-errors, also with a parent-element-id which
+   is often used to associate some child error on, say, Id, to the element it
+   is in, ie Precinct."
+  [{:keys [errors-chan] :as ctx}
+   severity scope identifier error-type parent-element-id
+   & error-data]
   (doseq [error-value error-data]
     (a/>!! errors-chan
            (->V5ValidationError ctx severity scope identifier error-type error-value parent-element-id)))

--- a/src/vip/data_processor/errors.clj
+++ b/src/vip/data_processor/errors.clj
@@ -27,7 +27,11 @@
 (defn add-v5-errors
   "Same error options as add-errors, also with a parent-element-id which
    is often used to associate some child error on, say, Id, to the element it
-   is in, ie Precinct."
+   is in, ie Precinct. This is important since we drop the table that was
+   previously used to look this up. So if there is a parent element associated
+   to the particular error type, it's important to use this instead of
+   `add-errors` to preserve that information. If your error is of a more
+   global type of nature, you can just use `add-errors`."
   [{:keys [errors-chan] :as ctx}
    severity scope identifier error-type parent-element-id
    & error-data]

--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -77,4 +77,5 @@
    polling-location/validate-no-missing-longitudes
    polling-location/validate-latitude
    polling-location/validate-longitude
+   polling-location/check-for-polling-locations-mapped-to-multiple-places
    booleans/validate-format])

--- a/src/vip/data_processor/validation/v5/polling_location.clj
+++ b/src/vip/data_processor/validation/v5/polling_location.clj
@@ -51,7 +51,7 @@
          :results)
         ids (map :dup_id results)]
     (if (seq ids)
-      (errors/add-errors ctx :warning :id :global
+      (errors/add-errors ctx :warnings :id :global
                          :multiple-polling-locations-mappings
                          (str/join " " ids))
       ctx)))

--- a/src/vip/data_processor/validation/v5/polling_location.clj
+++ b/src/vip/data_processor/validation/v5/polling_location.clj
@@ -1,6 +1,11 @@
 (ns vip.data-processor.validation.v5.polling-location
-  (:require [vip.data-processor.validation.v5.util :as util]
-            [clojure.edn :as edn]))
+  (:require [vip.data-processor.errors :as errors]
+            [vip.data-processor.validation.v5.util :as util]
+            [clojure.edn :as edn]
+            [clojure.tools.logging :as log]
+            [clojure.string :as str]
+            [korma.core :as korma]
+            [vip.data-processor.db.postgres :as postgres]))
 
 (def validate-no-missing-address-lines
   (util/validate-no-missing-elements :polling-location [:address-line]))
@@ -22,3 +27,31 @@
                           [:longitude]
                           (comp float? edn/read-string)
                           :errors :format))
+
+(defn check-for-polling-locations-mapped-to-multiple-places
+  "Sometimes Polling Locations are mistakenly scoped in
+   both Localities and Precincts. Usually, though not always,
+   this is a misunderstanding, so let's warn if it happens."
+  [{:keys [import-id] :as ctx}]
+  (log/info "Checking for Polling Places mapped to multiple levels for import: " import-id)
+  (let [results
+        (korma/exec-raw
+         (:conn postgres/xml-tree-values)
+         ["with locality_polling_locations AS
+             (select unnest(regexp_split_to_array(value, E'\\\\s+')) as id
+              from xml_tree_values where results_id = ? AND
+              path ~ 'VipObject.*.Locality.*.PollingLocationIds.*'),
+           precinct_polling_locations AS
+             (select unnest(regexp_split_to_array(value, E'\\\\s+')) as id from
+              xml_tree_values where results_id = ? AND
+              path ~ 'VipObject.*.Precinct.*.PollingLocationIds.*')
+           select distinct lpl.id as dup_id from locality_polling_locations lpl
+             join precinct_polling_locations ppl on lpl.id = ppl.id"
+          [import-id import-id]]
+         :results)
+        ids (map :dup_id results)]
+    (if (seq ids)
+      (errors/add-errors ctx :warning :id :global
+                         :multiple-polling-locations-mappings
+                         (str/join " " ids))
+      ctx)))

--- a/src/vip/data_processor/validation/v5/polling_location.clj
+++ b/src/vip/data_processor/validation/v5/polling_location.clj
@@ -33,7 +33,7 @@
    both Localities and Precincts. Usually, though not always,
    this is a misunderstanding, so let's warn if it happens."
   [{:keys [import-id] :as ctx}]
-  (log/info "Checking for Polling Places mapped to multiple levels for import: " import-id)
+  (log/info "Checking for Polling Places mapped to localities and precincts")
   (let [results
         (korma/exec-raw
          (:conn postgres/xml-tree-values)

--- a/test-resources/xml/v5-polling-locations-duplicated.xml
+++ b/test-resources/xml/v5-polling-locations-duplicated.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.1">
+  <Locality id="lc001">
+    <PollingLocationIds>pl001 pl002 pl003 pl004</PollingLocationIds>
+  </Locality>
+  <Precinct id="pc001">
+    <PollingLocationIds>pl001</PollingLocationIds>
+  </Precinct>
+  <Precinct id="pc002">
+    <PollingLocationIds>pl003</PollingLocationIds>
+  </Precinct>
+  <Precinct id="pc003">
+    <PollingLocationIds>pl005</PollingLocationIds>
+  </Precinct>
+  <PollingLocation id="pl001">
+  </PollingLocation>
+  <PollingLocation id="pl002">
+    <AddressLine>I'm an address line</AddressLine>
+  </PollingLocation>
+  <PollingLocation id="pl003">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Latitude>39.750016</Latitude>
+      <Longitude>-105.000361</Longitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
+  <PollingLocation id="pl004">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Longitude>-105.000361</Longitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
+  <PollingLocation id="pl005">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Latitude>39.750016</Latitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
+  <PollingLocation id="pl006">
+    <AddressLine>I'm an address line</AddressLine>
+    <LatLng>
+      <Latitude>invalid latitude</Latitude>
+      <Longitude></Longitude>
+      <Source>I'm a source</Source>
+    </LatLng>
+  </PollingLocation>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/polling_location_test.clj
+++ b/test/vip/data_processor/validation/v5/polling_location_test.clj
@@ -4,7 +4,8 @@
             [vip.data-processor.test-helpers :refer :all]
             [vip.data-processor.db.postgres :as psql]
             [vip.data-processor.validation.xml :as xml]
-            [clojure.core.async :as a]))
+            [clojure.core.async :as a]
+            [clojure.string :as str]))
 
 (use-fixtures :once setup-postgres)
 
@@ -87,3 +88,25 @@
                             :scope :lat-lng
                             :identifier "VipObject.0.PollingLocation.5.LatLng.1.Latitude.0"
                             :error-type :format})))))
+
+(deftest ^:postgres check-for-polling-locations-mapped-to-multiple-places-test
+  (let [errors-chan (a/chan 100)
+        ctx {:input (xml-input "v5-polling-locations-duplicated.xml")
+             :errors-chan errors-chan}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.polling-location/check-for-polling-locations-mapped-to-multiple-places)
+        errors (all-errors errors-chan)
+        dup-warning (matching-errors
+                     errors
+                     {:severity :warning
+                      :scope :id
+                      :error-type :multiple-polling-locations-mappings})]
+    (testing "there is a warning"
+      (is (seq dup-warning))
+      (is (= 1 (count dup-warning)))
+      (testing "with duplicated polling location ids in the value"
+        (let [error-value (-> dup-warning first :error-value)]
+          (is (str/includes? error-value "pl001"))
+          (is (str/includes? error-value "pl003")))))))

--- a/test/vip/data_processor/validation/v5/polling_location_test.clj
+++ b/test/vip/data_processor/validation/v5/polling_location_test.clj
@@ -100,7 +100,7 @@
         errors (all-errors errors-chan)
         dup-warning (matching-errors
                      errors
-                     {:severity :warning
+                     {:severity :warnings
                       :scope :id
                       :error-type :multiple-polling-locations-mappings})]
     (testing "there is a warning"


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/150649639)

Runs a check for polling location ids in both localities and precincts, and adds a warning with all of the ids if any are found.