### PR TITLE
updating deployment for newer buildkite agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ things:
 
 - `fleetctl` installed (available in Homebrew)
 - The public IP address of an EC2 instance in your chosen cluster (aka
-  `$FLEETCTL_TUNNEL`),
+  `$FLEETCTL_TUNNEL`), and the appropriate key for that environment added to your ssh-agent, e.g. `ssh-add ~/.ssh/key.pem`.
 - A [quay.io account][quay] to use with Docker (run `docker login quay.io` if you haven't
   already)
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ things:
 - `fleetctl` installed (available in Homebrew)
 - The public IP address of an EC2 instance in your chosen cluster (aka
   `$FLEETCTL_TUNNEL`),
-- The ssh key for that cluster (aka `$PEM_FILE`)
 - A [quay.io account][quay] to use with Docker (run `docker login quay.io` if you haven't
   already)
 
@@ -247,9 +246,8 @@ deployment should look something like this.
 
 ```
 $ export FLEETCTL_TUNNEL=an-ip-in-your-cluster
-$ PEM_FILE=/path/to/key.pem ./script/deploy
+$ ./script/deploy
 Agent pid 88741
-Identity added: /path/to/key.pem (/path/to/key.pem)
 Destroyed data-processor@.service
 Unit data-processor@.service inactive
 --- (re-)starting fleet service instances

--- a/script/build
+++ b/script/build
@@ -16,7 +16,7 @@ DOCKER_IMAGE=$DOCKER_REPO:$IMAGE_TAG
 echo '--- building docker image'
 docker build -t $DOCKER_IMAGE .
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if [ $CI = "true" ]; then
     echo '--- pushing docker image to registry'
     docker login -e="." -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
     docker push $DOCKER_IMAGE
@@ -29,7 +29,7 @@ cp ${SERVICE}@.service.template ${SERVICE}@.service
 
 perl -p -i -e "s|^Environment=DOCKER_IMAGE=.*$|Environment=DOCKER_IMAGE=${DOCKER_IMAGE}|" ${SERVICE}@.service
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if hash buildkite-agent 2>/dev/null ; then
   echo '--- saving service file'
   buildkite-agent artifact upload ${SERVICE}@.service
 fi

--- a/script/deploy
+++ b/script/deploy
@@ -14,20 +14,12 @@ if [[ ! -e ${SERVICE}@.service ]]; then
   exit 1
 fi
 
-if [[ ! -e $PEM_FILE ]]; then
-  echo "Please provide a .pem file for the fleet"
-  exit 1
-fi
-
-eval "$(ssh-agent -s)"
-ssh-add $PEM_FILE
-
-fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service
+fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service || true
 fleetctl --strict-host-key-checking=false submit ${SERVICE}@.service
 
 echo '--- (re-)starting fleet service instances'
 for i in {1..3}; do
-  fleetctl --strict-host-key-checking=false destroy ${SERVICE}@$i
+  fleetctl --strict-host-key-checking=false destroy ${SERVICE}@$i || true
   fleetctl --strict-host-key-checking=false start ${SERVICE}@$i
   # TODO: Use consul to see if ${SERVICE}@$i is healthy yet before moving on
 done


### PR DESCRIPTION
@tie-rack I've got the BuildKite pipeline for this partially updated to make the transition. The old steps are now renamed with "legacy" and the new steps are in place. Deployment is current restricted in both legacy and new by branch filtering on NONE, but the plan will be to only selectively deploy to staging, and turn master branch filtering on deploy to production.

Once this is approved, I'll remove legacy steps, turn master branch deploys on production, and merge this.