### PR TITLE
Add validation check for invalid xml characters

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,8 @@
                  [org.postgresql/postgresql "42.0.0" :exclusions [org.slf4j/slf4j-simple
                                                                   org.slf4j/slf4j-api]]
                  [org.xerial/sqlite-jdbc "3.8.11.2"]
-                 [commons-lang/commons-lang "2.6"]]
+                 [commons-lang/commons-lang "2.6"]
+                 [xerces/xercesImpl "2.11.0"]]
   :plugins [[com.pupeno/jar-copier "0.4.0"]]
   :profiles {:test {:resource-paths ["test-resources"]
                     :dependencies [[com.github.kyleburton/clj-xpath "1.4.5"]]}

--- a/test-resources/csv/invalid-xml-chars/candidate.txt
+++ b/test-resources/csv/invalid-xml-chars/candidate.txt
@@ -1,0 +1,16 @@
+name,party,candidate_url,biography,phone,photo_url,filed_mailing_address_location_name,filed_mailing_address_line1,filed_mailing_address_line2,filed_mailing_address_line3,filed_mailing_address_city,filed_mailing_address_state,filed_mailing_address_zip,email,sort_order,id
+"Candidate (Candidate) Candidate",,,"Elected Experience: In 2013 I was appointed to council, and then elected in 2014 for a four year term.
+
+Other Professional Experience: I served as treasurer, secretary and president on the board of directors of the Foothill Historical Society, Womans Musical Literary club, and treasurer on the Friends of Buckley Library board.
+
+Education: Graduated from White River High School and attended Green River Community college as well as Washington State College.
+
+Community Service: For over 20 years I have held several different board office positions and have been an active volunteer with the Foothills Historical Museum and friends of Buckley library. 
+
+Statement: I have a long history of supporting the Buckley community throughtout my professional career as well as volunteering many hour to help build this magnifient community.
+
+As our city continues to grow, I will support projects and events that bring people together to strengthen a sense of community and of belonging. Our Youth Center, public parks, and Summer Series programs provide opportunities to welcome our new citizens.
+
+I am committed to preserving the history of Buckley. However, I am a firm believer that the old and the new can coexist as we preserve our history but plan for the future.
+
+If elected, I will make balanced decisions, aware that my vote affects all the members of our wonderful community.",360-555-5555,http://weiapplets.sos.wa.gov,,"PO BOX XXX",,,BUCKLEY,WA,99999,fake@email.com,2,1

--- a/test-resources/csv/invalid-xml-chars/source.txt
+++ b/test-resources/csv/invalid-xml-chars/source.txt
@@ -1,0 +1,2 @@
+name,vip_id,datetime,description,organization_url,feed_contact_id,tou_url,id
+"Department of Elections ÿ Commonwealth of	Virginia",51,2015-01-21T18:13:25,The Department of Elections is the official source for Virginia data,http://www.elections.virginia.gov/,,,1

--- a/test/vip/data_processor/validation/data_spec_test.clj
+++ b/test/vip/data_processor/validation/data_spec_test.clj
@@ -268,3 +268,20 @@
                               :identifier "1"
                               :error-type "name"
                               :error-value "Is not valid UTF-8."}))))))
+
+(deftest invalid-xml-chars?-test
+  (testing "marks any value with characters that are invalid in XML"
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (csv-inputs ["invalid-xml-chars/candidate.txt"])
+                      :errors-chan errors-chan
+                      :data-specs v3-0/data-specs}
+                     (sqlite/temp-db "invalid-utf-8" "3.0"))
+          out-ctx (csv/load-csvs ctx)
+          errors (all-errors errors-chan)]
+      (testing "reports errors for values with the Unicode replacement character"
+        (is (contains-error? errors
+                             {:severity :fatal
+                              :scope :candidates
+                              :identifier "1"
+                              :error-type "biography"
+                              :error-value "Contains characters that are invalid in XML."}))))))


### PR DESCRIPTION
After several dead-ends and wild goose chases, I finally tracked down a sensible, workable way to do this. While the [Pivotal Card](https://www.pivotaltracker.com/story/show/152411377) mentions non UTF-8 characters being the problem, it's actually valid UTF-8 characters that are invalid in XML. So this check will look at all the string values and check them for any invalid XML characters. For the test I added, I used the actual bad file from the card, stripped it down and removed identifying information, and the test passes in that it finds the expected error because of the bad character. It should help someone find the problem, but in the case of control characters like this, it may still be difficult as many/most editors will hide it. Still, progress!