### PR TITLE
Candidate address validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ processor:
 rabbitmq:
   image: rabbitmq:3.6.5-management
   ports:
+    - 45672:5672
     - 55672:15672
   hostname: qa-engine-rabbit
 db:

--- a/src/vip/data_processor/validation/db/v3_0.clj
+++ b/src/vip/data_processor/validation/db/v3_0.clj
@@ -1,12 +1,15 @@
 (ns vip.data-processor.validation.db.v3-0
-  (:require [vip.data-processor.validation.db.v3-0.admin-addresses :as admin-addresses]
-            [vip.data-processor.validation.db.v3-0.precinct :as precinct]
-            [vip.data-processor.validation.db.v3-0.street-segment :as street-segment]
-            [vip.data-processor.validation.db.v3-0.jurisdiction-references :as jurisdiction-references]
-            [vip.data-processor.validation.db.v3-0.fips :as fips]))
+  (:require
+   [vip.data-processor.validation.db.v3-0.admin-addresses :as admin-addresses]
+   [vip.data-processor.validation.db.v3-0.candidate-addresses :as candidate-addresses]
+   [vip.data-processor.validation.db.v3-0.fips :as fips]
+   [vip.data-processor.validation.db.v3-0.jurisdiction-references :as jurisdiction-references]
+   [vip.data-processor.validation.db.v3-0.precinct :as precinct]
+   [vip.data-processor.validation.db.v3-0.street-segment :as street-segment]))
 
 (def validations
   [admin-addresses/validate-addresses
+   candidate-addresses/validate-addresses
    precinct/validate-no-missing-polling-locations
    street-segment/validate-no-overlapping-street-segments
    fips/validate-valid-source-vip-id

--- a/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
+++ b/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
@@ -1,0 +1,34 @@
+(ns vip.data-processor.validation.db.v3-0.candidate-addresses
+  (:require [clojure.string :as str]
+            [com.climate.newrelic.trace :refer [defn-traced]]
+            [korma.core :as korma]
+            [vip.data-processor.errors :as errors]))
+
+(defn validate-addresses'
+  "Given a candidates-table, confirms that all the rows are correct in
+  terms of having non-null/blank values for the fields as required by
+  the spec:
+
+  https://github.com/votinginfoproject/data-processor/blob/bce02bcd0e8be67c6211d0edcf3f2d92a3d8b26d/resources/specs/vip_spec_v3.0.xsd#L336
+  "
+  [candidates-table]
+  (->> (korma/fields :id
+                     :filed_mailing_address_line1
+                     :filed_mailing_address_city
+                     :filed_mailing_address_state
+                     :filed_mailing_address_zip)
+       (korma/select candidates-table)
+       (filter #(->> (dissoc % :id) vals (some str/blank?)))))
+
+(defn-traced validate-addresses
+  [ctx]
+  (let [bad-addresses (validate-addresses' (get-in ctx [:tables :candidates]))]
+    (if (seq bad-addresses)
+      (reduce
+       (fn [ctx {:keys [id]}]
+         ;; maybe this function should take a map
+         (errors/add-errors
+          ctx :errors :candidates id
+          "incomplete-candidate-address" "Incomplete address"))
+       ctx bad-addresses)
+      ctx)))

--- a/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
+++ b/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
@@ -28,7 +28,7 @@
        (fn [ctx {:keys [id]}]
          ;; maybe this function should take a map
          (errors/add-errors
-          ctx :errors :candidates id
-          "incomplete-candidate-address" "Incomplete address"))
+          ctx :critical :candidates id
+          :incomplete-candidate-address "Incomplete address"))
        ctx bad-addresses)
       ctx)))

--- a/test-resources/csv/bad-candidate-addresses/candidate.txt
+++ b/test-resources/csv/bad-candidate-addresses/candidate.txt
@@ -1,0 +1,3 @@
+name,party,candidate_url,biography,phone,photo_url,filed_mailing_address_location_name,filed_mailing_address_state,filed_mailing_address_line1,filed_mailing_address_line3,filed_mailing_address_line2,filed_mailing_address_zip,filed_mailing_address_city,email,sort_order,id
+"Fake Candidate 1","Republican","http://fakecandidate1.com","","540-710-9221","","","VA","214 Creek Lane","","","22407","","fake12345@aol.com","2","10478"
+"Fake Candidate 2","Democrat","http://fakecandidate2.com","","540-710-9221","","Some Town","","","","","22407","","fake22345@aol.com","2","10479"

--- a/test/vip/data_processor/validation/db/v3_0/candidate_addresses_test.clj
+++ b/test/vip/data_processor/validation/db/v3_0/candidate_addresses_test.clj
@@ -1,0 +1,35 @@
+(ns vip.data-processor.validation.db.v3-0.candidate-addresses-test
+  (:require
+   [clojure.core.async :as a]
+   [clojure.test :refer [deftest testing is run-tests]]
+   [vip.data-processor.db.sqlite :as sqlite]
+   [vip.data-processor.pipeline :as pipeline]
+   [vip.data-processor.test-helpers :as test-helpers]
+   [vip.data-processor.validation.csv :as csv]
+   [vip.data-processor.validation.data-spec :as data-spec]
+   [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
+   [vip.data-processor.validation.db.v3-0.candidate-addresses :as candidate-addresses]))
+
+(deftest validate-candidate-addresses-test
+  (testing "errors are returned if either the physical or mailing address is incomplete"
+    (let [errors-chan (a/chan 100)
+          ctx (merge {:input (test-helpers/csv-inputs ["bad-candidate-addresses/candidate.txt"])
+                      :errors-chan errors-chan
+                      :pipeline [(data-spec/add-data-specs v3-0/data-specs)
+                                 csv/load-csvs
+                                 candidate-addresses/validate-addresses]}
+                     (sqlite/temp-db "incomplete-candidate-addresses" "3.0"))
+          out-ctx (pipeline/run-pipeline ctx)
+          errors (test-helpers/all-errors errors-chan)]
+
+      (is (test-helpers/contains-error? errors
+                                        {:severity :critical
+                                         :scope :candidates
+                                         :identifier 10478
+                                         :error-type :incomplete-candidate-address}))
+
+      (is (test-helpers/contains-error? errors
+                                        {:severity :critical
+                                         :scope :candidates
+                                         :identifier 10479
+                                         :error-type :incomplete-candidate-address})))))


### PR DESCRIPTION
This adds a check to confirm we have all the fields required when we have a [`filed_mailing_address`](https://github.com/votinginfoproject/data-processor/blob/bce02bcd0e8be67c6211d0edcf3f2d92a3d8b26d/resources/specs/vip_spec_v3.0.xsd#L206) for a candidate, which is an instance of a [`simpleAddressType`](https://github.com/votinginfoproject/data-processor/blob/bce02bcd0e8be67c6211d0edcf3f2d92a3d8b26d/resources/specs/vip_spec_v3.0.xsd#L336). This specifies that we should have, at the least, `line1`, `city`, `state`, and `zip`. While this does not mean we are now confirming the presence of these four fields for _any_ `simpleAddressType` in a feed, we are for a `candidate`, at least.

Correspondingly, while the card (https://www.pivotaltracker.com/story/show/151256241) only highlighted the bug where the ingestion breaks because of a missing `city` field for a candidate's address, after checking with Franklin he agreed that this we should be checking for all four of these fields.

Finally, I've set the severity to `:critical` after discussion with Franklin as well. I've also confirmed that the validation errors I've added here are showing up without any further work in the dashboard, both in the validation errors export CSV as well as in the appropriate places on the dashboard UI itself.