### PR TITLE
refactor bulk-import-and-validate-csv into a number of smaller functions

### DIFF
--- a/src/vip/data_processor/errors.clj
+++ b/src/vip/data_processor/errors.clj
@@ -18,7 +18,6 @@
   (doseq [error-value error-data]
     (a/>!! errors-chan
            (->ValidationError ctx severity scope identifier error-type error-value)))
-
   ctx)
 
 (defrecord V5ValidationError [ctx severity scope

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -6,17 +6,17 @@
             [com.climate.newrelic.trace :refer [defn-traced]]
             [korma.core :as korma]
             [korma.db :as db]
-            [vip.data-processor.util :as util]
+            [vip.data-processor.db.postgres :as postgres]
+            [vip.data-processor.db.sqlite :as sqlite]
+            [vip.data-processor.db.translations.transformer :as v5-1-transformers]
             [vip.data-processor.db.util :as db.util]
+            [vip.data-processor.errors :as errors]
+            [vip.data-processor.errors.process :as process]
+            [vip.data-processor.output.tree-xml :as tree-xml]
+            [vip.data-processor.util :as util]
             [vip.data-processor.validation.csv.file-set :as csv-files]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]
-            [vip.data-processor.output.tree-xml :as tree-xml]
-            [vip.data-processor.db.sqlite :as sqlite]
-            [vip.data-processor.db.postgres :as postgres]
-            [vip.data-processor.db.translations.transformer :as v5-1-transformers]
-            [vip.data-processor.errors :as errors]
-            [vip.data-processor.errors.process :as process]))
+            [vip.data-processor.validation.data-spec.v5-1 :as v5-1]))
 
 (defn csv-filenames [data-specs]
   (set (map :filename data-specs)))
@@ -30,7 +30,8 @@
 
 (defn-traced remove-bad-filenames [ctx]
   (let [input (:input ctx)
-        {good-files true bad-files false} (group-by (partial good-filename? (:data-specs ctx)) input)]
+        {good-files true
+         bad-files false} (group-by (partial good-filename? (:data-specs ctx)) input)]
     (if (seq bad-files)
       (let [bad-filenames (->> bad-files (map file-name) sort)
             bad-file-list (apply str (interpose ", " bad-filenames))]
@@ -41,100 +42,160 @@
             (assoc :input good-files)))
       ctx)))
 
-(defn csv-error-path [filename line-number]
+(defn csv-error-path
+  [filename line-number]
   (str "CSVError.0."
-       (-> filename
-           (str/split #"\.")
-           first)
+       (-> filename (str/split #"\.") first)
        "." line-number))
+
+(defn process-row
+  "Uses the supplied `format-rules` to process a given row. If there
+  is a mismatch in the size of the columns in the row and the columns
+  specified by the header, records an error. Increments the
+  line-number and returns the context ctx with the formatted row
+  merged in."
+  [{:keys [filename table] :as data-spec}
+   {:keys [line-number headers headers-count format-rules] :as file-ctx}
+   ctx row]
+  (swap! line-number inc)
+  (let [row-map (zipmap headers row)
+        row-count (count row)
+        ctx (data-spec/apply-format-rules format-rules ctx row-map @line-number)]
+    (if (= headers-count row-count)
+      ctx
+      (let [identifier (if (= "3.0" @(:spec-version ctx))
+                         @line-number
+                         (csv-error-path filename @line-number))]
+        (errors/add-errors
+         ctx :critical table identifier :number-of-values
+         (str "Expected " headers-count
+              " values, found " row-count))))))
+
+(defn maybe-coerce-to-db-type
+  [{:keys [import-id]} sql-table columns chunk-values]
+  (if (= "postgresql" (get-in sql-table [:db :options :subprotocol]))
+    (->> chunk-values
+         (data-spec/coerce-rows columns)
+         (map #(assoc % "results_id" import-id)))
+    chunk-values))
+
+(defn process-row-chunks
+  "Processes all the map rows in a chunk via `process-row` with the
+  supplied format-rules (see `data-spec/create-format-rules` in
+  `do-bulk-import-and-validate-csv`) transforms (see
+  `data-spec/translation-fns` in
+  `do-bulk-import-and-validate-csv`). Inserts the row into the
+  database, and records any UNIQUE constraint-failing SQLExceptions as
+  errors. Returns the context ctx. If the supplied chunk is empty,
+  simply returns the context as-is."
+  [{:keys [columns filename] :as data-spec}
+   {:keys [transforms column-names headers sql-table line-number] :as file-ctx}
+   ctx chunk]
+  (if (seq chunk)
+    (let [ctx (reduce (partial process-row data-spec file-ctx) ctx chunk)
+          transform-row-fn (comp
+                            transforms
+                            #(select-keys % column-names)
+                            (partial zipmap headers))
+          chunk-values (->> chunk
+                            (map transform-row-fn)
+                            (maybe-coerce-to-db-type ctx sql-table columns))]
+      (try
+        (korma/insert sql-table (korma/values chunk-values))
+        ctx
+        (catch java.sql.SQLException e
+          (let [message (.getMessage e)]
+            (if (re-find #"UNIQUE constraint failed: (\w+).id" message)
+              (db.util/retry-chunk-without-dupe-ids ctx sql-table chunk-values)
+              (let [identifier (if (= "3.0" @(:spec-version ctx))
+                                 @line-number
+                                 (csv-error-path filename @line-number))]
+                (errors/add-errors
+                 ctx :fatal (:name sql-table) identifier
+                 :unknown-sql-error message)))))))
+    ctx))
+
+(defn chunk-rows-and-process
+  "Converts the file into map rows using clojure.data.csv, chunks them
+  up into partitions so that we don't go over our statement parameter
+  limit, and then processes all the chunks using
+  `process-row-chunks`. Returns the context ctx. If no headers are
+  present reports an error and returns the context as-is."
+  [ctx
+   {:keys [table] :as data-spec}
+   {:keys [in-file headers required-header-names] :as file-ctx}]
+  (if-let [missing-headers (seq (set/difference (set required-header-names)
+                                                (set headers)))]
+    (apply
+     errors/add-errors
+     ctx :critical table :global :missing-headers missing-headers)
+    (->> (db.util/chunk-rows
+          (csv/read-csv in-file) sqlite/statement-parameter-limit)
+         (reduce (partial process-row-chunks data-spec file-ctx) ctx))))
 
 (defn read-one-line
   "Reads one line at a time from a reader and parses it as a CSV
-  string. Does not close the reader at the end, that's your job."
+  string. Does NOT close the reader at the end."
   [reader]
-  (->> reader
-       .readLine
-       csv/read-csv
-       first))
+  (->> reader .readLine csv/read-csv first))
+
+(defn warn-if-extraneous-headers
+  [ctx {:keys [table] :as data-spec} headers column-names]
+  (let [extraneous-headers (seq (set/difference (set headers) (set column-names)))]
+    (if extraneous-headers
+      (apply errors/add-errors
+             ctx :warnings table :global :extraneous-headers
+             extraneous-headers)
+      ctx)))
+
+(defn file-handle->string-keys
+  [file-handle]
+  (->> file-handle
+       read-one-line
+       (map #(str/replace % #"\W" ""))
+       (map str/lower-case)))
+
+(defn required-header-names
+  [columns]
+  (-> (comp (filter :required)
+            (map :name)
+            (map clojure.string/lower-case))
+      (eduction columns)))
+
+(defn do-bulk-import-and-validate-csv
+  "Prepares all the necessary formatting and transformation functions
+  along with other useful meta-data and initiates the insertion and
+  preliminary validation of CSV data using the chunking mechanism in
+  vip.data-processor.db.util/chunk-rows."
+  [{:keys [data-specs tables] :as ctx}
+   {:keys [filename table columns] :as data-spec}
+   in-file]
+  (let [headers (file-handle->string-keys in-file)
+        column-names (map :name columns)
+        ctx (warn-if-extraneous-headers ctx data-spec headers column-names)]
+    (if (empty? (set/intersection (set headers) (set column-names)))
+      (errors/add-errors ctx :critical table :global :no-header "No header row")
+      (->> {:in-file in-file
+            :sql-table (get tables table)
+            :headers headers
+            :headers-count (count headers)
+            :column-names column-names
+            :required-header-names (required-header-names columns)
+            :line-number (atom 1)
+            :format-rules (data-spec/create-format-rules data-specs filename columns)
+            :transforms (apply comp (data-spec/translation-fns columns))}
+           (chunk-rows-and-process ctx data-spec)))))
 
 (defn-traced bulk-import-and-validate-csv
   "Bulk importing and CSV validation is done in one go, so that it can
   be done without holding the entire file in memory at once."
-  [ctx {:keys [filename table columns] :as data-spec}]
+  [ctx {:keys [filename] :as data-spec}]
   (if-let [file-to-load (util/find-input-file ctx filename)]
     (do
       (log/info "Loading" filename)
       (try
         (with-open [in-file (util/bom-safe-reader file-to-load :encoding "UTF-8")]
-          (let [headers (->> in-file
-                             read-one-line
-                             (map #(str/replace % #"\W" ""))
-                             (map str/lower-case))
-                headers-count (count headers)
-                sql-table (get-in ctx [:tables table])
-                column-names (map :name columns)
-                required-header-names (->> columns
-                                           (filter :required)
-                                           (map :name)
-                                           (map str/lower-case))
-                extraneous-headers (seq (set/difference (set headers) (set column-names)))
-                transforms (apply comp (data-spec/translation-fns columns))
-                format-rules (data-spec/create-format-rules (:data-specs ctx) filename columns)
-                ctx (if extraneous-headers
-                      (apply errors/add-errors
-                             ctx :warnings table :global :extraneous-headers
-                             extraneous-headers)
-                      ctx)
-                line-number (atom 1)]
-            (if (empty? (set/intersection (set headers) (set column-names)))
-              (errors/add-errors ctx :critical table :global :no-header "No header row")
-              (if-let [missing-headers (seq (set/difference (set required-header-names) (set headers)))]
-                (apply errors/add-errors
-                       ctx :critical table :global :missing-headers
-                       missing-headers)
-                (reduce (fn [ctx chunk]
-                          (if (seq chunk)
-                            (let [ctx (reduce (fn [ctx row]
-                                                (swap! line-number inc)
-                                                (let [row-map (zipmap headers row)
-                                                      row-count (count row)
-                                                      ctx (data-spec/apply-format-rules format-rules ctx row-map @line-number)]
-                                                  (if (= headers-count row-count)
-                                                    ctx
-                                                    (let [identifier (if (= "3.0" @(:spec-version ctx))
-                                                                       @line-number
-                                                                       (csv-error-path filename @line-number))]
-                                                      (errors/add-errors
-                                                       ctx
-                                                       :critical
-                                                       table
-                                                       identifier
-                                                       :number-of-values
-                                                       (str "Expected " headers-count
-                                                            " values, found " row-count))))))
-                                              ctx chunk)
-                                  chunk-values (map (comp transforms #(select-keys % column-names) (partial zipmap headers)) chunk)
-                                  chunk-values (if (= "postgresql" (get-in sql-table [:db :options :subprotocol]))
-                                                 (->> chunk-values
-                                                      (data-spec/coerce-rows columns)
-                                                      (map #(assoc % "results_id" (:import-id ctx))))
-                                                 chunk-values)]
-                              (try
-                                (korma/insert sql-table (korma/values chunk-values))
-                                ctx
-                                (catch java.sql.SQLException e
-                                  (let [message (.getMessage e)]
-                                    (if (re-find #"UNIQUE constraint failed: (\w+).id" message)
-                                      (db.util/retry-chunk-without-dupe-ids ctx sql-table chunk-values)
-                                      (let [identifier (if (= "3.0" @(:spec-version ctx))
-                                                         @line-number
-                                                         (csv-error-path filename @line-number))]
-                                        (errors/add-errors
-                                         ctx :fatal (:name sql-table) identifier
-                                         :unknown-sql-error message)))))))
-                            ctx))
-                        ctx (db.util/chunk-rows (csv/read-csv in-file)
-                                                sqlite/statement-parameter-limit))))))
+          (do-bulk-import-and-validate-csv ctx data-spec in-file))
         (catch java.lang.Exception e
           (errors/add-errors ctx :fatal filename :global :csv-error (.getMessage e)))))
     ctx))

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -164,7 +164,7 @@
   [columns]
   (-> (comp (filter :required)
             (map :name)
-            (map clojure.string/lower-case))
+            (map str/lower-case))
       (eduction columns)))
 
 (defn make-row-translation-fn


### PR DESCRIPTION
...and add some docstrings to better document the intermediate steps in importing a CSV.

As I've been going through `data-processor` I've found many areas that are hard to understand, but as opposed to other parts of the code, this function was a place where I thought I could give us a quick refactoring win. This refactoring should not change the logic of the process, the goal here was simply to take an 80-line, hard to understand function and refactor it into a set of smaller, easy-to-understand functions, each with its own obvious purpose. This should also make the flow of data through the CSV import process more clear so that augmenting this or refactoring it more substantially at a later date becomes simpler.

Any further refactoring comments are very welcome--I really hope you let me know where things are still unclear. Ideally, by the time I'm ready to merge this PR in, I hope to have replaced the original function with some code that anyone on our team can read through and get the gist of pretty quickly.