### PR TITLE
fix too-strict candidate address validation

### DIFF
--- a/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
+++ b/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
@@ -10,22 +10,22 @@
     :filed_mailing_address_state
     :filed_mailing_address_zip})
 
-(defn invalid-address?
+(defn valid-address?
   [address]
   (let [address' (dissoc address :id)]
     (cond
       ;; if all address fields are empty then is valid
       (not (seq (remove str/blank? (vals address'))))
-      false
+      true
 
       ;; if there is an address with any required fields blank, then invalid
       (->> ((apply juxt required-address-fields) address')
            (some str/blank?))
-      true
+      false
 
       ;; Otherwise we have a valid address with all required fields
       :else
-      false)))
+      true)))
 
 (defn validate-addresses'
   "Given a candidates-table, confirms that all the rows are correct in
@@ -44,7 +44,7 @@
                      :filed_mailing_address_zip
                      :filed_mailing_address_city)
        (korma/select candidates-table)
-       (filter invalid-address?)))
+       (remove valid-address?)))
 
 (defn-traced validate-addresses
   [ctx]

--- a/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
+++ b/src/vip/data_processor/validation/db/v3_0/candidate_addresses.clj
@@ -4,6 +4,29 @@
             [korma.core :as korma]
             [vip.data-processor.errors :as errors]))
 
+(def required-address-fields
+  #{:filed_mailing_address_line1
+    :filed_mailing_address_city
+    :filed_mailing_address_state
+    :filed_mailing_address_zip})
+
+(defn invalid-address?
+  [address]
+  (let [address' (dissoc address :id)]
+    (cond
+      ;; if all address fields are empty then is valid
+      (not (seq (remove str/blank? (vals address'))))
+      false
+
+      ;; if there is an address with any required fields blank, then invalid
+      (->> ((apply juxt required-address-fields) address')
+           (some str/blank?))
+      true
+
+      ;; Otherwise we have a valid address with all required fields
+      :else
+      false)))
+
 (defn validate-addresses'
   "Given a candidates-table, confirms that all the rows are correct in
   terms of having non-null/blank values for the fields as required by
@@ -13,12 +36,15 @@
   "
   [candidates-table]
   (->> (korma/fields :id
-                     :filed_mailing_address_line1
-                     :filed_mailing_address_city
+                     :filed_mailing_address_location_name
                      :filed_mailing_address_state
-                     :filed_mailing_address_zip)
+                     :filed_mailing_address_line1
+                     :filed_mailing_address_line3
+                     :filed_mailing_address_line2
+                     :filed_mailing_address_zip
+                     :filed_mailing_address_city)
        (korma/select candidates-table)
-       (filter #(->> (dissoc % :id) vals (some str/blank?)))))
+       (filter invalid-address?)))
 
 (defn-traced validate-addresses
   [ctx]

--- a/test-resources/csv/bad-candidate-addresses/candidate.txt
+++ b/test-resources/csv/bad-candidate-addresses/candidate.txt
@@ -2,3 +2,4 @@ name,party,candidate_url,biography,phone,photo_url,filed_mailing_address_locatio
 "Fake Candidate 1","Republican","http://fakecandidate1.com","","540-710-9221","","","VA","214 Creek Lane","","","22407","","fake12345@aol.com","2","10478"
 "Fake Candidate 2","Democrat","http://fakecandidate2.com","","540-710-9221","","","","","","","22407","Some Town","fake22345@aol.com","2","10479"
 "Fake Candidate 3","Republican","http://fakecandidate3.com","","540-710-9221","","","VA","214 Creek Lane","","","22407","Some Town","fake32345@aol.com","2","10480"
+"Fake Candidate 4","Republican","http://fakecandidate4.com","","540-710-9221","","","","","","","","","fake42345@aol.com","2","10481"

--- a/test/vip/data_processor/validation/db/v3_0/candidate_addresses_test.clj
+++ b/test/vip/data_processor/validation/db/v3_0/candidate_addresses_test.clj
@@ -20,18 +20,19 @@
                                  candidate-addresses/validate-addresses]}
                      (sqlite/temp-db "incomplete-candidate-addresses" "3.0"))
           out-ctx (pipeline/run-pipeline ctx)
-          errors (test-helpers/all-errors errors-chan)]
+          errors (->> (test-helpers/all-errors errors-chan)
+                      (map #(dissoc % :ctx)))]
 
       (is (= 2 (count errors)))
 
-      (is (test-helpers/contains-error? errors
-                                        {:severity :critical
-                                         :scope :candidates
-                                         :identifier 10478
-                                         :error-type :incomplete-candidate-address}))
+      (is (test-helpers/contains-error?
+           errors {:severity :critical
+                   :scope :candidates
+                   :identifier 10478
+                   :error-type :incomplete-candidate-address}))
 
-      (is (test-helpers/contains-error? errors
-                                        {:severity :critical
-                                         :scope :candidates
-                                         :identifier 10479
-                                         :error-type :incomplete-candidate-address})))))
+      (is (test-helpers/contains-error?
+           errors {:severity :critical
+                   :scope :candidates
+                   :identifier 10479
+                   :error-type :incomplete-candidate-address})))))


### PR DESCRIPTION
The candidate validation I added for https://github.com/votinginfoproject/data-processor/pull/280 was too strict, as it wouldn't allow candidates with _no_ addresses through, even though the [`filed_mailing_address` for a candidate is optional](https://github.com/votinginfoproject/data-processor/blob/b22a60dd0ef29a5c857528dda918e1b14c2686a6/resources/specs/vip_spec_v3.0.xsd#L206).

This fixes the over-zealousness of the validation, and adds a test to confirm that a candidate with no address is **not** marked as invalid, along with continuing to correctly mark those candidates with addresses but missing required fields as invalid (and those with all required fields are valid).