### PR TITLE
replace cleanup function with one that works with just results

### DIFF
--- a/resources/migrations/20180419-fix-cleanup.up.sql
+++ b/resources/migrations/20180419-fix-cleanup.up.sql
@@ -1,0 +1,22 @@
+create schema if not exists cleanup;
+
+create or replace view cleanup.feeds_by_election(state, vip_id, current_run, old_runs) as
+  with feeds as
+      (select r.state as state,
+              r.vip_id as vip_id,
+              r.spec_version as spec_version,
+              r.election_type as election_type,
+              r.election_date as election_date,
+              array_agg(r.id order by r.id desc) as ids
+       from results r
+       where r.complete is true
+         and r.vip_id is not null
+       group by r.vip_id, r.state, r.spec_version, r.election_type, r.election_date)
+
+  select
+    state,
+    vip_id,
+    ids[1:5] as current_runs,
+    ids[6:array_upper(ids, 1)] as old_runs
+  from feeds
+  where cardinality(ids) > 5;


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/156922010)

Replaces the cleanup function with one that will catch 5.1 feeds. Once we started deleting from `xml_tree_values` when processing was over, this couldn't clean up 5.1 feeds anymore. I tested this locally, processed 7 copies of the same feed, and it figured out which 2 to delete.