### PR TITLE
Removes required check for 'Type' element from BallotMeasureContest validation, adds check for ElectoralDistrictId

### DIFF
--- a/src/vip/data_processor/validation/v5.clj
+++ b/src/vip/data_processor/validation/v5.clj
@@ -1,5 +1,6 @@
 (ns vip.data-processor.validation.v5
   (:require [vip.data-processor.validation.v5.ballot-measure-contest :as ballot-measure-contest]
+            [vip.data-processor.validation.v5.candidate-contest :as candidate-contest]
             [vip.data-processor.validation.v5.candidate :as candidate]
             [vip.data-processor.validation.v5.email :as email]
             [vip.data-processor.validation.v5.external-identifiers :as external-identifiers]
@@ -26,6 +27,7 @@
 (def validations
   [ballot-measure-contest/validate-ballot-measure-types
    ballot-measure-contest/validate-no-missing-types
+   candidate-contest/validate-no-missing-types
    candidate/validate-no-missing-ballot-names
    candidate/validate-pre-election-statuses
    candidate/validate-post-election-statuses

--- a/src/vip/data_processor/validation/v5/ballot_measure_contest.clj
+++ b/src/vip/data_processor/validation/v5/ballot_measure_contest.clj
@@ -5,4 +5,4 @@
   (util/validate-enum-elements :ballot-measure-type :errors))
 
 (def validate-no-missing-types
-  (util/validate-no-missing-elements :ballot-measure-contest [:type]))
+  (util/validate-no-missing-elements :ballot-measure-contest [:electoral-district-id]))

--- a/src/vip/data_processor/validation/v5/candidate_contest.clj
+++ b/src/vip/data_processor/validation/v5/candidate_contest.clj
@@ -1,0 +1,5 @@
+(ns vip.data-processor.validation.v5.candidate-contest
+  (:require [vip.data-processor.validation.v5.util :as util]))
+
+(def validate-no-missing-types
+  (util/validate-no-missing-elements :candidate-contest [:electoral-district-id]))

--- a/test-resources/xml/v5-ballot-measure-contests.xml
+++ b/test-resources/xml/v5-ballot-measure-contests.xml
@@ -1,20 +1,29 @@
 <?xml version="1.0"?>
 <VipObject schemaVersion="5.1">
+  <ElectoralDistrict id="ed001">
+    <Name>Commonwealth of Virginia</Name>
+    <Type>state</Type>
+  </ElectoralDistrict>
   <BallotMeasureContest id="bmc000">
   </BallotMeasureContest>
   <BallotMeasureContest id="bmc001">
     <Type>Not a real type</Type>
+    <ElectoralDistrictId>ed001</ElectoralDistrictId>
   </BallotMeasureContest>
   <BallotMeasureContest id="bmc002">
     <Type>ballot-measure</Type>
+    <ElectoralDistrictId>ed001</ElectoralDistrictId>
   </BallotMeasureContest>
   <BallotMeasureContest id="bmc003">
     <Type>initiative</Type>
+    <ElectoralDistrictId>ed001</ElectoralDistrictId>
   </BallotMeasureContest>
   <BallotMeasureContest id="bmc004">
     <Type>referendum</Type>
+    <ElectoralDistrictId>ed001</ElectoralDistrictId>
   </BallotMeasureContest>
   <BallotMeasureContest id="bmc005">
     <Type>other</Type>
+    <ElectoralDistrictId>ed001</ElectoralDistrictId>
   </BallotMeasureContest>
 </VipObject>

--- a/test-resources/xml/v5-candidate-contests.xml
+++ b/test-resources/xml/v5-candidate-contests.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<VipObject schemaVersion="5.1">
+  <ElectoralDistrict id="ed001">
+    <Name>Commonwealth of Virginia</Name>
+    <Type>state</Type>
+  </ElectoralDistrict>
+  <CandidateContest id="cc20001">
+    <Name>Missing ElectoralDistrictId</Name>
+  </CandidateContest>
+  <CandidateContest id="cc20002">
+    <ElectoralDistrictId>ed001</ElectoralDistrictId>
+    <Name>Has ElectoralDistrictId</Name>
+  </CandidateContest>
+</VipObject>

--- a/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/ballot_measure_contest_test.clj
@@ -8,7 +8,7 @@
 
 (use-fixtures :once setup-postgres)
 
-(deftest ^:postgres validate-no-missing-types-test
+(deftest ^:postgres validate-no-missing-electoral-district-ids-test
   (let [errors-chan (a/chan 100)
         ctx {:input (xml-input "v5-ballot-measure-contests.xml")
              :errors-chan errors-chan}
@@ -17,21 +17,22 @@
                     xml/load-xml-ltree
                     v5.bmc/validate-no-missing-types)
         errors (all-errors errors-chan)]
-    (testing "type missing is an error"
-      (is (contains-error? errors
-                           {:severity :errors
-                            :scope :ballot-measure-contest
-                            :identifier "VipObject.0.BallotMeasureContest.0.Type"
-                            :error-type :missing})))
-    (testing "type present is OK"
-      (doseq [path ["VipObject.0.BallotMeasureContest.1.Type"
-                    "VipObject.0.BallotMeasureContest.2.Type"
-                    "VipObject.0.BallotMeasureContest.3.Type"
-                    "VipObject.0.BallotMeasureContest.4.Type"
-                    "VipObject.0.BallotMeasureContest.5.Type"]]
+    (testing "electoral-district-id missing is an error"
+      (is (contains-error?
+           errors
+           {:severity :errors
+            :scope :ballot-measure-contest
+            :identifier "VipObject.0.BallotMeasureContest.1.ElectoralDistrictId"
+            :error-type :missing})))
+    (testing "electoral-district-id present is OK"
+      (doseq [path ["VipObject.0.BallotMeasureContest.2.ElectoralDistrictId"
+                    "VipObject.0.BallotMeasureContest.3.ElectoralDistrictId"
+                    "VipObject.0.BallotMeasureContest.4.ElectoralDistrictId"
+                    "VipObject.0.BallotMeasureContest.5.ElectoralDistrictId"
+                    "VipObject.0.BallotMeasureContest.6.ElectoralDistrictId"]]
         (assert-no-problems errors {:scope :ballot-measure-contest
-                                      :identifier path
-                                      :error-type :missing})))))
+                                    :identifier path
+                                    :error-type :missing})))))
 
 (deftest ^:postgres validate-ballot-measure-types-test
   (let [errors-chan (a/chan 100)
@@ -46,13 +47,13 @@
       (is (contains-error? errors
                            {:severity :errors
                             :scope :ballot-measure-contest
-                            :identifier "VipObject.0.BallotMeasureContest.1.Type.0"
+                            :identifier "VipObject.0.BallotMeasureContest.2.Type.0"
                             :error-type :format})))
     (testing "a good type is okay"
-      (doseq [path ["VipObject.0.BallotMeasureContest.2.Type.0"
-                    "VipObject.0.BallotMeasureContest.3.Type.0"
+      (doseq [path ["VipObject.0.BallotMeasureContest.3.Type.0"
                     "VipObject.0.BallotMeasureContest.4.Type.0"
-                    "VipObject.0.BallotMeasureContest.5.Type.0"]]
+                    "VipObject.0.BallotMeasureContest.5.Type.0"
+                    "VipObject.0.BallotMeasureContest.6.Type.0"]]
         (assert-no-problems errors
                               {:scope :ballot-measure-contest
                                :identifier path

--- a/test/vip/data_processor/validation/v5/candidate_contest_test.clj
+++ b/test/vip/data_processor/validation/v5/candidate_contest_test.clj
@@ -1,0 +1,32 @@
+(ns vip.data-processor.validation.v5.candidate-contest-test
+  (:require [vip.data-processor.validation.v5.candidate-contest :as v5.cc]
+            [clojure.test :refer [deftest testing use-fixtures is run-tests]]
+            [vip.data-processor.test-helpers :as test-helpers]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.validation.xml :as xml]
+            [clojure.core.async :as a]))
+
+(use-fixtures :once test-helpers/setup-postgres)
+
+(deftest ^:postgres validate-no-missing-electoral-district-ids-test
+  (let [errors-chan (a/chan 100)
+        ctx {:input (test-helpers/xml-input "v5-candidate-contests.xml")
+             :errors-chan errors-chan}
+        out-ctx (-> ctx
+                    psql/start-run
+                    xml/load-xml-ltree
+                    v5.cc/validate-no-missing-types)
+        errors (test-helpers/all-errors errors-chan)]
+    (testing "electoral-district-id missing is an error"
+      (is (test-helpers/contains-error?
+           errors
+           {:severity :errors
+            :scope :candidate-contest
+            :identifier "VipObject.0.CandidateContest.1.ElectoralDistrictId"
+            :error-type :missing})))
+    (testing "electoral-district-id present is OK"
+      (doseq [path ["VipObject.0.CandidateContest.2.ElectoralDistrictId"]]
+        (test-helpers/assert-no-problems
+         errors {:scope :candidate-contest
+                 :identifier path
+                 :error-type :missing})))))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155005125
https://www.pivotaltracker.com/story/show/155984152

Pretty straightforward tweaking I think: removes `Type` validation, adds a new validation for `CandidateContest` to ensure we have `ElectoralDistrictId`, and adds a check for `ElectoralDistrictId` to the `BallotMeasureContest` validation. Let me know if you have questions!