### PR TITLE
Add EDN reader to `max-zipfile-size` config

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -14,4 +14,4 @@
  :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
             :exchange #resource-config/env "VIP_DP_RABBITMQ_EXCHANGE"}
- :max-zipfile-size #resource-config/env "VIP_DP_MAX_ZIPFILE_SIZE"}
+ :max-zipfile-size #resource-config/edn #resource-config/env "VIP_DP_MAX_ZIPFILE_SIZE"}


### PR DESCRIPTION
This should have had the `edn` reader, that's probably why this was breaking. Leaving the coercion check as it should only add more safety, but figured this should be in there too.

Related to original PR for: https://www.pivotaltracker.com/story/show/157016498