### PR TITLE
Ack sqs messages after processing begins

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ VIP_DP_AWS_ACCESS_KEY=
 VIP_DP_AWS_SECRET_KEY=
 VIP_DP_S3_UNPROCESSED_BUCKET=
 VIP_DP_S3_PROCESSED_BUCKET=
+VIP_DP_S3_REGION=
 VIP_DP_SQS_REGION=
 VIP_DP_SQS_QUEUE=
 VIP_DP_SQS_FAIL_QUEUE=
@@ -74,7 +75,12 @@ VIP_DP_MAX_ZIPFILE_SIZE=(3221225472 = 3GB by default)
 ```
 
 As you can see, you'll need to have set up two S3 buckets and two SQS
-queues. The value for `VIP_DP_SQS_REGION` is in the form of
+queues.
+
+There are two different places to set the region, one for S3 and one for
+SQS and the libraries we use require different forms of this setting. The
+`VIP_DP_S3_REGION` setting needs to be in the form of `us-east-1`.
+The value for `VIP_DP_SQS_REGION` is in the form of
 `US_WEST_2` (not `us-west-2`). The value for
 `VIP_DP_RABBITMQ_EXCHANGE` is whatever you'd like it to be.
 

--- a/data-processor@.service.template
+++ b/data-processor@.service.template
@@ -28,6 +28,7 @@ ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --env VIP_DP_AWS_SECRET_KEY=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/aws/secret-key?raw) \
   --env VIP_DP_S3_UNPROCESSED_BUCKET=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/s3/unprocessed-bucket?raw) \
   --env VIP_DP_S3_PROCESSED_BUCKET=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/s3/processed-bucket?raw) \
+  --env VIP_DP_S3_REGION=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/s3/region?raw) \
   --env VIP_DP_SQS_REGION=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/sqs/region?raw) \
   --env VIP_DP_SQS_QUEUE=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/sqs/queue?raw) \
   --env VIP_DP_SQS_FAIL_QUEUE=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/sqs/fail-queue?raw) \

--- a/project.clj
+++ b/project.clj
@@ -27,8 +27,9 @@
                  [ragtime/ragtime.jdbc "0.6.4"]
                  [korma "0.4.3"]
                  [org.clojure/java.jdbc "0.7.8"]
-                 [org.postgresql/postgresql "42.2.5" :exclusions [org.slf4j/slf4j-simple
-                                                                  org.slf4j/slf4j-api]]
+                 [org.postgresql/postgresql "42.2.5"
+                  :exclusions [org.slf4j/slf4j-simple
+                               org.slf4j/slf4j-api]]
                  [org.xerial/sqlite-jdbc "3.23.1"]
                  [commons-lang/commons-lang "2.6"]
                  [xerces/xercesImpl "2.12.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,38 +1,42 @@
 (defproject vip.data-processor "0.1.0-SNAPSHOT"
   :description "Voting Information Project Data Processor"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.csv "0.1.3"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/data.csv "0.1.4"]
                  [org.clojure/data.xml "0.0.8"]
-                 [org.clojure/tools.logging "0.4.0"]
+                 [org.clojure/tools.logging "0.4.1"]
                  [ch.qos.logback/logback-classic "1.2.3"]
-                 [com.novemberain/langohr "3.5.1"]
-                 [joda-time "2.9.3"]
-                 [clj-time "0.12.2"]
-                 [clj-aws-s3 "0.3.10" :exclusions [joda-time]]
+                 [com.novemberain/langohr "5.0.0"]
+                 [joda-time "2.10"]
+                 [clj-time "0.14.4"]
+                 [amazonica "0.3.132"
+                  :exclusions [com.amazonaws/aws-java-sdk
+                               com.amazonaws/amazon-kinesis-client]]
+                 [com.amazonaws/aws-java-sdk-core "1.11.410"]
+                 [com.amazonaws/aws-java-sdk-s3 "1.11.410"]
                  [com.climate/clj-newrelic "0.2.1"]
-                 [democracyworks/squishy "3.0.1"
+                 [democracyworks/squishy "3.0.2"
                     :exclusions [joda-time
                                  org.slf4j/slf4j-simple
                                  org.slf4j/slf4j-api]]
-                 [org.clojure/core.async "0.2.391"]
+                 [org.clojure/core.async "0.4.474"]
                  [democracyworks/utility-fns "0.2.0"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
-                 [turbovote.resource-config "0.2.0"]
+                 [turbovote.resource-config "0.2.1"]
                  [joplin.jdbc "0.3.10"
                   :exclusions [ragtime/ragtime.jdbc]]
                  [ragtime/ragtime.jdbc "0.6.4"]
                  [korma "0.4.3"]
-                 [org.clojure/java.jdbc "0.6.1"]
-                 [org.postgresql/postgresql "42.0.0" :exclusions [org.slf4j/slf4j-simple
+                 [org.clojure/java.jdbc "0.7.8"]
+                 [org.postgresql/postgresql "42.2.5" :exclusions [org.slf4j/slf4j-simple
                                                                   org.slf4j/slf4j-api]]
                  [org.xerial/sqlite-jdbc "3.23.1"]
                  [commons-lang/commons-lang "2.6"]
-                 [xerces/xercesImpl "2.11.0"]
+                 [xerces/xercesImpl "2.12.0"]
                  [com.fasterxml.woodstox/woodstox-core "5.1.0"]
                  [me.raynes/fs "1.4.6"]]
   :plugins [[com.pupeno/jar-copier "0.4.0"]]
   :profiles {:test {:resource-paths ["test-resources"]
-                    :dependencies [[com.github.kyleburton/clj-xpath "1.4.5"]]}
+                    :dependencies [[com.github.kyleburton/clj-xpath "1.4.11"]]}
              :dev {:source-paths ["dev-src"]
                    :resource-paths ["dev-resources"]
                    :main dev.core}}
@@ -40,7 +44,7 @@
                    :postgres :postgres
                    :all (constantly true)}
   :repl-options {:init (set! *print-length* 50)}
-  :java-agents [[com.newrelic.agent.java/newrelic-agent "3.25.0"]]
+  :java-agents [[com.newrelic.agent.java/newrelic-agent "4.5.0"]]
   :jar-copier {:java-agents true
                :destination "resources/jars"}
   :prep-tasks ["javac" "compile" "jar-copier"]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,8 @@
 {:aws {:creds {:access-key #resource-config/env "VIP_DP_AWS_ACCESS_KEY"
                :secret-key #resource-config/env "VIP_DP_AWS_SECRET_KEY"}
        :s3 {:unprocessed-bucket #resource-config/env "VIP_DP_S3_UNPROCESSED_BUCKET"
-            :processed-bucket #resource-config/env "VIP_DP_S3_PROCESSED_BUCKET"}
+            :processed-bucket #resource-config/env "VIP_DP_S3_PROCESSED_BUCKET"
+            :endpoint "us-east-1"}
        :sqs {:region #aws/region #resource-config/env "VIP_DP_SQS_REGION"
              :queue #resource-config/env "VIP_DP_SQS_QUEUE"
              :fail-queue #resource-config/env "VIP_DP_SQS_FAIL_QUEUE"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,7 +2,7 @@
                :secret-key #resource-config/env "VIP_DP_AWS_SECRET_KEY"}
        :s3 {:unprocessed-bucket #resource-config/env "VIP_DP_S3_UNPROCESSED_BUCKET"
             :processed-bucket #resource-config/env "VIP_DP_S3_PROCESSED_BUCKET"
-            :endpoint "us-east-1"}
+            :endpoint #resource-config/env "VIP_DP_S3_REGION"}
        :sqs {:region #aws/region #resource-config/env "VIP_DP_SQS_REGION"
              :queue #resource-config/env "VIP_DP_SQS_QUEUE"
              :fail-queue #resource-config/env "VIP_DP_SQS_FAIL_QUEUE"

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -19,10 +19,23 @@
             [vip.data-processor.validation.zip :as zip])
   (:gen-class))
 
+(defn ack-sqs-message
+  "If we were configured with a delete-callback from SQS, call it, effectively
+   acking that data-processor has received and kicked off processing.
+
+   This will allow us to process very long feeds without spawning zombie
+   processes after 12 hours, the maximum time we could keep a message
+   checked out."
+  [ctx]
+  (when-let [delete-callback (:delete-callback ctx)]
+    (delete-callback))
+  ctx)
+
 (def download-pipeline
   [t/read-edn-sqs-message
    t/assert-filename
    psql/start-run
+   ack-sqs-message
    t/download-from-s3
    #(zip/assoc-file % (config [:max-zipfile-size] 3221225472)) ; 3GB default
    zip/extracted-contents])
@@ -66,23 +79,27 @@
            psql/delete-from-xml-tree-values
            cleanup/cleanup]))
 
-(defn-traced process-message [message]
-  (q/publish {:initial-input message
-              :status :started}
-             "processing.started")
-  (let [result (pipeline/process pipeline message)]
-    (psql/complete-run result)
-    (log/info "New run completed:"
-              (psql/get-run result))
-    (let [exception (:exception result)
-          completed-message (cond-> {:initial-input message
-                                     :status :complete
-                                     :public-id (:public-id result)}
-                              exception (assoc :exception (.getMessage exception)))]
-      (q/publish completed-message
-                 "processing.complete")
-      (when exception
-        (throw exception)))))
+(defn-traced process-message
+  ([message]
+   (process-message message nil))
+  ([message delete-callback]
+   (log/info "processing SQS message" (pr-str message))
+   (q/publish {:initial-input message
+               :status :started}
+              "processing.started")
+   (let [result (pipeline/process pipeline message delete-callback)]
+     (psql/complete-run result)
+     (log/info "New run completed:"
+               (psql/get-run result))
+     (let [exception (:exception result)
+           completed-message (cond-> {:initial-input message
+                                      :status :complete
+                                      :public-id (:public-id result)}
+                               exception (assoc :exception (.getMessage exception)))]
+       (q/publish completed-message
+                  "processing.complete")
+       (when exception
+         (throw exception))))))
 
 (defn consume []
   (let [{:keys [access-key secret-key]} (config [:aws :creds])
@@ -108,4 +125,5 @@
                                    (log/info "VIP Data Processor shutting down...")
                                    (q/publish {:id id :event "stopping"} "qa-engine.status")
                                    (sqs/stop-consumer consumer-id))))
+      (log/info "SQS processing started")
       consumer-id)))

--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -91,8 +91,9 @@
         creds {:access-key access-key
                :access-secret secret-key
                :region region}
-        opts (when visibility-timeout
-               {:visibility-timeout visibility-timeout})]
+        opts (merge {:delete-callback true}
+              (when visibility-timeout
+                {:visibility-timeout visibility-timeout}))]
     (sqs/consume-messages creds queue fail-queue opts process-message)))
 
 (defn -main [& args]


### PR DESCRIPTION
This wraps up the work to prevent zombie feeds after 12 hours of processing.

The new version of `squishy` introduces the `{:delete-callback true/false}` option, and when set to true, calls the processing function with two parameters: the message and a callback function the processor calls when it has safely received the message. This allows the processor to, say, record the start of the processing in a db and then call the delete callback to delete the message out of SQS. In this way, feed messages should never get lost in, say, a shutdown or whatever, and we no longer will spawn zombies in 12 hours on the larger feeds.

I had to replace `clj-aws-s3` because it was too old and pulling in very old incompatible dependencies, so upgrading to `amazonica` seemed appropriate and wasn't that difficult to do (with the minor annoyance now that we have to configure the region as `US_EAST_1` for squishy and `us-east-1` for amazonica.

I've already added the new configuration to both staging and production.

[Pivotal Card](https://www.pivotaltracker.com/story/show/158603633)