### PR TITLE
add migration for foreign key constraint to clean up validations table when results are deleted

### DIFF
--- a/resources/migrations/20180921-00-validations-table-result-id-cascade-delete.down.sql
+++ b/resources/migrations/20180921-00-validations-table-result-id-cascade-delete.down.sql
@@ -1,0 +1,1 @@
+alter table validations drop constraint validations_results_id_fkey;

--- a/resources/migrations/20180921-00-validations-table-result-id-cascade-delete.up.sql
+++ b/resources/migrations/20180921-00-validations-table-result-id-cascade-delete.up.sql
@@ -1,0 +1,1 @@
+alter table validations add foreign key (results_id) references results(id) on delete cascade;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160106899

Tested these locally FWIW, both as migrations (at least, the up migration) and manually using `psql` client directly (both up and down migrations).