### PR TITLE
get unprocessed file bucket from SQS message

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,6 @@
 {:aws {:creds {:access-key #resource-config/env "VIP_DP_AWS_ACCESS_KEY"
                :secret-key #resource-config/env "VIP_DP_AWS_SECRET_KEY"}
-       :s3 {:unprocessed-bucket #resource-config/env "VIP_DP_S3_UNPROCESSED_BUCKET"
-            :processed-bucket #resource-config/env "VIP_DP_S3_PROCESSED_BUCKET"
+       :s3 {:processed-bucket #resource-config/env "VIP_DP_S3_PROCESSED_BUCKET"
             :endpoint #resource-config/env "VIP_DP_S3_REGION"}
        :sqs {:region #aws/region #resource-config/env "VIP_DP_SQS_REGION"
              :queue #resource-config/env "VIP_DP_SQS_QUEUE"

--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -28,7 +28,7 @@
 (def tmp-path-prefix "vip-data-processor")
 
 (defn download
-  "Downloads the file named `key` from the configured S3 bucket to a
+  "Downloads the file named `key` from the passed in S3 `bucket` to a
   temporary file and returns that path."
   [key bucket]
   (let [tmp-path (Files/createTempFile tmp-path-prefix key

--- a/src/vip/data_processor/s3.clj
+++ b/src/vip/data_processor/s3.clj
@@ -13,10 +13,10 @@
            [net.lingala.zip4j.model ZipParameters]
            [net.lingala.zip4j.util Zip4jConstants]))
 
-(defn get-object [key]
+(defn get-object [key bucket]
   (s3/get-object (merge (config [:aws :creds])
                         {:endpoint (config [:aws :s3 :endpoint])})
-                 (config [:aws :s3 :unprocessed-bucket])
+                 bucket
                  key))
 
 (defn put-object [key value]
@@ -30,10 +30,10 @@
 (defn download
   "Downloads the file named `key` from the configured S3 bucket to a
   temporary file and returns that path."
-  [key]
+  [key bucket]
   (let [tmp-path (Files/createTempFile tmp-path-prefix key
                                        (into-array FileAttribute []))
-        s3-object (get-object key)
+        s3-object (get-object key bucket)
         stream (:input-stream s3-object)]
     (try
       (Files/copy stream

--- a/src/vip/data_processor/validation/transforms.clj
+++ b/src/vip/data_processor/validation/transforms.clj
@@ -22,7 +22,8 @@
 
 (defn download-from-s3 [ctx]
   (let [filename (get-in ctx [:input :filename])
-        file (s3/download filename)]
+        bucket (get-in ctx [:input :bucket])
+        file (s3/download filename bucket)]
     (-> ctx
         (update :to-be-cleaned conj file)
         (assoc :input file))))


### PR DESCRIPTION
While not strictly needed for dasher to kick off processing so long as dasher and data-processor are configured with the same bucket, this is a change that's been long overdue to get the filename AND bucket from the processing message rather than just the filename. So long that the other projects that made a similar move have probably stopped using SQS long ago.