### PR TITLE
Fix xml filename

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                                  org.slf4j/slf4j-api]]
                  [org.clojure/core.async "0.4.500"]
                  [democracyworks/utility-fns "0.2.0"]
-                 [net.lingala.zip4j/zip4j "1.3.3"]
+                 [net.lingala.zip4j/zip4j "2.6.1"]
                  [turbovote.resource-config "0.2.1"]
                  [joplin.jdbc "0.3.11"
                   :exclusions [ragtime/ragtime.jdbc]]

--- a/src/vip/data_processor/output/tree_xml.clj
+++ b/src/vip/data_processor/output/tree_xml.clj
@@ -2,7 +2,8 @@
   (:require [clojure.data.xml :as xml]
             [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
-            [vip.data-processor.output.xml-helpers :refer [create-xml-file]]
+            [vip.data-processor.output.xml-helpers :refer [create-xml-file
+                                                           generate-file-basename]]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.db.util :as db.util]
             [clojure.tools.logging :as log]
@@ -158,5 +159,6 @@
   ctx)
 
 (def pipeline
-  [create-xml-file
+  [generate-file-basename
+   create-xml-file
    generate-xml-file])

--- a/src/vip/data_processor/output/xml.clj
+++ b/src/vip/data_processor/output/xml.clj
@@ -19,7 +19,8 @@
             [clojure.java.io :as io]
             [clojure.walk :as walk]
             [vip.data-processor.output.v3-0.xml :as v3-0]
-            [vip.data-processor.output.xml-helpers :refer [create-xml-file]]
+            [vip.data-processor.output.xml-helpers :refer [create-xml-file
+                                                           generate-file-basename]]
             [vip.data-processor.errors :as errors])
   (:import [javax.xml XMLConstants]
            [javax.xml.transform.stream StreamSource]
@@ -91,6 +92,7 @@
         (errors/add-errors ctx :errors :xml-generation :global :invalid-xml (.getMessage e))))))
 
 (def pipeline
-  [create-xml-file
+  [generate-file-basename
+   create-xml-file
    write-xml
    validate-xml-output])

--- a/src/vip/data_processor/validation/zip.clj
+++ b/src/vip/data_processor/validation/zip.clj
@@ -1,6 +1,6 @@
 (ns vip.data-processor.validation.zip
   (:require [clojure.tools.logging :as log])
-  (:import [net.lingala.zip4j.core ZipFile]
+  (:import [net.lingala.zip4j ZipFile]
            [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]))
 

--- a/test/vip/data_processor/output/xml_helpers_test.clj
+++ b/test/vip/data_processor/output/xml_helpers_test.clj
@@ -3,6 +3,33 @@
             [clojure.string :as str]
             [clojure.test :refer :all]))
 
+(deftest format-fips-test
+  (testing "empty"
+    (is (= "XX" (format-fips "")))
+    (is (= "XX" (format-fips nil))))
+  (testing "1 digit fips"
+    (is (= "01" (format-fips "1"))))
+  (testing "2 digit fips"
+    (is (= "08" (format-fips "08")))
+    (is (= "10" (format-fips "10"))))
+  (testing "3 digit fips (shouldn't be many/any of these)"
+    (is (= "00008" (format-fips "008")))
+    (is (= "00101" (format-fips "101"))))
+  (testing "4 digit fips (could be a county fips from a low number state)"
+    (is (= "08001" (format-fips "8001"))))
+  (testing "5 digit fips (county fips)"
+    (is (= "08001" (format-fips "08001")))
+    (is (= "10101" (format-fips "10101")))))
+
+(deftest format-state-test
+  (testing "empty"
+    (is (= "YY" (format-state "")))
+    (is (= "YY" (format-state nil))))
+  (testing "Single Word State"
+    (is (= "Colorado" (format-state "Colorado"))))
+  (testing "Two Word State"
+    (is (= "New-York" (format-state "New York")))))
+
 (deftest filename*-test
   (testing "nicely formatted dates make nice filenames"
     (is (= "vipfeed-51-VA-2015-03-24"

--- a/test/vip/data_processor/output/xml_helpers_test.clj
+++ b/test/vip/data_processor/output/xml_helpers_test.clj
@@ -1,9 +1,38 @@
 (ns vip.data-processor.output.xml-helpers-test
   (:require [vip.data-processor.output.xml-helpers :refer :all]
+            [clojure.string :as str]
             [clojure.test :refer :all]))
+
+(deftest filename*-test
+  (testing "nicely formatted dates make nice filenames"
+    (is (= "vipfeed-51-VA-2015-03-24"
+           (filename* "51" "VA" "2015-03-24"))))
+
+  (testing "workably formatted dates make nice filenames"
+    (is (= "vipfeed-52-FL-2015-03-27"
+           (filename* "52" "FL" "2015/03/27"))))
+
+  (testing "poorly formatted dates use a workable filename"
+    (is (= "vipfeed-12345-North-Carolina-"
+           (filename* "12345" "North Carolina" nil))))
+
+  (testing "missing the fips and/or state doesn't break the world"
+    (is (= "vipfeed-12-YY-2016-11-08"
+           (filename* "12" nil "2016-11-08")))
+    (is (= "vipfeed-XX-North-Carolina-2016-11-08"
+           (filename* "" " North Carolina " "2016-11-08")))))
 
 (deftest create-xml-file-test
   (testing "adds an :xml-output-file key to a context"
-    (let [ctx {:filename "create-xml-test"}
+    (let [ctx {:output-file-basename "vipfeed-51-VA-2015-03-24"}
           out-ctx (create-xml-file ctx)]
-      (is (:xml-output-file out-ctx)))))
+      (is (:xml-output-file out-ctx))
+      (is (str/starts-with?
+           (-> (:xml-output-file out-ctx)
+               .getFileName
+               .toString)
+           "vipfeed-51-VA-2015-03-24"))
+      (is (= "vipfeed-51-VA-2015-03-24.xml"
+             (-> (:xml-output-file out-ctx)
+                 .getFileName
+                 .toString))))))

--- a/test/vip/data_processor/s3_test.clj
+++ b/test/vip/data_processor/s3_test.clj
@@ -1,22 +1,3 @@
 (ns vip.data-processor.s3-test
   (:require [vip.data-processor.s3 :refer :all]
             [clojure.test :refer [deftest testing is]]))
-
-(deftest zip-filename*-test
-  (testing "nicely formatted dates make nice filenames"
-    (is (= "vipfeed-51-VA-2015-03-24.zip"
-           (zip-filename* "51" "VA" "2015-03-24"))))
-
-  (testing "workably formatted dates make nice filenames"
-    (is (= "vipfeed-52-FL-2015-03-27.zip"
-           (zip-filename* "52" "FL" "2015/03/27"))))
-
-  (testing "poorly formatted dates use a workable filename"
-    (is (= "vipfeed-12345-North-Carolina-.zip"
-           (zip-filename* "12345" "North Carolina" nil))))
-
-  (testing "missing the fips and/or state doesn't break the world"
-    (is (= "vipfeed-12-YY-2016-11-08.zip"
-           (zip-filename* "12" nil "2016-11-08")))
-    (is (= "vipfeed-XX-North-Carolina-2016-11-08.zip"
-           (zip-filename* "" " North Carolina " "2016-11-08")))))

--- a/test/vip/data_processor/validation/zip_test.clj
+++ b/test/vip/data_processor/validation/zip_test.clj
@@ -4,7 +4,7 @@
    [clojure.test :refer [deftest testing is use-fixtures run-tests]]
    [vip.data-processor.validation.zip :as zip])
   (:import
-   [net.lingala.zip4j.core ZipFile]))
+   [net.lingala.zip4j ZipFile]))
 
 (deftest wont-open-too-big-zipfile
   (let [zipfile-path (.getPath (io/resource "example.zip"))


### PR DESCRIPTION
* Upgrade zip4j dependency
* Make the filename generation a bit more generic so we can use it for both XML and ZIP filenames
* Rename the temp xml file from the pseudo-random name that all temp files get by default to the well structured name