### PR TITLE
Get all versions of the XML file output named properly

### DIFF
--- a/dev-src/dev/core.clj
+++ b/dev-src/dev/core.clj
@@ -1,29 +1,56 @@
 (ns dev.core
-  (:require
-   [clojure.core.async :as a]
-   [clojure.java.io :as io]
-   [clojure.pprint :as pprint]
-   [clojure.tools.logging :as log]
-   [squishy.data-readers]
-   [turbovote.resource-config :refer [config]]
-   [vip.data-processor :as data-processor]
-   [vip.data-processor.db.postgres :as psql]
-   [vip.data-processor.errors :as errors]
-   [vip.data-processor.output.street-segments :as output-ss]
-   [vip.data-processor.output.xml :as xml-output]
-   [vip.data-processor.pipeline :as pipeline]
-   [vip.data-processor.s3 :as s3 :refer [zip-filename]]
-   [vip.data-processor.validation.data-spec :as data-spec]
-   [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
-   [vip.data-processor.validation.db :as db]
-   [vip.data-processor.validation.db.v3-0 :as db.v3-0]
-   [vip.data-processor.validation.transforms :as t]
-   [vip.data-processor.validation.zip :as zip]))
+  (:require [clojure.core.async :as a]
+            [clojure.java.io :as io]
+            [clojure.pprint :as pprint]
+            [clojure.tools.logging :as log]
+            [squishy.data-readers]
+            [turbovote.resource-config :refer [config]]
+            [vip.data-processor :as data-processor]
+            [vip.data-processor.cleanup :as cleanup]
+            [vip.data-processor.db.postgres :as psql]
+            [vip.data-processor.errors :as errors]
+            [vip.data-processor.output.street-segments :as output-ss]
+            [vip.data-processor.output.xml :as xml-output]
+            [vip.data-processor.pipeline :as pipeline]
+            [vip.data-processor.s3 :as s3]
+            [vip.data-processor.validation.data-spec :as data-spec]
+            [vip.data-processor.validation.data-spec.v3-0 :as v3-0]
+            [vip.data-processor.validation.db :as db]
+            [vip.data-processor.validation.db.v3-0 :as db.v3-0]
+            [vip.data-processor.validation.transforms :as t]
+            [vip.data-processor.validation.zip :as zip])
+  (:import [java.io File]
+           [java.nio.file Files Paths StandardCopyOption]))
 
 ;; modify this to add flags to processing
 (defn set-context
   [ctx]
-  (assoc ctx :post-process-street-segments? true))
+  (-> ctx
+      (assoc :post-process-street-segments? true)
+      (assoc :save-zip-locally? false)))
+
+(defn save-zip-to-local-file
+  "A dev pipeline step to save the resulting zip file to a local file at the
+   end of processing, should you want to examine it. To activate it, flip
+   the context keyword `:save-zip-locally?` to true above."
+  [{:keys [xml-output-file save-zip-locally?] :as ctx}]
+  (if save-zip-locally?
+    (let [zip-name (s3/zip-filename ctx)
+
+          {:keys [zip-file zip-dir]}
+          (s3/prepare-zip-file zip-name xml-output-file)
+
+          current-dir (-> ""
+                          (Paths/get (into-array String []))
+                          .toAbsolutePath)
+
+          target-file (.resolve current-dir zip-name)]
+      (Files/copy (.toPath zip-file) target-file
+                  (into-array [StandardCopyOption/REPLACE_EXISTING]))
+      (-> ctx
+          (assoc :generated-xml-filename zip-name)
+          (update :to-be-cleaned concat [zip-file zip-dir])))
+    ctx))
 
 (def pipeline
   [set-context
@@ -41,16 +68,17 @@
    output-ss/insert-street-segment-nodes
    errors/close-errors-chan
    errors/await-statistics
-   psql/delete-from-xml-tree-values])
+   save-zip-to-local-file
+   psql/delete-from-xml-tree-values
+   cleanup/cleanup])
+
 
 (defn -main [filename]
   (psql/initialize)
   (let [file (if (zip/xml-file? filename)
-               (java.nio.file.Paths/get filename (into-array [""]))
-               (java.io.File. filename))
+               (Paths/get filename (into-array [""]))
+               (File. filename))
         result (pipeline/process pipeline file)]
     (when-let [xml-output-file (:xml-output-file result)]
-      (println "XML:" (.toString xml-output-file))
-      (let [filename (zip-filename result)
-            results (assoc result :generated-xml-filename filename)]
-        (psql/complete-run results)))))
+      (println "XML:" (.toString xml-output-file)))
+    (psql/complete-run result)))

--- a/src/vip/data_processor/output/street_segments.clj
+++ b/src/vip/data_processor/output/street_segments.clj
@@ -11,7 +11,8 @@
    [vip.data-processor.errors :as errors]
    [vip.data-processor.util :as util])
   (:import
-   [javax.xml.stream XMLInputFactory XMLOutputFactory XMLEventFactory]))
+   [javax.xml.stream XMLInputFactory XMLOutputFactory XMLEventFactory]
+   [java.nio.file Files StandardCopyOption]))
 
 (defn add-element
   [event-factory writer el-name el-content]
@@ -135,9 +136,9 @@
           (.add writer event)))
       (.close reader)
       (.close writer)
-      (-> (assoc ctx :xml-output-file (.toPath tmpfile))
-          ;; Not sure if we care about this, we may want to just throw it away
-          (assoc :xml-output-file-old xml-output-file)))
+      (assoc ctx :xml-output-file
+             (Files/move (.toPath tmpfile) xml-output-file
+                         (into-array [StandardCopyOption/REPLACE_EXISTING]))))
     ctx))
 
 (defn insert-street-segment-nodes

--- a/src/vip/data_processor/validation/csv.clj
+++ b/src/vip/data_processor/validation/csv.clj
@@ -12,7 +12,6 @@
             [vip.data-processor.errors :as errors]
             [vip.data-processor.errors.process :as process]
             [vip.data-processor.output.tree-xml :as tree-xml]
-            [vip.data-processor.output.xml-helpers :as xml-helpers]
             [vip.data-processor.util :as util]
             [vip.data-processor.validation.csv.file-set :as csv-files]
             [vip.data-processor.validation.data-spec :as data-spec]
@@ -269,15 +268,13 @@
   {"3.0" [sqlite/attach-sqlite-db
           process/process-v3-validations
           (csv-files/validate-dependencies csv-files/v3-0-file-dependencies)
-          load-csvs
-          xml-helpers/generate-file-basename]
+          load-csvs]
    "5.1" (concat [(fn [ctx] (assoc ctx :tables postgres/v5-1-tables))
                   (fn [ctx] (assoc ctx :ltree-index 0))
                   process/process-v5-validations
                   load-csvs]
                  v5-1-transformers/transformers
-                 tree-xml/pipeline
-                 [xml-helpers/generate-file-basename])})
+                 tree-xml/pipeline)})
 
 (defn branch-on-spec-version [{:keys [spec-version] :as ctx}]
   (if-let [pipeline (get version-pipelines


### PR DESCRIPTION
Once more with feeling, including:

* Some dev-src changes to make it easier to test the output locally
* Renaming the input file if we just pass it along as the output file too
* Fixing the filename when we use the post processing street segments hack (because that creates yet another temp feed file version)