### PR TITLE
Compute checksum

### DIFF
--- a/src/vip/data_processor.clj
+++ b/src/vip/data_processor.clj
@@ -36,7 +36,8 @@
      (if exception
        (q/publish-failure (merge completed-message
                                  {:exception (.getMessage exception)}))
-       (q/publish-success completed-message))
+       (q/publish-success (merge completed-message
+                                 (select-keys result [:checksum]))))
      (when exception
        (throw exception)))))
 


### PR DESCRIPTION
If we're going to upload a file to S3, we'll
compute the checksum and add it to the processing message we send to the dashboard.
This will allow the dashboard to send the checksum to Slack where the data team can use it.