### PR TITLE
Form-encode the generated database connection string

### DIFF
--- a/src/vip/data_processor/db/postgres.clj
+++ b/src/vip/data_processor/db/postgres.clj
@@ -11,11 +11,15 @@
             [vip.data-processor.util :as util]
             [vip.data-processor.validation.data-spec :as data-spec])
   (:import [org.postgresql.util PGobject]
+           [java.net URLEncoder]
            [java.text Normalizer]))
 
 (defn url []
   (let [{:keys [host port user password database]} (config [:postgres])]
-    (str "jdbc:postgresql://" host ":" port "/" database "?user=" user "&password=" password)))
+    (apply format
+           "jdbc:postgresql://%s:%s/%s?user=%s&password=%s"
+           (map (comp #(URLEncoder/encode % "UTF-8") str)
+                [host port database user password]))))
 
 (defn db-spec []
   (let [{:keys [host port user password database]} (config [:postgres])]

--- a/test/vip/data_processor/db/postgres_test.clj
+++ b/test/vip/data_processor/db/postgres_test.clj
@@ -1,6 +1,18 @@
 (ns vip.data-processor.db.postgres-test
   (:require [vip.data-processor.db.postgres :refer :all]
+            [turbovote.resource-config :refer [config]]
             [clojure.test :refer :all]))
+
+(deftest url-test
+  (let [db-spec-1 {:host "host"
+                   :port "5678"
+                   :user "us&r"
+                   :password "p&ssw@rd"
+                   :database "database"}]
+    (with-redefs [config (constantly db-spec-1)]
+      (is (= "jdbc:postgresql://host:5678/database?user=us%26r&password=p%26ssw%40rd"
+             (url))
+          "Percent encoding is done for username and password values"))))
 
 (deftest build-public-id-test
   (testing "builds public ids with as much information as it has"


### PR DESCRIPTION
While this technically is not URL encoding, this is also the method of decoding that some (most?) JDBC drivers (checking PostgreSQL and MySQL, but probably others) use, and so it will work for most use cases. Critically, hand-written parsers seen in JDBC driver code typically look for `/`, `&`, and `=`, so as long as these are encoded using a method that java.net.URLDecoder can decode, everything will work nicely.

# References

- [VIP-21](https://democracyworks.atlassian.net/browse/VIP-21)