### PR TITLE
Vip 370 locality stats logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,3 +360,54 @@ To delete any but the most recent 5 versions of a feed (where two feeds are cons
 ```sql
 delete from results where id in (select unnest(old_runs) from cleanup.feeds_by_election);
 ```
+
+## Migrations
+
+For development, there are a couple of options for manually running, rolling back, and creating migrations. We now have aliases setup so you can activate these from the command line, or you can also run them from a REPL in the `dev.core` namespace.
+
+### Command Line Migration Interactions
+
+#### Running pending migrations
+`lein migrate`
+
+#### Seeing if there are pending migrations
+`lein pending`
+
+#### Creating new migration up/down files
+`lein create 01-my-cool-new-migration`
+
+With this one, the joplin subsystem automatically prepends the date in YYYYMMDD- format to the value you supply, and creates up/down migration files. If you have multiple migrations on the same day that you want applied in a particular order, our best practice is to start your migrations with 01-, 02-, 03-. That way when the date is prepended, the migrations lexically sort with the 01 first, then 02, 03, etc.
+
+#### Rolling back migrations
+Rollback the most recent migration
+`lein rollback`
+
+Rollback N number of migrations
+`lein rollback N` (where N is some integer between 1 and the total number of migrations applied)
+
+Rollback all migrations after a particular ID
+`lein rollback 20210615-01-my-cool-new-migration`
+(Note that this is the full ID including the date stamp, but minus the up/down parts)
+
+### REPL
+Alternatively to the command line options above, you can call the functions in the `dev.core` namespace directly. The following examples assume you're in the `dev.core` namespace, which is the default when you fire up a REPL.
+
+#### Run all pending migrations
+`(migrate)`
+
+#### List all pending migrations
+`(pending)`
+
+#### Create a new migration
+See the notes about naming migrations under the command line section.
+`(create "01-my-cool-new-migration")`
+
+#### Rollback migrations
+Rollback the last migration
+`(rollback)`
+
+Rollback the last N migrations (where N is an integer between 1 and the number of applied migrations)
+`(rollback N)`
+
+Rollback all migrations applied after a specific migration ID (see notes above in command line section)
+`(rollback "20210605-01-my-cool-new-migration")`

--- a/project.clj
+++ b/project.clj
@@ -47,6 +47,10 @@
   :test-selectors {:default (complement :postgres)
                    :postgres :postgres
                    :all (constantly true)}
+  :aliases {"migrate" ["with-profile" "+dev" "run" "-m" "dev.core/migrate"]
+            "rollback" ["with-profile" "+dev" "run" "-m" "dev.core/rollback"]
+            "pending" ["with-profile" "+dev" "run" "-m" "dev.core/pending"]
+            "create" ["with-profile" "+dev" "run" "-m" "dev.core/create"]}
   :repl-options {:init (set! *print-length* 50)}
   :prep-tasks ["javac" "compile"]
   :main vip.data-processor)

--- a/resources/migrations/20210521-01-v5-street-segment-validations.down.sql
+++ b/resources/migrations/20210521-01-v5-street-segment-validations.down.sql
@@ -1,1 +1,2 @@
 drop table if exists v5_street_segment_validations;
+drop extension btree_gist;

--- a/resources/migrations/20210521-01-v5-street-segment-validations.down.sql
+++ b/resources/migrations/20210521-01-v5-street-segment-validations.down.sql
@@ -1,0 +1,1 @@
+drop table if exists v5_street_segment_validations;

--- a/resources/migrations/20210521-01-v5-street-segment-validations.up.sql
+++ b/resources/migrations/20210521-01-v5-street-segment-validations.up.sql
@@ -1,0 +1,19 @@
+create table v5_street_segment_validations (
+    results_id bigint NOT NULL,
+    path ltree,
+    severity character varying(255) COLLATE pg_catalog."default",
+    scope character varying(255) COLLATE pg_catalog."default",
+    error_type character varying(255) COLLATE pg_catalog."default",
+    error_data text COLLATE pg_catalog."default",
+    parent_element_id text COLLATE pg_catalog."default",
+    CONSTRAINT xml_tree_validations_results_id_fkey FOREIGN KEY (results_id)
+        REFERENCES public.results (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE CASCADE
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+create index v5_street_segment_paths on v5_street_segment_validations using gist (path);

--- a/resources/migrations/20210521-01-v5-street-segment-validations.up.sql
+++ b/resources/migrations/20210521-01-v5-street-segment-validations.up.sql
@@ -1,3 +1,5 @@
+create extension btree_gist;
+
 create table v5_street_segment_validations (
     results_id bigint NOT NULL,
     path ltree,
@@ -16,4 +18,4 @@ WITH (
 )
 TABLESPACE pg_default;
 
-create index v5_street_segment_paths on v5_street_segment_validations using gist (path);
+create index v5_street_segment_paths on v5_street_segment_validations using gist (results_id, path);

--- a/resources/migrations/20210521-01-v5-street-segment-validations.up.sql
+++ b/resources/migrations/20210521-01-v5-street-segment-validations.up.sql
@@ -1,4 +1,4 @@
-create extension btree_gist;
+create extension if not exists btree_gist;
 
 create table v5_street_segment_validations (
     results_id bigint NOT NULL,

--- a/resources/migrations/20210521-02-log-locality-stats-process.down.sql
+++ b/resources/migrations/20210521-02-log-locality-stats-process.down.sql
@@ -1,0 +1,36 @@
+create or replace function
+v5_dashboard.feed_localities(rid int)
+returns void as $$
+declare
+  locality record;
+  street_segment_validations text;
+  street_segment_validations_idx text;
+begin
+
+  street_segment_validations := 'v5_street_segment_validations_' || rid;
+  street_segment_validations_idx := 'v5_street_segment_paths_' || rid;
+
+  create temp table street_segment_validations on commit drop as
+    select * from xml_tree_validations
+    where results_id = rid
+      and path ~ 'VipObject.0.StreetSegment.*';
+
+  create index street_segment_validations_idx on street_segment_validations using gist (path);
+
+  analyze street_segment_validations;
+
+  for locality in
+    select xtv.value as id
+    from xml_tree_values xtv
+    where xtv.simple_path = 'VipObject.Locality.id'
+      and xtv.results_id = rid
+  loop
+    execute 'insert into v5_dashboard.localities
+             select *
+             from v5_dashboard.locality_stats('|| rid || ', ''' || locality.id || ''' :: text)';
+  end loop;
+
+  drop table street_segment_validations;
+
+end;
+$$ language plpgsql;

--- a/resources/migrations/20210521-02-log-locality-stats-process.up.sql
+++ b/resources/migrations/20210521-02-log-locality-stats-process.up.sql
@@ -1,0 +1,2 @@
+drop function if exists v5_dashboard.feed_localities;
+

--- a/resources/migrations/20210521-03-adjust-locality-stats.down.sql
+++ b/resources/migrations/20210521-03-adjust-locality-stats.down.sql
@@ -1,0 +1,208 @@
+drop function if exists v5_dashboard.locality_stats (integer, text);
+
+create function v5_dashboard.locality_stats(rid int, lid text)
+returns table(results_id int, id text, name text, type text, error_count int,
+              precinct_errors int, precinct_count int, precinct_completion int,
+              polling_location_errors int, polling_location_count int, polling_location_completion int,
+              street_segment_errors int, street_segment_count int, street_segment_completion int,
+              hours_open_errors int, hours_open_count int, hours_open_completion int,
+              election_administration_errors int, election_administration_count int, election_administration_completion int,
+              department_errors int, department_count int, department_completion int,
+              voter_service_errors int, voter_service_count int, voter_service_completion int)
+as $$
+  declare
+    locality record;
+    pbl ltree[];
+    precinct_polling_location_ids text[];
+    precinct_polling_locations ltree[];
+    locality_ea ltree[];
+    precincts text[];
+    street_segments ltree[];
+    precinct_errors int;
+    precinct_completion int;
+    street_segment_errors int;
+    street_segment_count int;
+    street_segment_completion int;
+    polling_location_errors int;
+    polling_location_count int;
+    polling_location_completion int;
+    hours_open_errors int;
+    hours_open_count int;
+    hours_open_completion int;
+    election_administration_errors int;
+    election_administration_count int;
+    election_administration_completion int;
+    department_count int;
+    error_count int;
+    street_segment_validations text;
+  begin
+    select ct.parent_with_id, ct.name, ct.type, ct.id
+    into locality
+    from crosstab('select xtv.parent_with_id, subpath(xtv.simple_path, -1) as element, xtv.value
+                   from xml_tree_values xtv
+                   where xtv.results_id = ''' || rid || '''
+                   and xtv.simple_path in (''VipObject.Locality.id'',
+                   ''VipObject.Locality.Name'',
+                   ''VipObject.Locality.Type'')
+                   and xtv.path <@ (select subpath(xtv.parent_with_id, 0, 4)
+                                    from xml_tree_values xtv
+                                    where xtv.results_id = ''' || rid || '''
+                                      and xtv.simple_path = ''VipObject.Locality.id''
+                                      and xtv.value = ''' || lid || ''')
+                                    order by parent_with_id, element',
+                    'select unnest(ARRAY[''Name'', ''Type'', ''id''])' )
+    as ct(parent_with_id ltree, name text, type text, id text);
+    pbl := v5_dashboard.precincts_by_locality(rid, lid);
+
+    select string_to_array(string_agg(precincts.value, ' '), ' ')
+    into precinct_polling_location_ids
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.PollingLocationIds'
+      and precincts.parent_with_id <@ pbl;
+
+    select array_agg(subpath(polling_locations.parent_with_id, 0, 4))
+    into precinct_polling_locations
+    from xml_tree_values polling_locations
+    where polling_locations.results_id = rid
+    and polling_locations.simple_path = 'VipObject.PollingLocation.id'
+    and polling_locations.value in (select unnest(precinct_polling_location_ids));
+
+    select count(subpath(errors.path, 0, 4)) as precincts
+    into precinct_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+      and errors.path ~ 'VipObject.*{1}.Precinct.*'
+      and errors.path <@ pbl
+      or errors.error_data = '"' || lid || '"';
+
+    select array_agg(precincts.value)
+    into precincts
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.id'
+      and precincts.path <@ pbl;
+
+    precinct_completion := v5_dashboard.completion_rate(cardinality(precincts), precinct_errors);
+
+    select array_agg(subpath(xtv.parent_with_id, 0, 4))
+    into street_segments
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and xtv.simple_path = 'VipObject.StreetSegment.PrecinctId'
+      and xtv.value in (select unnest(precincts));
+
+    select count(subpath(polling_location_errors.path, 0, 4))
+    into polling_location_errors
+    from xml_tree_validations polling_location_errors
+    where polling_location_errors.results_id = rid
+      and polling_location_errors.path ~ 'VipObject.0.PollingLocation.*'
+      and polling_location_errors.path <@ precinct_polling_locations;
+
+    polling_location_count := cardinality(precinct_polling_locations);
+    polling_location_completion := v5_dashboard.completion_rate(polling_location_count, polling_location_errors);
+
+    street_segment_validations := 'v5_street_segment_validations_' || rid;
+
+    with paths as (
+      select unnest (paths) as path
+      from v5_dashboard.paths_by_locality pbl
+      where pbl.results_id = rid
+        and pbl.locality_id = lid)
+    select count (v.path)
+    into street_segment_errors
+    from paths p, street_segment_validations v
+    where v.results_id = rid
+      and v.path <@ p.path;
+
+    street_segment_completion := v5_dashboard.completion_rate(cardinality(street_segments), street_segment_errors);
+
+    select count(subpath(errors.path, 0, 4))
+    into hours_open_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+    and errors.path ~ 'VipObject.0.HoursOpen.*'
+    and errors.path <@ (select array_agg(hours_open.parent_with_id)
+                        from xml_tree_values hours_open
+                        where hours_open.results_id = rid
+                        and hours_open.simple_path = 'VipObject.HoursOpen.id'
+                        and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                        (select polling_location.value as hours_open_id
+                         from xml_tree_values polling_location
+                         where polling_location.results_id = rid
+                         and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                         and polling_location.parent_with_id <@ precinct_polling_locations));
+
+    select count(hours_open.value) as hours_open
+    into hours_open_count
+    from xml_tree_values hours_open
+    where hours_open.results_id = rid
+      and hours_open.simple_path = 'VipObject.HoursOpen.id'
+      and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                           (select polling_location.value as hours_open_id
+                           from xml_tree_values polling_location
+                           where polling_location.results_id = rid
+                             and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                             and polling_location.parent_with_id <@ precinct_polling_locations);
+    hours_open_completion := v5_dashboard.completion_rate(hours_open_count, hours_open_errors);
+
+    locality_ea := v5_dashboard.locality_election_administration(rid, lid);
+
+    select count(errors.path)
+      into election_administration_errors
+      from xml_tree_validations errors
+      where errors.results_id = rid
+        and element_type(errors.path) = 'ElectionAdministration'
+      and errors.path <@ locality_ea;
+
+    election_administration_completion := v5_dashboard.completion_rate(cardinality(locality_ea), election_administration_errors);
+
+    select count(xtv.path)
+    into department_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and xtv.path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*{1}'
+      and xtv.path <@ locality_ea;
+
+
+    select count(xtv.path)
+    into department_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'Department'
+      and xtv.parent_with_id <@ locality_ea;
+
+    department_completion := v5_dashboard.completion_rate(department_count, department_errors);
+
+    select count(xtv.path)
+    into voter_service_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.path <@ locality_ea;
+
+    select count(distinct subpath(xtv.path, 0, 6))
+    into voter_service_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.parent_with_id <@ locality_ea;
+
+    voter_service_completion := v5_dashboard.completion_rate(voter_service_count, voter_service_errors);
+
+    error_count := precinct_errors + polling_location_errors + street_segment_errors +
+                   hours_open_errors + election_administration_errors + department_errors +
+                   voter_service_errors;
+    return query
+    select
+      rid, locality.id, locality.name, locality.type, error_count,
+      precinct_errors, cardinality(precincts), precinct_completion,
+      polling_location_errors, polling_location_count, polling_location_completion,
+      street_segment_errors, cardinality(street_segments), street_segment_completion,
+      hours_open_errors, hours_open_count, hours_open_completion,
+      election_administration_errors, cardinality(locality_ea), election_administration_completion,
+      department_errors, department_count, department_completion,
+      voter_service_errors, voter_service_count, voter_service_completion;
+
+  end;
+$$ language plpgsql;

--- a/resources/migrations/20210521-03-adjust-locality-stats.up.sql
+++ b/resources/migrations/20210521-03-adjust-locality-stats.up.sql
@@ -1,0 +1,205 @@
+drop function if exists v5_dashboard.locality_stats (integer, text);
+
+create function v5_dashboard.locality_stats(rid int, lid text)
+returns table(results_id int, id text, name text, type text, error_count int,
+              precinct_errors int, precinct_count int, precinct_completion int,
+              polling_location_errors int, polling_location_count int, polling_location_completion int,
+              street_segment_errors int, street_segment_count int, street_segment_completion int,
+              hours_open_errors int, hours_open_count int, hours_open_completion int,
+              election_administration_errors int, election_administration_count int, election_administration_completion int,
+              department_errors int, department_count int, department_completion int,
+              voter_service_errors int, voter_service_count int, voter_service_completion int)
+as $$
+  declare
+    locality record;
+    pbl ltree[];
+    precinct_polling_location_ids text[];
+    precinct_polling_locations ltree[];
+    locality_ea ltree[];
+    precincts text[];
+    street_segments ltree[];
+    precinct_errors int;
+    precinct_completion int;
+    street_segment_errors int;
+    street_segment_count int;
+    street_segment_completion int;
+    polling_location_errors int;
+    polling_location_count int;
+    polling_location_completion int;
+    hours_open_errors int;
+    hours_open_count int;
+    hours_open_completion int;
+    election_administration_errors int;
+    election_administration_count int;
+    election_administration_completion int;
+    department_count int;
+    error_count int;
+  begin
+    select ct.parent_with_id, ct.name, ct.type, ct.id
+    into locality
+    from crosstab('select xtv.parent_with_id, subpath(xtv.simple_path, -1) as element, xtv.value
+                   from xml_tree_values xtv
+                   where xtv.results_id = ''' || rid || '''
+                   and xtv.simple_path in (''VipObject.Locality.id'',
+                   ''VipObject.Locality.Name'',
+                   ''VipObject.Locality.Type'')
+                   and xtv.path <@ (select subpath(xtv.parent_with_id, 0, 4)
+                                    from xml_tree_values xtv
+                                    where xtv.results_id = ''' || rid || '''
+                                      and xtv.simple_path = ''VipObject.Locality.id''
+                                      and xtv.value = ''' || lid || ''')
+                                    order by parent_with_id, element',
+                    'select unnest(ARRAY[''Name'', ''Type'', ''id''])' )
+    as ct(parent_with_id ltree, name text, type text, id text);
+    pbl := v5_dashboard.precincts_by_locality(rid, lid);
+
+    select string_to_array(string_agg(precincts.value, ' '), ' ')
+    into precinct_polling_location_ids
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.PollingLocationIds'
+      and precincts.parent_with_id <@ pbl;
+
+    select array_agg(subpath(polling_locations.parent_with_id, 0, 4))
+    into precinct_polling_locations
+    from xml_tree_values polling_locations
+    where polling_locations.results_id = rid
+    and polling_locations.simple_path = 'VipObject.PollingLocation.id'
+    and polling_locations.value in (select unnest(precinct_polling_location_ids));
+
+    select count(subpath(errors.path, 0, 4)) as precincts
+    into precinct_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+      and errors.path ~ 'VipObject.*{1}.Precinct.*'
+      and errors.path <@ pbl
+      or errors.error_data = '"' || lid || '"';
+
+    select array_agg(precincts.value)
+    into precincts
+    from xml_tree_values precincts
+    where precincts.results_id = rid
+      and precincts.simple_path = 'VipObject.Precinct.id'
+      and precincts.path <@ pbl;
+
+    precinct_completion := v5_dashboard.completion_rate(cardinality(precincts), precinct_errors);
+
+    select array_agg(subpath(xtv.parent_with_id, 0, 4))
+    into street_segments
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and xtv.simple_path = 'VipObject.StreetSegment.PrecinctId'
+      and xtv.value in (select unnest(precincts));
+
+    select count(subpath(polling_location_errors.path, 0, 4))
+    into polling_location_errors
+    from xml_tree_validations polling_location_errors
+    where polling_location_errors.results_id = rid
+      and polling_location_errors.path ~ 'VipObject.0.PollingLocation.*'
+      and polling_location_errors.path <@ precinct_polling_locations;
+
+    polling_location_count := cardinality(precinct_polling_locations);
+    polling_location_completion := v5_dashboard.completion_rate(polling_location_count, polling_location_errors);
+
+    with paths as (
+      select unnest (paths) as path
+      from v5_dashboard.paths_by_locality pbl
+      where pbl.results_id = rid
+        and pbl.locality_id = lid)
+    select count (v.path)
+    into street_segment_errors
+    from paths p, public.v5_street_segment_validations v
+    where v.results_id = rid
+      and v.path <@ p.path;
+
+    street_segment_completion := v5_dashboard.completion_rate(cardinality(street_segments), street_segment_errors);
+
+    select count(subpath(errors.path, 0, 4))
+    into hours_open_errors
+    from xml_tree_validations errors
+    where errors.results_id = rid
+    and errors.path ~ 'VipObject.0.HoursOpen.*'
+    and errors.path <@ (select array_agg(hours_open.parent_with_id)
+                        from xml_tree_values hours_open
+                        where hours_open.results_id = rid
+                        and hours_open.simple_path = 'VipObject.HoursOpen.id'
+                        and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                        (select polling_location.value as hours_open_id
+                         from xml_tree_values polling_location
+                         where polling_location.results_id = rid
+                         and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                         and polling_location.parent_with_id <@ precinct_polling_locations));
+
+    select count(hours_open.value) as hours_open
+    into hours_open_count
+    from xml_tree_values hours_open
+    where hours_open.results_id = rid
+      and hours_open.simple_path = 'VipObject.HoursOpen.id'
+      and hours_open.value in -- Schedules for a Polling Location in a Precinct in a Locality
+                           (select polling_location.value as hours_open_id
+                           from xml_tree_values polling_location
+                           where polling_location.results_id = rid
+                             and polling_location.simple_path = 'VipObject.PollingLocation.HoursOpenId'
+                             and polling_location.parent_with_id <@ precinct_polling_locations);
+    hours_open_completion := v5_dashboard.completion_rate(hours_open_count, hours_open_errors);
+
+    locality_ea := v5_dashboard.locality_election_administration(rid, lid);
+
+    select count(errors.path)
+      into election_administration_errors
+      from xml_tree_validations errors
+      where errors.results_id = rid
+        and element_type(errors.path) = 'ElectionAdministration'
+      and errors.path <@ locality_ea;
+
+    election_administration_completion := v5_dashboard.completion_rate(cardinality(locality_ea), election_administration_errors);
+
+    select count(xtv.path)
+    into department_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and xtv.path ~ 'VipObject.0.ElectionAdministration.*{1}.Department.*{1}'
+      and xtv.path <@ locality_ea;
+
+
+    select count(xtv.path)
+    into department_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'Department'
+      and xtv.parent_with_id <@ locality_ea;
+
+    department_completion := v5_dashboard.completion_rate(department_count, department_errors);
+
+    select count(xtv.path)
+    into voter_service_errors
+    from xml_tree_validations xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.path <@ locality_ea;
+
+    select count(distinct subpath(xtv.path, 0, 6))
+    into voter_service_count
+    from xml_tree_values xtv
+    where xtv.results_id = rid
+      and element_type(xtv.path) = 'VoterService'
+      and xtv.parent_with_id <@ locality_ea;
+
+    voter_service_completion := v5_dashboard.completion_rate(voter_service_count, voter_service_errors);
+
+    error_count := precinct_errors + polling_location_errors + street_segment_errors +
+                   hours_open_errors + election_administration_errors + department_errors +
+                   voter_service_errors;
+    return query
+    select
+      rid, locality.id, locality.name, locality.type, error_count,
+      precinct_errors, cardinality(precincts), precinct_completion,
+      polling_location_errors, polling_location_count, polling_location_completion,
+      street_segment_errors, cardinality(street_segments), street_segment_completion,
+      hours_open_errors, hours_open_count, hours_open_completion,
+      election_administration_errors, cardinality(locality_ea), election_administration_completion,
+      department_errors, department_count, department_completion,
+      voter_service_errors, voter_service_count, voter_service_completion;
+
+  end;
+$$ language plpgsql;

--- a/src/vip/data_processor/db/statistics.clj
+++ b/src/vip/data_processor/db/statistics.clj
@@ -44,8 +44,8 @@
   (let [specs (data-specs-with-stats (:data-specs ctx))]
     (into {} (map (juxt :table (partial stats-for-table ctx)) specs))))
 
-(defn stats-map [ctx]
-  (let [stats (stats ctx)]
+(defn stats-map [{:keys [import-id] :as ctx}]
+  (let [stats (stats import-id)]
     (->> stats
          (map (fn [[table {:keys [count error-count complete]}]]
                 (let [table-prefix (-> table
@@ -58,5 +58,5 @@
 
 (defn store-stats [{:keys [import-id] :as ctx}]
   (korma/insert psql/statistics
-    (korma/values (assoc (stats-map ctx) :results_id import-id)))
+    (korma/values (assoc (stats-map import-id) :results_id import-id)))
   ctx)

--- a/src/vip/data_processor/db/tree_statistics.clj
+++ b/src/vip/data_processor/db/tree_statistics.clj
@@ -77,7 +77,7 @@
        (reduce merge)))
 
 (defn prepare-temp-data-for-locality-stats
-  "Adds steet segment validation data to processing table for faster
+  "Adds street segment validation data to processing table for faster
    processing, only used for the locality stats computations and then
    deleted"
   [import-id]

--- a/src/vip/data_processor/db/tree_statistics.clj
+++ b/src/vip/data_processor/db/tree_statistics.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [korma.core :as korma]
+            [korma.db :as korma.db]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.db.translations.util :as t-util]))
 
@@ -70,21 +71,70 @@
      (keyword (str (camel->snake element) "_completion")) completion}))
 
 (defn stats
-  [{:keys [import-id]}]
+  [import-id]
   (->> (korma/exec-raw [(error-query) [import-id import-id]] :results)
        (map stats-map)
        (reduce merge)))
 
+(defn prepare-temp-data-for-locality-stats
+  "Adds steet segment validation data to processing table for faster
+   processing, only used for the locality stats computations and then
+   deleted"
+  [import-id]
+  (log/info "Saving temp data for locality stats")
+  (korma/exec-raw
+   ["insert into v5_street_segment_validations
+       select * from xml_tree_validations
+       where results_id = ?
+             and path ~ 'VipObject.0.StreetSegment.*'" [import-id]]))
+
+(defn cleanup-temp-data-for-locality-stats
+  "Deletes street segment validation data from processing table"
+  [import-id]
+  (log/info "Deleting temp data for locality stats")
+  (korma/exec-raw
+   ["delete from v5_street_segment_validations where results_id = ?"
+    [import-id]]))
+
+(defn locality-ids
+  "Gets all the locality ids for the feed."
+  [import-id]
+  (->> (korma/select postgres/xml-tree-values
+         (korma/fields :value)
+         (korma/where {:simple_path
+                       (postgres/path->ltree "VipObject.Locality.id")})
+         (korma/where {:results_id import-id}))
+       (map :value)))
+
+(defn compute-locality-stats
+  "Runs through each locality and computes the stats for it, logging along
+   progress along the way."
+  [import-id]
+  (log/info "Computing locality stats")
+  (let [locality-ids (locality-ids import-id)
+        loc-count (count locality-ids)]
+    (doall (map-indexed
+            (fn [idx locality-id]
+              (log/info "Processing locality" (inc idx) "of" loc-count
+                        "with id" locality-id)
+              (korma/exec-raw
+               ["insert into v5_dashboard.localities
+                              select * from v5_dashboard.locality_stats(?, ?)"
+                [import-id locality-id]]))
+            locality-ids))))
+
+(defn locality-stats [import-id]
+  (prepare-temp-data-for-locality-stats import-id)
+  (compute-locality-stats import-id)
+  (cleanup-temp-data-for-locality-stats import-id))
+
 (defn store-tree-stats
-  [{:keys [import-id] :as ctx}]
+  [import-id]
   (log/info "Building basic feed stats")
   (korma/insert postgres/v5-statistics
     (korma/values
-     (assoc (stats ctx) :results_id import-id)))
+     (assoc (stats import-id) :results_id import-id)))
   (log/info "Getting additional feed stats")
   (korma/exec-raw
    ["select * from v5_dashboard.polling_locations_by_type(?)" [import-id]])
-  (log/info "Building locality stats")
-  (korma/exec-raw
-   ["select * from v5_dashboard.feed_localities(?)" [import-id]])
-  ctx)
+  (locality-stats import-id))

--- a/src/vip/data_processor/errors/process.clj
+++ b/src/vip/data_processor/errors/process.clj
@@ -18,7 +18,7 @@
                           :wrapup-f (partial stats/store-stats ctx)})]
     (assoc ctx :processing-chan processing-chan)))
 
-(defn process-v5-validations [{:keys [errors-chan] :as ctx}]
+(defn process-v5-validations [{:keys [errors-chan import-id] :as ctx}]
   (let [processing-chan (util-async/batch-process
                          errors-chan
                          (fn [errors]
@@ -29,5 +29,5 @@
                          {:batch-size 10000
                           :timeout 5000
                           :pool-size 30
-                          :wrapup-f (partial tree-stats/store-tree-stats ctx)})]
+                          :wrapup-f (partial tree-stats/store-tree-stats import-id)})]
     (assoc ctx :processing-chan processing-chan)))


### PR DESCRIPTION
Moved a loop over all the localities that was inside a db function out into Clojure so we could log progress.

Slightly less efficient to do it this way, might want to do some staging testing with a WI for MI feed with a lot of localities and compare before and after applying this. I mentioned in the commit message that maybe we plan on some kind of batching operation instead, where we send groups of ids, as that will cut down on the db connection penalty a bit while still providing some insights.

[Jira Card](https://democracyworks.atlassian.net/browse/VIP-370)