### PR TITLE
Fix v3 feed errors stats

### DIFF
--- a/src/vip/data_processor/db/statistics.clj
+++ b/src/vip/data_processor/db/statistics.clj
@@ -45,7 +45,7 @@
     (into {} (map (juxt :table (partial stats-for-table ctx)) specs))))
 
 (defn stats-map [{:keys [import-id] :as ctx}]
-  (let [stats (stats import-id)]
+  (let [stats (stats ctx)]
     (->> stats
          (map (fn [[table {:keys [count error-count complete]}]]
                 (let [table-prefix (-> table
@@ -58,5 +58,5 @@
 
 (defn store-stats [{:keys [import-id] :as ctx}]
   (korma/insert psql/statistics
-    (korma/values (assoc (stats-map import-id) :results_id import-id)))
+    (korma/values (assoc (stats-map ctx) :results_id import-id)))
   ctx)


### PR DESCRIPTION
Whoops, only should have done the ctx -> import-id swap in error/stats for the v5 pipeline, but some v3 stats code also got changed and that broke the 3.0 stats. This reverts the change in the v3 stats code, ran a 3.0 and 5.2 feed locally and they both worked and got stats.