### PR TITLE
Avoid XXE in clojure.data.xml

### DIFF
--- a/src/vip/data_processor/validation/xml.clj
+++ b/src/vip/data_processor/validation/xml.clj
@@ -1,12 +1,12 @@
 (ns vip.data-processor.validation.xml
-  (:require [clojure.data.xml :as xml]
-            [clojure.walk :refer [stringify-keys]]
+  (:require [clojure.walk :refer [stringify-keys]]
             [korma.core :as korma]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.db.sqlite :as sqlite]
             [vip.data-processor.util :as util]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.errors :as errors])
+            [vip.data-processor.errors :as errors]
+            [vip.data-processor.xml :as xml])
   (:import [java.nio.file Files StandardCopyOption]))
 
 (def address-elements

--- a/src/vip/data_processor/validation/xml/v5.clj
+++ b/src/vip/data_processor/validation/xml/v5.clj
@@ -1,10 +1,10 @@
 (ns vip.data-processor.validation.xml.v5
-  (:require [clojure.data.xml :as xml]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [vip.data-processor.db.postgres :as postgres]
             [vip.data-processor.util :as util]
             [vip.data-processor.validation.data-spec :as data-spec]
-            [vip.data-processor.validation.data-spec.v5-2 :as data-spec.v5-2]))
+            [vip.data-processor.validation.data-spec.v5-2 :as data-spec.v5-2]
+            [vip.data-processor.xml :as xml]))
 
 (defn element->database-key [element]
   (->> element

--- a/src/vip/data_processor/xml.clj
+++ b/src/vip/data_processor/xml.clj
@@ -1,0 +1,28 @@
+(ns vip.data-processor.xml
+  "Provide safer versions of unsafe clojure.data.xml public functions that are
+  vulnerable to
+  [XML external entity attacks](https://en.wikipedia.org/wiki/XML_external_entity_attack).
+
+  This namespace should be removed when clojure.data.xml is upgraded beyond
+  version 0.0.8"
+  (:require [clojure.data.xml :as xml]))
+
+(def ^:private safer-defaults
+  "Defaults for old versions of `clojure.data.xml` to avoid XXE."
+  {:supporting-external-entities false
+   :support-dtd false})
+
+(defn source-seq
+  "See [[xml/source-seq]]."
+  [s & {:as props}]
+  (apply xml/source-seq s (apply concat (merge safer-defaults props))))
+
+(defn parse
+  "See [[xml/parse]]."
+  [s & {:as props}]
+  (apply xml/parse s (apply concat (merge safer-defaults props))))
+
+(defn parse-str
+  "See [[xml/parse-str]]."
+  [s & {:as props}]
+  (apply xml/parse-str s (apply concat (merge safer-defaults props))))

--- a/test-resources/xml/v3-xxe.xml
+++ b/test-resources/xml/v3-xxe.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE author [
+  <!ELEMENT author (#PCDATA)>
+  <!ENTITY xxe SYSTEM "file:///etc/hostname">]>
+<vip_object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://election-info-standard.googlecode.com/files/election_spec_v3.0.xsd" schemaVersion="3.0">
+  <source id="0">
+    <name>State of Ohio</name>
+    <vip_id>39</vip_id>
+    <datetime>2012-10-31T15:45:10</datetime>
+    <description>&xxe;</description>
+  </source>
+</vip_object>


### PR DESCRIPTION
XXE (an **X**ML e**x**ternal **e**ntity attack) is possible in `clojure.data.xml` versions 0.0.8 and below. We are unable to easily upgrade to a more recent version (and no more recent "stable" version exists).

We are introducing a wrapper namespace wrapping functions in `clojure.data.xml` with safer XML parsing functions that apply XXE protection by default, with the goal of ultimately removing the wrapper namespace when the application is updated.

# References

- [VIP-386](https://democracyworks.atlassian.net/browse/VIP-386)